### PR TITLE
Support browser-targeted build.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,6 +9,7 @@
  */
 module.exports = function(grunt) {
   grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
     jshint: {
       options: {
         asi: true,
@@ -28,7 +29,7 @@ module.exports = function(grunt) {
         nonstandard: true,
         trailing: true,
         undef: true,
-        unused: 'vars',
+        unused: 'vars'
       },
       all: ['src/**/*.js']
     },
@@ -58,7 +59,7 @@ module.exports = function(grunt) {
             cwd: 'type-definitions',
             src: ['**/*.d.ts'],
             dest: 'dist/'
-          },
+          }
         ]
       }
     },
@@ -66,7 +67,26 @@ module.exports = function(grunt) {
       options: {
         testPathPattern: /.*/
       }
+    },
+    browserify: {
+      standalone: {
+        src: ['dist/Immutable.js'],
+        dest: 'dist/browserify/<%= pkg.name %>-<%= pkg.version %>.js',
+        options: {
+          bundleOptions: {
+            standalone: 'Immutable'
+          }
+        }
+      }
+    },
+    uglify: {
+      standalone: {
+        files: {
+          'dist/browserify/<%= pkg.name %>-<%= pkg.version %>.min.js': ['dist/browserify/<%= pkg.name %>-<%= pkg.version %>.js']
+        }
+      }
     }
+
   });
 
   grunt.loadNpmTasks('grunt-contrib-jshint');
@@ -74,9 +94,11 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-react');
   grunt.loadNpmTasks('grunt-jest');
+  grunt.loadNpmTasks('grunt-browserify');
+  grunt.loadNpmTasks('grunt-contrib-uglify');
 
   grunt.registerTask('lint', 'Lint all source javascript', ['jshint']);
-  grunt.registerTask('build', 'Build distributed javascript', ['clean', 'react', 'copy']);
+  grunt.registerTask('build', 'Build distributed javascript', ['clean', 'react', 'copy', 'browserify', 'uglify']);
   grunt.registerTask('test', 'Test built javascript', ['jest']);
   grunt.registerTask('default', 'Lint, build and test.', ['lint', 'build', 'test']);
-}
+};

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-clean": "^0.5.0",
+    "grunt-browserify": "^2.1.4",
+    "grunt-contrib-uglify": "^0.5.1",
     "grunt-jest": "^0.1.0",
     "grunt-react": "^0.8.2",
     "react-tools": "~0.10.0",


### PR DESCRIPTION
This adds two artifacts to the build: uncompressed (development) and minimized (production). Both can be loaded with Require.js or similar and used as a global var `Immutable` in browser.

Artifacts names:
- `immutable-x.y.z.js`
- `immutable-x.y.z.min.js`

Placed to `dist/browserify`.
