### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ of [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Glo
 [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map), and
 [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set).
 
-The difference for the immutable collections is that method which would mutate
+The difference for the immutable collections is that methods which would mutate
 the collection, like `push`, `set`, `unshift` or `splice` instead return a new
 immutable collection. Methods which return new arrays like `slice` or `concat`
 instead return new immutable collections.


### PR DESCRIPTION
Adds an 's' to method on line 102 where it should be plural, change adds grammatical clarity and improves flow for the reader. Nothing else is changed:

OLD LINE: The difference for the immutable collections is that method which would mutate
the collection, like `push`, `set`, `unshift` or `splice` instead return a new
immutable collection.

NEW LINE: The difference for the immutable collections is that methods which would mutate
the collection, like `push`, `set`, `unshift` or `splice` instead return a new
immutable collection.
