### PR TITLE
Fix minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ alpha.map((v, k) => k.toUpperCase()).join();
 ### Accepts raw JavaScript objects.
 
 Designed to inter-operate with your existing JavaScript, `immutable`
-accepts plain JavaScript Array and Objects anywhere a method expects a
+accepts plain JavaScript Arrays and Objects anywhere a method expects a
 `Sequence` with no performance penalty.
 
 ```javascript


### PR DESCRIPTION
Fixes minor typo on line 132.

Before: Designed to inter-operate with your existing JavaScript, `immutable` accepts plain JavaScript [Array] and Objects anywhere a method expects a `Sequence` with no performance penalty.

After: Designed to inter-operate with your existing JavaScript, `immutable` accepts plain JavaScript [Arrays] and Objects anywhere a method expects a `Sequence` with no performance penalty.

This corrects the parallel structure of the clause and slightly improves readability. I'd like to propose additional changes to document grammar and syntax, if desired.
