### PR TITLE
Fix fromEntries return type

### DIFF
--- a/__tests__/groupBy.ts
+++ b/__tests__/groupBy.ts
@@ -5,11 +5,11 @@ import I = require('../dist/Immutable');
 describe('groupBy', () => {
 
   it('groups keyed sequence', () => {
-    expect(
-      I.Sequence({a:1,b:2,c:3,d:4}).groupBy(x => x % 2).toJS()
-    ).toEqual(
-      {1:{a:1,c:3}, 0:{b:2,d:4}}
-    );
+    var grouped = I.Sequence({a:1,b:2,c:3,d:4}).groupBy(x => x % 2);
+    expect(grouped.toJS()).toEqual({1:{a:1,c:3}, 0:{b:2,d:4}});
+
+    // Each group should be a keyed sequence, not an indexed sequence
+    expect(grouped.get(1).toArray()).toEqual([1, 3]);
   })
 
   it('groups indexed sequence', () => {

--- a/dist/Sequence.js
+++ b/dist/Sequence.js
@@ -484,7 +484,7 @@ for(var Sequence____Key in Sequence){if(Sequence.hasOwnProperty(Sequence____Key)
 
   IndexedSequence.prototype.fromEntries=function() {"use strict";
     var sequence = this;
-    var fromEntriesSequence = sequence.__makeSequence();
+    var fromEntriesSequence = makeSequence();
     fromEntriesSequence.length = sequence.length;
     fromEntriesSequence.entries = function()  {return sequence;};
     fromEntriesSequence.__iterateUncached = function(fn, reverse, flipIndices) 

--- a/src/Sequence.js
+++ b/src/Sequence.js
@@ -484,7 +484,7 @@ class IndexedSequence extends Sequence {
 
   fromEntries() {
     var sequence = this;
-    var fromEntriesSequence = sequence.__makeSequence();
+    var fromEntriesSequence = makeSequence();
     fromEntriesSequence.length = sequence.length;
     fromEntriesSequence.entries = () => sequence;
     fromEntriesSequence.__iterateUncached = (fn, reverse, flipIndices) =>


### PR DESCRIPTION
Fixes #31.

Previously, grouping a keyed sequence would return each group as an IndexedSequence with nonnumeric keys, which was wrong. This was caused by fromEntries returning an IndexedSequence instead of a keyed sequence. With this, fromEntries always returns a keyed sequence (which matches the type definition) and Sequence's groupBy returns the correct type. (Calling groupBy on an IndexedSequence still gives each group as an IndexedSequence, as before.)

Test Plan: jest
