### PR TITLE
Range slice bug fixed and init/tail methods added

### DIFF
--- a/__tests__/Range.ts
+++ b/__tests__/Range.ts
@@ -46,10 +46,14 @@ describe('Range', () => {
   });
 
   it('slices range', () => {
-    var v = Range(1, 11, 2);
-    var s = v.slice(1, -2);
-    expect(s.length).toBe(2);
-    expect(s.toArray()).toEqual([3,5]);
+    var v0 = Range(1, 11, 2);
+    var v1 = Range(10, 10);
+    var s0 = v0.slice(1, -2);
+    var s1 = v1.slice(1);
+    expect(s0.length).toBe(2);
+    expect(s0.toArray()).toEqual([3,5]);
+    expect(s1.length).toBe(0);
+    expect(s1.toArray()).toEqual([]);
   });
 
   it('stepped range does not land on end', () => {

--- a/src/Range.js
+++ b/src/Range.js
@@ -71,6 +71,9 @@ class Range extends IndexedSequence {
     if (maintainIndices) {
       return super.slice(begin, end, maintainIndices);
     }
+    if (this.length === 0) {
+      return new Range(this._start, this._end, this._step);
+    }
     begin = begin < 0 ? Math.max(0, this.length + begin) : Math.min(this.length, begin);
     end = end == null ? this.length : end > 0 ? Math.min(this.length, end) : Math.max(0, this.length + end);
     return new Range(this.get(begin), end === this.length ? this._end : this.get(end), this._step);


### PR DESCRIPTION
Certainly open to any feedback, particularly around if there are more performant ways to do the init/tail methods. I need more time to really dig in and digest the nitty-gritty of how things are implemented in the library. Currently, I have a only have a cursory level of knowledge on said library algorithms/implementations.
