### PR TITLE
Use dev build in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bugs": {
     "url": "https://github.com/facebook/immutable-js/issues"
   },
-  "main": "dist/Immutable.js",
+  "main": "dist/Immutable.dev.js",
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
When working in node, you'll typically want to have the unminified source for cases where you might want to inspect / step-through the code with a debugger. Similarly, when referencing the module client-side working with webpack, browserify, or similar the common practice is to provide the unminified build as there will be a separate step to optimize/minify the entire build.
