### PR TITLE
Loosen "engines" version dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jasmine-check": "^0.1.2"
   },
   "engines": {
-    "node": "^0.8.0"
+    "node": ">=0.8.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Really resolves https://github.com/facebook/immutable-js/issues/11 and removes these warnings:
`npm WARN engine immutable@2.0.11: wanted: {"node":"^0.8.0"} (current: {"node":"0.10.30","npm":"1.4.23"})`
