### PR TITLE
Added a manifest file for the bower package manager

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "immutable",
+  "version": "2.0.16",
+  "description": "Immutable Data Collections",
+  "homepage": "https://github.com/facebook/immutable-js",
+  "main": "dist/Immutable.js",
+  "keywords": [
+    "immutable",
+    "persistent",
+    "lazy",
+    "data",
+    "datastructure",
+    "functional",
+    "collection",
+    "stateless",
+    "sequence",
+    "iteration"
+  ],
+  "ignore": [
+    "**/.*",
+    "__tests__",
+    "resources",
+    "src"
+  ],
+  "license": "BSD"
+}


### PR DESCRIPTION
Hi,

This adds a manifest file which will enable the [bower package manager](http://bower.io/) to introspect the immutable-js repo.

Bower's the most common solution for the packaging of front-end assets, so adding the `bower.json` file will massively reduce the overhead on integrating immutable-js into front-end projects.

If you merge the commit, you will probably want to also register the repo with the bower library, via...

`bower register immutable git://github.com/facebook/immutable-js.git`

If you don't have `bower` installed, you can install it with `npm install -g bower`.

Registering the repo will allow users to run `bower install immutable` and have the project fetched in a style akin to npm's.

Cheers,
Mark.
