### PR TITLE
Add browserify note to readme’s Browser section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ require(['./Immutable.min.js'], function (Immutable) {
     map = map.set('b', 20);
     map.get('b'); // 20
 });
+
+If you're using [browserify](http://browserify.org/), the `immutable` npm module also works from the browser.
 ```
 
 ### TypeScript


### PR DESCRIPTION
Thought it'd be nice to mention in the readme's Browser section that `immutable` is browserify-ready for those that would like to use it. Let me know if you'd like different wording.
