### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,14 @@
     "sequence",
     "iteration"
   ],
-  "license": "BSD"
+  "license": "BSD",
+  "spm": {
+    "main": "dist/immutable.js",
+    "ignore": [
+      "__tests__",
+      "contrib",
+      "resources",
+      "type-definitions"
+    ]
+  }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/immutable

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of immutable in spmjs, I can add it for your account after signing in http://spmjs.io.