### PR TITLE
[Suggestion] for ordered groupBy

### DIFF
--- a/src/Operations.js
+++ b/src/Operations.js
@@ -353,7 +353,14 @@ function countByFactory(iterable, grouper, context) {
 
 function groupByFactory(iterable, grouper, context) {
   var isKeyedIter = isKeyed(iterable);
-  var groups = Map().asMutable();
+  var groups;
+  
+  if(iterable.isOrdered(iterable)){
+    groups = OrderedMap().asMutable();
+  } else {
+    groups = Map().asMutable();
+  }
+  
   iterable.__iterate((v, k) => {
     groups.update(
       grouper.call(context, v, k, iterable),


### PR DESCRIPTION
I am grouping a sorted list, and want the map created by groupBy to reflect the order in the list.
Locally i just switched the map to a OrderedMap and the behavior was working as expected.

I am typing this out directly in GitHub so it might contains bugs. My local modifications were naive and always did OrderedMap, which might not be as lean/performant as you want.

Any thoughts?