### PR TITLE
Be able to set value of a cursor

### DIFF
--- a/contrib/cursor/__tests__/Cursor.ts
+++ b/contrib/cursor/__tests__/Cursor.ts
@@ -157,6 +157,25 @@ describe('Cursor', () => {
     );
   });
 
+  it('can set value of a cursor', () => {
+    var onChange = jest.genMockFunction();
+
+    var data = Immutable.fromJS(json);
+    var aCursor = Cursor.from(data, onChange);
+
+    expect(aCursor.set(
+        Immutable.fromJS({ a: 1 })
+      ).deref()).toEqual(
+      Immutable.fromJS({ a: 1 })
+    );
+
+    expect(onChange).lastCalledWith(
+      Immutable.fromJS({ a: 1 }),
+      data,
+      []
+    );
+  });
+
   it('creates maps as necessary', () => {
     var data = Immutable.Map();
     var cursor = Cursor.from(data, ['a', 'b', 'c']);
@@ -171,6 +190,25 @@ describe('Cursor', () => {
     expect(cursor.deref()).toBe(undefined);
     cursor = cursor.set('d', undefined);
     expect(cursor.toJS()).toEqual({d: undefined});
+  });
+
+  it('can set value of cursor to be undefined', () => {
+    var onChange = jest.genMockFunction();
+
+    var data = Immutable.fromJS(json);
+    var cursor = Cursor.from(data, ['a', 'b'], onChange);
+    expect(cursor.deref()).toEqual(
+        Immutable.fromJS({ c: 1 })
+      );
+    cursor = cursor.cursor('d').set(undefined);
+    expect(cursor.toJS()).toEqual({});
+    expect(cursor.deref()).toEqual(undefined);
+
+    expect(onChange).lastCalledWith(
+      Immutable.fromJS({ a: { b: { c: 1, d: undefined } } }),
+      data,
+      ['a', 'b', 'd']
+    );
   });
 
   it('has the sequence API', () => {

--- a/contrib/cursor/index.d.ts
+++ b/contrib/cursor/index.d.ts
@@ -92,6 +92,7 @@ declare module 'immutable/contrib/cursor' {
      * Sets `value` at `key` in the cursor, returning a new cursor to the same
      * point in the new data.
      */
+    set(value: any): Cursor;
     set(key: any, value: any): Cursor;
 
     /**

--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -87,7 +87,20 @@ IndexedCursorPrototype.getIn = function(key, notSetValue) {
 
 IndexedCursorPrototype.set =
 KeyedCursorPrototype.set = function(key, value) {
-  return updateCursor(this, function (m) { return m.set(key, value); }, key);
+  var ctx = this;
+  if(arguments.length === 1) {
+    value = key;
+    key = void 0;
+    if(value === void 0) {
+      var _key = this._keyPath.slice();
+      key = _key.pop();
+      ctx = makeCursor(this._rootData, _key, this._onChange);
+    }
+  }
+  var cursor = updateCursor(ctx, function (m) {
+    return key ? m.set(key, value) : value;
+  }, key);
+  return arguments.length === 1 && key ? subCursor(cursor, key) : cursor;
 }
 
 KeyedCursorPrototype.remove =


### PR DESCRIPTION
Add:
```js
Cursor.set(value: any): Cursor
```

Similar to `update(updater: (value: any) => any): Cursor`, but with being able to set `undefined`.

Closes https://github.com/facebook/immutable-js/issues/249