### PR TITLE
allow `cursor()` and `cursor('foo', 'bar', ...)`

### DIFF
--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -120,6 +120,10 @@ IndexedCursorPrototype.withMutations = function(fn) {
 
 KeyedCursorPrototype.cursor =
 IndexedCursorPrototype.cursor = function(subKey) {
+  // allow cursor() and cursor('foo', 'bar', ...)
+  if (!Array.isArray(subKey)) {
+    subKey = arguments.length > 1 ? [].slice.call(arguments, 0) : [];
+  }
   return Array.isArray(subKey) && subKey.length === 0 ?
     this : subCursor(this, subKey);
 }


### PR DESCRIPTION
I personally much preferred to pass the arguments as a splat rather than a list. Using it myself so figured why not submit a PR!
