### PR TITLE
fix: change require to immutable library name

### DIFF
--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -15,7 +15,7 @@
  * If you wish to use it in the browser, please check out Browserify or WebPack!
  */
 
-var Immutable = require('../../');
+var Immutable = require('immutable');
 var Iterable = Immutable.Iterable;
 var Iterator = Iterable.Iterator;
 var Seq = Immutable.Seq;


### PR DESCRIPTION
1) declaration in typescript is `import Immutable = require('immutable');`
2) it's not easy work with such `require('../..')` create external browserify bundle with immutable and contrib/cursor both included
