### PR TITLE
Fixed broken links to Wikipedia articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ intermediate representations. Create some `Seq` with `Range` and `Repeat`.
 
 [Persistent]: http://en.wikipedia.org/wiki/Persistent_data_structure
 [Immutable]: http://en.wikipedia.org/wiki/Immutable_object
-[hash maps tries]: (http://en.wikipedia.org/wiki/Hash_array_mapped_trie)
-[vector tries]: (http://hypirion.com/musings/understanding-persistent-vector-pt-1)
+[hash maps tries]: http://en.wikipedia.org/wiki/Hash_array_mapped_trie
+[vector tries]: http://hypirion.com/musings/understanding-persistent-vector-pt-1
 
 
 Getting started


### PR DESCRIPTION
In the intro text there are a couple of links whose `href` is invalid. I.e. `<a href="(http://en.wikipedia.org/wiki/Hash_array_mapped_trie)">hash maps tries</a>`. Clicking on these links results in the browser redirecting to https://code.facebook.com/