### PR TITLE
Avoid making x properties non-enumerable

### DIFF
--- a/src/Hash.js
+++ b/src/Hash.js
@@ -131,7 +131,7 @@ function hashJSObj(obj) {
 // True if Object.defineProperty works as expected. IE8 fails this test.
 var canDefineProperty = (function() {
   try {
-    Object.defineProperty({}, 'x', {});
+    Object.defineProperty({}, '___x', {});
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
I'm seeing cases where Object.keys({x:1, y:2}) is yielding ['y'].