### PR TITLE
makeCursor may return incorrect cursor type

### DIFF
--- a/contrib/cursor/__tests__/Cursor.ts
+++ b/contrib/cursor/__tests__/Cursor.ts
@@ -49,6 +49,13 @@ describe('Cursor', () => {
     expect(deepCursor.deref()).toBe(data.getIn(Immutable.fromJS(['a', 'b'])));
   });
 
+  it('cursor return new cursors of correct type', () => {
+    var data = Immutable.fromJS({ a: [1, 2, 3] });
+    var cursor = Cursor.from(data);
+    var deepCursor = <any>cursor.cursor('a');
+    expect(deepCursor.findIndex).toBeDefined();
+  });
+
   it('can be treated as a value', () => {
     var data = Immutable.fromJS(json);
     var cursor = Cursor.from(data, ['a', 'b']);

--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -220,7 +220,7 @@ IndexedCursor.prototype = IndexedCursorPrototype;
 var NOT_SET = {}; // Sentinel value
 
 function makeCursor(rootData, keyPath, onChange, value) {
-  if (arguments.length < 4) {
+  if (value === void 0) {
     value = rootData.getIn(keyPath);
   }
   var size = value && value.size;


### PR DESCRIPTION
Certain code paths call makeCursor with four arguments, with 'value' undefined. Since arguments.length is still four in this case, the value is not retrieved from rootData, and an incorrect cursor type may be generated.

Fixes #318 

(As a side effect, this change may also make makeCursor [eligible for VM optimizations](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#31-reassigning-a-defined-parameter-while-also-mentioning-arguments-in-the-body-typical-example).)