### PR TITLE
Instantiate classes with 'new', now that ES6 requires it.

### DIFF
--- a/__tests__/RecordJS.js
+++ b/__tests__/RecordJS.js
@@ -6,7 +6,7 @@ var Record = Immutable.Record;
 describe('Record', () => {
 
   it('defines a constructor', () => {
-    var MyType = Record({a:1, b:2, c:3});
+    var MyType = new Record({a:1, b:2, c:3});
 
     var t = new MyType();
     var t2 = t.set('a', 10);
@@ -16,7 +16,7 @@ describe('Record', () => {
   });
 
   it('can have mutations apply', () => {
-    var MyType = Record({a:1, b:2, c:3});
+    var MyType = new Record({a:1, b:2, c:3});
 
     var t = new MyType();
 
@@ -50,14 +50,14 @@ describe('Record', () => {
   });
 
   it('can be cleared', () => {
-    var MyType = Record({a:1, b:2, c:3});
+    var MyType = new Record({a:1, b:2, c:3});
     var t = new MyType({c:'cats'});
 
     expect(t.c).toBe('cats');
     t = t.clear();
     expect(t.c).toBe(3);
 
-    var MyType2 = Record({d:4, e:5, f:6});
+    var MyType2 = new Record({d:4, e:5, f:6});
     var t2 = new MyType2({d:'dogs'});
 
     expect(t2.d).toBe('dogs');

--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -163,7 +163,7 @@ KeyedCursorPrototype.mergeDeepIn = Map.prototype.mergeDeepIn;
 KeyedCursorPrototype.withMutations =
 IndexedCursorPrototype.withMutations = function(fn) {
   return updateCursor(this, function (m) {
-    return (m || Map()).withMutations(fn);
+    return (m || new Map()).withMutations(fn);
   });
 }
 
@@ -245,7 +245,7 @@ function updateCursor(cursor, changeFn, changeKeyPath) {
   var deepChange = arguments.length > 2;
   var newRootData = cursor._rootData.updateIn(
     cursor._keyPath,
-    deepChange ? Map() : undefined,
+    deepChange ? new Map() : undefined,
     changeFn
   );
   var keyPath = cursor._keyPath || [];

--- a/src/Iterable.js
+++ b/src/Iterable.js
@@ -12,25 +12,25 @@ import { Seq, KeyedSeq, IndexedSeq, SetSeq } from './Seq'
 
 export class Iterable {
   constructor(value) {
-    return isIterable(value) ? value : Seq(value);
+    return isIterable(value) ? value : new Seq(value);
   }
 }
 
 export class KeyedIterable extends Iterable {
   constructor(value) {
-    return isKeyed(value) ? value : KeyedSeq(value);
+    return isKeyed(value) ? value : new KeyedSeq(value);
   }
 }
 
 export class IndexedIterable extends Iterable {
   constructor(value) {
-    return isIndexed(value) ? value : IndexedSeq(value);
+    return isIndexed(value) ? value : new IndexedSeq(value);
   }
 }
 
 export class SetIterable extends Iterable {
   constructor(value) {
-    return isIterable(value) && !isAssociative(value) ? value : SetSeq(value);
+    return isIterable(value) && !isAssociative(value) ? value : new SetSeq(value);
   }
 }
 

--- a/src/IterableImpl.js
+++ b/src/IterableImpl.js
@@ -78,7 +78,7 @@ mixin(Iterable, {
 
   toMap() {
     // Use Late Binding here to solve the circular dependency.
-    return Map(this.toKeyedSeq());
+    return new Map(this.toKeyedSeq());
   },
 
   toObject() {
@@ -90,17 +90,17 @@ mixin(Iterable, {
 
   toOrderedMap() {
     // Use Late Binding here to solve the circular dependency.
-    return OrderedMap(this.toKeyedSeq());
+    return new OrderedMap(this.toKeyedSeq());
   },
 
   toOrderedSet() {
     // Use Late Binding here to solve the circular dependency.
-    return OrderedSet(isKeyed(this) ? this.valueSeq() : this);
+    return new OrderedSet(isKeyed(this) ? this.valueSeq() : this);
   },
 
   toSet() {
     // Use Late Binding here to solve the circular dependency.
-    return Set(isKeyed(this) ? this.valueSeq() : this);
+    return new Set(isKeyed(this) ? this.valueSeq() : this);
   },
 
   toSetSeq() {
@@ -115,12 +115,12 @@ mixin(Iterable, {
 
   toStack() {
     // Use Late Binding here to solve the circular dependency.
-    return Stack(isKeyed(this) ? this.valueSeq() : this);
+    return new Stack(isKeyed(this) ? this.valueSeq() : this);
   },
 
   toList() {
     // Use Late Binding here to solve the circular dependency.
-    return List(isKeyed(this) ? this.valueSeq() : this);
+    return new List(isKeyed(this) ? this.valueSeq() : this);
   },
 
 
@@ -351,7 +351,7 @@ mixin(Iterable, {
   },
 
   isSubset(iter) {
-    iter = typeof iter.contains === 'function' ? iter : Iterable(iter);
+    iter = typeof iter.contains === 'function' ? iter : new Iterable(iter);
     return this.every(value => iter.contains(value));
   },
 

--- a/src/List.js
+++ b/src/List.js
@@ -30,7 +30,7 @@ export class List extends IndexedCollection {
     if (isList(value)) {
       return value;
     }
-    var iter = IndexedIterable(value);
+    var iter = new IndexedIterable(value);
     var size = iter.size;
     if (size === 0) {
       return empty;
@@ -582,7 +582,7 @@ function mergeIntoListWith(list, merger, iterables) {
   var maxSize = 0;
   for (var ii = 0; ii < iterables.length; ii++) {
     var value = iterables[ii];
-    var iter = IndexedIterable(value);
+    var iter = new IndexedIterable(value);
     if (iter.size > maxSize) {
       maxSize = iter.size;
     }

--- a/src/Map.js
+++ b/src/Map.js
@@ -31,7 +31,7 @@ export class Map extends KeyedCollection {
     return value === null || value === undefined ? emptyMap() :
       isMap(value) ? value :
       emptyMap().withMutations(map => {
-        var iter = KeyedIterable(value);
+        var iter = new KeyedIterable(value);
         assertNotInfinite(iter.size);
         iter.forEach((v, k) => map.set(k, v));
       });
@@ -129,12 +129,12 @@ export class Map extends KeyedCollection {
 
   sort(comparator) {
     // Late binding
-    return OrderedMap(sortFactory(this, comparator));
+    return new OrderedMap(sortFactory(this, comparator));
   }
 
   sortBy(mapper, comparator) {
     // Late binding
-    return OrderedMap(sortFactory(this, comparator, mapper));
+    return new OrderedMap(sortFactory(this, comparator, mapper));
   }
 
   // @pragma Mutability
@@ -705,7 +705,7 @@ function mergeIntoMapWith(map, merger, iterables) {
   var iters = [];
   for (var ii = 0; ii < iterables.length; ii++) {
     var value = iterables[ii];
-    var iter = KeyedIterable(value);
+    var iter = new KeyedIterable(value);
     if (!isIterable(value)) {
       iter = iter.map(v => fromJS(v));
     }

--- a/src/Operations.js
+++ b/src/Operations.js
@@ -333,7 +333,7 @@ export function filterFactory(iterable, predicate, context, useKeys) {
 
 
 export function countByFactory(iterable, grouper, context) {
-  var groups = Map().asMutable();
+  var groups = new Map().asMutable();
   iterable.__iterate((v, k) => {
     groups.update(
       grouper.call(context, v, k, iterable),
@@ -347,7 +347,7 @@ export function countByFactory(iterable, grouper, context) {
 
 export function groupByFactory(iterable, grouper, context) {
   var isKeyedIter = isKeyed(iterable);
-  var groups = (isOrdered(iterable) ? OrderedMap() : Map()).asMutable();
+  var groups = (isOrdered(iterable) ? new OrderedMap() : new Map()).asMutable();
   iterable.__iterate((v, k) => {
     groups.update(
       grouper.call(context, v, k, iterable),
@@ -542,7 +542,7 @@ export function concatFactory(iterable, values) {
         keyedSeqFromValue(v) :
         indexedSeqFromValue(Array.isArray(v) ? v : [v]);
     } else if (isKeyedIterable) {
-      v = KeyedIterable(v);
+      v = new KeyedIterable(v);
     }
     return v;
   }).filter(v => v.size !== 0);
@@ -683,9 +683,9 @@ export function sortFactory(iterable, comparator, mapper) {
     (v, i) => { entries[i].length = 2; } :
     (v, i) => { entries[i] = v[1]; }
   );
-  return isKeyedIterable ? KeyedSeq(entries) :
-    isIndexed(iterable) ? IndexedSeq(entries) :
-    SetSeq(entries);
+  return isKeyedIterable ? new KeyedSeq(entries) :
+    isIndexed(iterable) ? new IndexedSeq(entries) :
+    new SetSeq(entries);
 }
 
 
@@ -742,7 +742,7 @@ export function zipWithFactory(keyIter, zipper, iters) {
   };
   zipSequence.__iteratorUncached = function(type, reverse) {
     var iterators = iters.map(i =>
-      (i = Iterable(i), getIterator(reverse ? i.reverse() : i))
+      (i = new Iterable(i), getIterator(reverse ? i.reverse() : i))
     );
     var iterations = 0;
     var isDone = false;

--- a/src/OrderedMap.js
+++ b/src/OrderedMap.js
@@ -22,7 +22,7 @@ export class OrderedMap extends Map {
     return value === null || value === undefined ? emptyOrderedMap() :
       isOrderedMap(value) ? value :
       emptyOrderedMap().withMutations(map => {
-        var iter = KeyedIterable(value);
+        var iter = new KeyedIterable(value);
         assertNotInfinite(iter.size);
         iter.forEach((v, k) => map.set(k, v));
       });

--- a/src/OrderedSet.js
+++ b/src/OrderedSet.js
@@ -21,7 +21,7 @@ export class OrderedSet extends Set {
     return value === null || value === undefined ? emptyOrderedSet() :
       isOrderedSet(value) ? value :
       emptyOrderedSet().withMutations(set => {
-        var iter = SetIterable(value);
+        var iter = new SetIterable(value);
         assertNotInfinite(iter.size);
         iter.forEach(v => set.add(v));
       });
@@ -32,7 +32,7 @@ export class OrderedSet extends Set {
   }
 
   static fromKeys(value) {
-    return this(KeyedIterable(value).keySeq());
+    return this(new KeyedIterable(value).keySeq());
   }
 
   toString() {

--- a/src/Record.js
+++ b/src/Record.js
@@ -22,7 +22,7 @@ export class Record extends KeyedCollection {
       if (!(this instanceof RecordType)) {
         return new RecordType(values);
       }
-      this._map = Map(values);
+      this._map = new Map(values);
     };
 
     var keys = Object.keys(defaultValues);
@@ -109,11 +109,11 @@ export class Record extends KeyedCollection {
   }
 
   __iterator(type, reverse) {
-    return KeyedIterable(this._defaultValues).map((_, k) => this.get(k)).__iterator(type, reverse);
+    return new KeyedIterable(this._defaultValues).map((_, k) => this.get(k)).__iterator(type, reverse);
   }
 
   __iterate(fn, reverse) {
-    return KeyedIterable(this._defaultValues).map((_, k) => this.get(k)).__iterate(fn, reverse);
+    return new KeyedIterable(this._defaultValues).map((_, k) => this.get(k)).__iterate(fn, reverse);
   }
 
   __ensureOwner(ownerID) {

--- a/src/Seq.js
+++ b/src/Seq.js
@@ -21,7 +21,7 @@ export class Seq extends Iterable {
   }
 
   static of(/*...values*/) {
-    return Seq(arguments);
+    return new Seq(arguments);
   }
 
   toSeq() {
@@ -77,7 +77,7 @@ export class IndexedSeq extends Seq {
   }
 
   static of(/*...values*/) {
-    return IndexedSeq(arguments);
+    return new IndexedSeq(arguments);
   }
 
   toIndexedSeq() {
@@ -108,7 +108,7 @@ export class SetSeq extends Seq {
   }
 
   static of(/*...values*/) {
-    return SetSeq(arguments);
+    return new SetSeq(arguments);
   }
 
   toSetSeq() {

--- a/src/Set.js
+++ b/src/Set.js
@@ -25,7 +25,7 @@ export class Set extends SetCollection {
     return value === null || value === undefined ? emptySet() :
       isSet(value) ? value :
       emptySet().withMutations(set => {
-        var iter = SetIterable(value);
+        var iter = new SetIterable(value);
         assertNotInfinite(iter.size);
         iter.forEach(v => set.add(v));
       });
@@ -36,7 +36,7 @@ export class Set extends SetCollection {
   }
 
   static fromKeys(value) {
-    return this(KeyedIterable(value).keySeq());
+    return this(new KeyedIterable(value).keySeq());
   }
 
   toString() {
@@ -75,7 +75,7 @@ export class Set extends SetCollection {
     }
     return this.withMutations(set => {
       for (var ii = 0; ii < iters.length; ii++) {
-        SetIterable(iters[ii]).forEach(value => set.add(value));
+        new SetIterable(iters[ii]).forEach(value => set.add(value));
       }
     });
   }
@@ -84,7 +84,7 @@ export class Set extends SetCollection {
     if (iters.length === 0) {
       return this;
     }
-    iters = iters.map(iter => SetIterable(iter));
+    iters = iters.map(iter => new SetIterable(iter));
     var originalSet = this;
     return this.withMutations(set => {
       originalSet.forEach(value => {
@@ -99,7 +99,7 @@ export class Set extends SetCollection {
     if (iters.length === 0) {
       return this;
     }
-    iters = iters.map(iter => SetIterable(iter));
+    iters = iters.map(iter => new SetIterable(iter));
     var originalSet = this;
     return this.withMutations(set => {
       originalSet.forEach(value => {
@@ -120,12 +120,12 @@ export class Set extends SetCollection {
 
   sort(comparator) {
     // Late binding
-    return OrderedSet(sortFactory(this, comparator));
+    return new OrderedSet(sortFactory(this, comparator));
   }
 
   sortBy(mapper, comparator) {
     // Late binding
-    return OrderedSet(sortFactory(this, comparator, mapper));
+    return new OrderedSet(sortFactory(this, comparator, mapper));
   }
 
   wasAltered() {

--- a/src/Stack.js
+++ b/src/Stack.js
@@ -72,7 +72,7 @@ export class Stack extends IndexedCollection {
   }
 
   pushAll(iter) {
-    iter = IndexedIterable(iter);
+    iter = new IndexedIterable(iter);
     if (iter.size === 0) {
       return this;
     }

--- a/src/fromJS.js
+++ b/src/fromJS.js
@@ -17,20 +17,20 @@ export function fromJS(json, converter) {
 
 function fromJSWith(converter, json, key, parentJSON) {
   if (Array.isArray(json)) {
-    return converter.call(parentJSON, key, IndexedSeq(json).map((v, k) => fromJSWith(converter, v, k, json)));
+    return converter.call(parentJSON, key, new IndexedSeq(json).map((v, k) => fromJSWith(converter, v, k, json)));
   }
   if (isPlainObj(json)) {
-    return converter.call(parentJSON, key, KeyedSeq(json).map((v, k) => fromJSWith(converter, v, k, json)));
+    return converter.call(parentJSON, key, new KeyedSeq(json).map((v, k) => fromJSWith(converter, v, k, json)));
   }
   return json;
 }
 
 function fromJSDefault(json) {
   if (Array.isArray(json)) {
-    return IndexedSeq(json).map(fromJSDefault).toList();
+    return new IndexedSeq(json).map(fromJSDefault).toList();
   }
   if (isPlainObj(json)) {
-    return KeyedSeq(json).map(fromJSDefault).toMap();
+    return new KeyedSeq(json).map(fromJSDefault).toMap();
   }
   return json;
 }

--- a/src/utils/forceIterator.js
+++ b/src/utils/forceIterator.js
@@ -19,7 +19,7 @@ export default function forceIterator(keyPath) {
     if (!isArrayLike(keyPath)) {
       throw new TypeError('Expected iterable or array-like: ' + keyPath);
     }
-    iter = getIterator(Iterable(keyPath));
+    iter = getIterator(new Iterable(keyPath));
   }
   return iter;
 }


### PR DESCRIPTION
immutable-js instantiates a lot of classes without `new`, which is no longer legal.  As per ES6 February 2, 2015 Draft Rev 32, "Constructors defined using class definition syntax throw when called as functions" https://www.mail-archive.com/es-discuss@mozilla.org/msg34104.html

6to5 implemented the new behavior in  https://github.com/6to5/6to5/commit/3a11c7d46b5788175c9c1141ff50ed59ce26c40c, and I couldn't run immutable-js/src/ with 6to5 until making these changes.

I extracted the list of classes with
```bash
grep --no-filename -o -P '^(export )?class .*? ' src/**/*.js
```

and generated the diff with this shell program:
```bash
for i in Collection KeyedCollection IndexedCollection SetCollection Iterable KeyedIterable IndexedIterable SetIterable Iterator List VNode Map ArrayMapNode BitmapIndexedNode HashArrayMapNode HashCollisionNode ValueNode MapIterator ToKeyedSequence ToIndexedSequence ToSetSequence FromEntriesSequence OrderedMap OrderedSet Range Record Repeat Seq KeyedSeq IndexedSeq SetSeq ArraySeq ObjectSeq IterableSeq IteratorSeq Set Stack; do echo; echo $i; perl -p -i -e "s,(?<\!new|ion|nds)([\( ])(\\b$i\\(),\\1new \\2,g" src/**/*.js __tests__/**/*.js contrib/**/*.js; done
```

I've signed the CLA as ivan@ludios.org