### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ has changed.
 ```javascript
 var map1 = Immutable.Map({a:1, b:2, c:3});
 var map2 = map1.set('b', 2);
-assert(map1 === map2);
+assert(map1 !== map2);
 var map3 = map1.set('b', 50);
 assert(map1 !== map3);
 ```


### PR DESCRIPTION
Currently the example in the `README.md` shows `assert(map1 === map2)`. This is confusing for readers since these two are not equal, but we `assert` that they are. This change adjusts the example to `assert` the reality.