### PR TITLE
Use load-grunt-tasks for load dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -213,12 +213,7 @@ module.exports = function(grunt) {
     var ts = require('ts-compiler');
   });
 
-
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-jest');
-  grunt.loadNpmTasks('grunt-release');
+  require('load-grunt-tasks')(grunt);
 
   grunt.registerTask('lint', 'Lint all source javascript', ['jshint']);
   grunt.registerTask('build', 'Build distributed javascript', ['clean', 'bundle', 'copy']);

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "grunt-jest": "^0.1.0",
     "grunt-release": "^0.7.0",
     "jasmine-check": "^0.1.2",
+    "load-grunt-tasks": "^3.1.0",
     "magic-string": "^0.2.6",
     "microtime": "^1.2.0",
     "react-tools": "^0.11.1",


### PR DESCRIPTION
Automatically include all grunt dependencies `grunt-*` using **load-grunt-tasks**  instead of call `loadNpmTasks` for each one :)