### PR TITLE
added List methods push, pop, unshift, shift to List IndexedCursor

### DIFF
--- a/contrib/cursor/__tests__/Cursor.ts
+++ b/contrib/cursor/__tests__/Cursor.ts
@@ -179,6 +179,59 @@ describe('Cursor', () => {
     expect(cursor.map((x: number) => x * x)).toEqual(Immutable.Map({a: 1, b: 4, c: 9}));
   });
 
+  it('can push values on a List', () => {
+    var onChange = jest.genMockFunction();
+    var data = Immutable.fromJS({a: {b: [0, 1, 2]}});
+    var cursor = Cursor.from(data, ['a', 'b'], onChange);
+
+    expect(cursor.push(3,4)).toEqual(Immutable.List([0, 1, 2, 3, 4]));
+    expect(onChange).lastCalledWith(
+      Immutable.fromJS({a: {b: [0, 1, 2, 3, 4]}}),
+      data,
+      ['a', 'b']
+    );
+  });
+
+  it('can pop values of a List', () => {
+    var onChange = jest.genMockFunction();
+    var data = Immutable.fromJS({a: {b: [0, 1, 2]}});
+    var cursor = Cursor.from(data, ['a', 'b'], onChange);
+
+    expect(cursor.pop()).toEqual(Immutable.List([0, 1]));
+    expect(onChange).lastCalledWith(
+      Immutable.fromJS({a: {b: [0, 1]}}),
+      data,
+      ['a', 'b']
+    );
+  });
+
+  it('can unshift values on a List', () => {
+    var onChange = jest.genMockFunction();
+    var data = Immutable.fromJS({a: {b: [0, 1, 2]}});
+    var cursor = Cursor.from(data, ['a', 'b'], onChange);
+
+    expect(cursor.unshift(-2, -1)).toEqual(Immutable.List([-2, -1, 0, 1, 2]));
+    expect(onChange).lastCalledWith(
+      Immutable.fromJS({a: {b: [-2, -1, 0, 1, 2]}}),
+      data,
+      ['a', 'b']
+    );
+  });
+
+  it('can shift values of a List', () => {
+    var onChange = jest.genMockFunction();
+    var data = Immutable.fromJS({a: {b: [0, 1, 2]}});
+    var cursor = Cursor.from(data, ['a', 'b'], onChange);
+
+    expect(cursor.shift()).toEqual(Immutable.List([1, 2]));
+    expect(onChange).lastCalledWith(
+      Immutable.fromJS({a: {b: [1, 2]}}),
+      data,
+      ['a', 'b']
+    );
+  });
+
+
   it('returns wrapped values for sequence API', () => {
     var data = Immutable.fromJS({a: {v: 1}, b: {v: 2}, c: {v: 3}});
     var onChange = jest.genMockFunction();

--- a/contrib/cursor/index.d.ts
+++ b/contrib/cursor/index.d.ts
@@ -165,6 +165,29 @@ declare module 'immutable/contrib/cursor' {
     setIn(keyPath: Immutable.Iterable<any, any>, value: any): Cursor;
 
     /**
+     * Returns a new Cursor with provided `values` appended
+     */
+    push(...values: Array<any>): Cursor;
+
+    /**
+     * Returns a new Cursor with a size ones less than this Cursor,
+     * excluding the last index in this Cursor.
+     */
+    pop(): Cursor;
+
+    /**
+     * Returns a new Cursor with the provided `values` prepended,
+     * shifting other values ahead to higher indices.
+     */
+    unshift(...values: Array<any>): Cursor;
+
+    /**
+     * Returns a new Cursor with a size ones less than this Cursor, excluding
+     * the first index in this Cursor, shifting all other values to a lower index.
+     */
+    shift(): Cursor;
+
+    /**
      * Returns a new Cursor having removed the value at this `keyPath`.
      *
      * @alias removeIn

--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -88,6 +88,32 @@ KeyedCursorPrototype.set = function(key, value) {
   return updateCursor(this, function (m) { return m.set(key, value); }, [key]);
 }
 
+IndexedCursorPrototype.push = function(/* values */) {
+  var args = arguments;
+  return updateCursor(this, function (m) {
+    return m.push.apply(m, args);
+  });
+}
+
+IndexedCursorPrototype.pop = function() {
+  return updateCursor(this, function (m) {
+    return m.pop();
+  });
+}
+
+IndexedCursorPrototype.unshift = function(/* values */) {
+  var args = arguments;
+  return updateCursor(this, function (m) {
+    return m.unshift.apply(m, args);
+  });
+}
+
+IndexedCursorPrototype.shift = function() {
+  return updateCursor(this, function (m) {
+    return m.shift();
+  });
+}
+
 IndexedCursorPrototype.setIn =
 KeyedCursorPrototype.setIn = Map.prototype.setIn;
 


### PR DESCRIPTION
I tried to add some methods to the Cursor API because they are missing. This solves #346.

I'm not sure if this is the right way to do it, because all other methods extend both KeyedCursorPrototype and IndexedCursorPrototype and this only extends IndexedCursorPrototype. So all feedback is more then welcome!