### PR TITLE
Support tree-like data structures through Cursors

### DIFF
--- a/contrib/cursor/__tests__/Cursor.ts
+++ b/contrib/cursor/__tests__/Cursor.ts
@@ -294,4 +294,71 @@ describe('Cursor', () => {
     );
   });
 
+  it ('can get its parent', () => {
+    var data = Immutable.fromJS({a:{b:{c:1}}});
+    var c1 = Cursor.from(data, ['a']);
+    var c2 = Cursor.from(data, ['a', 'b']);
+
+    expect(Immutable.is(c1.parent(), data)).toBeTruthy();
+    expect(Immutable.is(c2.parent(), c1)).toBeTruthy();
+    expect(Immutable.is(c2.parent(), data.get('a'))).toBeTruthy();
+  });
+
+  it ('can get its sibling', () => {
+    var data = Immutable.fromJS({a:{b1:{c:1},b2:{c:2}}});
+    var c = Cursor.from(data, ['a', 'b1']);
+
+    expect(c.sibling('b2').deref()).toEqual(Immutable.fromJS({c:2}));
+  });
+
+  it ('can get any sibling', () => {
+    var data = Immutable.fromJS({a:{b1:{c:1},b2:{c:2},b3:{c:3}}});
+    var c = Cursor.from(data, ['a', 'b3']);
+
+    expect(c.sibling('b1').deref()).toEqual(Immutable.fromJS({c:1}));
+  });
+
+  it ('can get the next sibling', () => {
+    var data = Immutable.fromJS({a:[{c:1},{c:2},{c:3}]});
+    var c = Cursor.from(data, ['a', 0]);
+
+    expect(c.nextSibling().deref()).toEqual(Immutable.fromJS({c:2}));
+  });
+
+  it ('returns undefined if the next sibling is requested and we are the last', () => {
+    var data = Immutable.fromJS({a:[{c:1},{c:2},{c:3}]});
+    var c = Cursor.from(data, ['a', 2]);
+
+    expect(c.nextSibling()).toBeUndefined();
+  });
+
+
+  it ('can get the previous sibling', () => {
+    var data = Immutable.fromJS({a:[{c:1},{c:2},{c:3}]});
+    var c = Cursor.from(data, ['a', 1]);
+
+    expect(c.prevSibling().deref()).toEqual(Immutable.fromJS({c:1}));
+  });
+
+  it ('returns undefined if the previous sibling is requested and we are the first', () => {
+    var data = Immutable.fromJS({a:[{c:1},{c:2},{c:3}]});
+    var c = Cursor.from(data, ['a', 0]);
+
+    expect(c.prevSibling()).toBeUndefined();
+  });
+
+  it ('returns undefined if we are trying to get the next sibling and our parent is not a list', () => {
+    var data = Immutable.fromJS({a:{b1:{c:1},b2:{c:2},b3:{c:3}}});
+    var c = Cursor.from(data, ['a', 'b3']);
+
+    expect(c.nextSibling()).toBeUndefined();
+  });
+
+  it ('returns undefined if we are trying to get the previous sibling and our parent is not a list', () => {
+    var data = Immutable.fromJS({a:{b1:{c:1},b2:{c:2},b3:{c:3}}});
+    var c = Cursor.from(data, ['a', 'b3']);
+
+    expect(c.prevSibling()).toBeUndefined();
+  });
+
 });

--- a/contrib/cursor/index.d.ts
+++ b/contrib/cursor/index.d.ts
@@ -260,6 +260,38 @@ declare module 'immutable/contrib/cursor' {
      * callback is triggered with the final value.
      */
     withMutations(mutator: (mutable: any) => any): Cursor;
+
+    // Tree-like browsing methods
+
+    /**
+     * Returns the cursor's parent or itself if it's the root node.
+     *
+     * A new Cursor is returned.
+     */
+    parent(): any;
+
+    /**
+     * Returns a cursor's sibling or `notSetValue` if it's the sibling doesn't exist.
+     *
+     * A new Cursor is returned.
+     */
+    sibling(key: any, notSetValue?: any): any;
+
+    /**
+     * Returns a cursor's next sibling or `notSetValue` if its parent isn't an IndexedCursor or
+     * the node is the first node.
+     *
+     * A new Cursor is returned.
+     */
+    nextSibling(notSetValue?: any): any;
+
+    /**
+     * Returns a cursor's previous sibling or `notSetValue` if its parent isn't an IndexedCursor or
+     * the node is the first node.
+     *
+     * A new Cursor is returned.
+     */
+    prevSibling(notSetValue?: any): any;
   }
 
 }

--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -216,6 +216,43 @@ IndexedCursorPrototype.__iterator = function(type, reverse) {
 KeyedCursor.prototype = KeyedCursorPrototype;
 IndexedCursor.prototype = IndexedCursorPrototype;
 
+KeyedCursorPrototype.parent =
+IndexedCursorPrototype.parent = function(notSetValue) {
+  return cursorFrom(this._rootData, this._keyPath.slice(0, this._keyPath.length - 1));
+}
+
+KeyedCursorPrototype.sibling =
+IndexedCursorPrototype.sibling = function(key, notSetValue) {
+  return this.parent(notSetValue).get(key, notSetValue);
+}
+
+KeyedCursorPrototype.prevSibling =
+IndexedCursorPrototype.prevSibling = function(notSetValue) {
+  var key = this._keyPath[this._keyPath.length - 1];
+  var parent = this.parent(notSetValue);
+  if (parent instanceof IndexedCursor) {
+    key = key === -1 ? parent.size - 1 : key; // Iterable#last sets the key to -1
+
+    if(key > 0) {
+      return parent.get(key - 1, notSetValue);
+    }
+  }
+  return notSetValue;
+}
+
+KeyedCursorPrototype.nextSibling =
+IndexedCursorPrototype.nextSibling = function(notSetValue) {
+  var key = this._keyPath[this._keyPath.length - 1];
+  var parent = this.parent(notSetValue);
+  if (parent instanceof IndexedCursor) {
+    key = key === -1 ? parent.size - 1 : key; // Iterable#last sets the key to -1
+
+    if(key < parent.size) {
+      return parent.get(key + 1, notSetValue);
+    }
+  }
+  return notSetValue;
+}
 
 var NOT_SET = {}; // Sentinel value
 


### PR DESCRIPTION
Hi all,

Following up on #242, [we're using Cursors to browse tree-like data structures](https://github.com/facebook/immutable-js/issues/242#issuecomment-77404067).

This PR implements `parent`, `sibling`, `nextSibling` and `prevSibling` on `Cursor` to work with tree-like data structures.

Would that be a desirable feature for `Cursor` or should it live in a more specific implementation?

Thanks :)
Darío