### PR TITLE
subCursor (cursor.cursor('a')) returns improper type

### DIFF
--- a/contrib/cursor/__tests__/Cursor.ts
+++ b/contrib/cursor/__tests__/Cursor.ts
@@ -49,6 +49,13 @@ describe('Cursor', () => {
     expect(deepCursor.deref()).toBe(data.getIn(Immutable.fromJS(['a', 'b'])));
   });
 
+  it('cursor return new cursors of correct type', () => {
+    var data = Immutable.fromJS({ a: [1, 2, 3] });
+    var cursor = Cursor.from(data);
+    var deepCursor = <any>cursor.cursor('a');
+    expect(deepCursor.findIndex).toBeDefined();
+  });
+
   it('can be treated as a value', () => {
     var data = Immutable.fromJS(json);
     var cursor = Cursor.from(data, ['a', 'b']);

--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -220,7 +220,7 @@ IndexedCursor.prototype = IndexedCursorPrototype;
 var NOT_SET = {}; // Sentinel value
 
 function makeCursor(rootData, keyPath, onChange, value) {
-  if (value === void 0) {
+  if (arguments.length < 4) {
     value = rootData.getIn(keyPath);
   }
   var size = value && value.size;
@@ -233,6 +233,13 @@ function wrappedValue(cursor, keyPath, value) {
 }
 
 function subCursor(cursor, keyPath, value) {
+  if (arguments.length < 3) {
+    return makeCursor( // call without value
+      cursor._rootData,
+      newKeyPath(cursor._keyPath, keyPath),
+      cursor._onChange
+    );
+  }
   return makeCursor(
     cursor._rootData,
     newKeyPath(cursor._keyPath, keyPath),

--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -220,7 +220,7 @@ IndexedCursor.prototype = IndexedCursorPrototype;
 var NOT_SET = {}; // Sentinel value
 
 function makeCursor(rootData, keyPath, onChange, value) {
-  if (arguments.length < 4) {
+  if (value === void 0) {
     value = rootData.getIn(keyPath);
   }
   var size = value && value.size;


### PR DESCRIPTION
Due to defect in the code, calling cursor() on cursor can return improper type

```javascript
var data = Immutable.fromJS({ a: [1, 2, 3] });
var cursor = Cursor.from(data);
var deepCursor = cursor.cursor('a');
deepCursor instanceof IndexedCursor; // fails since is KeyedCursor
```

Originally reported here https://github.com/facebook/immutable-js/pull/297 I decided that it might be a safer fix to continue using argument.length rather than checking undefined since I think it might be valid to use undefined in some circumstances.

So this fix goes back to using argument.length in the makeCursor check, but properly calls it with only 3 arguments from subCursor if subCursor is not called with value.
