### PR TITLE
fromJS: should return the same result if used with or withour converter

### DIFF
--- a/src/fromJS.js
+++ b/src/fromJS.js
@@ -17,10 +17,10 @@ export function fromJS(json, converter) {
 
 function fromJSWith(converter, json, key, parentJSON) {
   if (Array.isArray(json)) {
-    return converter.call(parentJSON, key, IndexedSeq(json).map((v, k) => fromJSWith(converter, v, k, json)));
+    return converter.call(parentJSON, key, IndexedSeq(json).map((v, k) => fromJSWith(converter, v, k, json)).toList());
   }
   if (isPlainObj(json)) {
-    return converter.call(parentJSON, key, KeyedSeq(json).map((v, k) => fromJSWith(converter, v, k, json)));
+    return converter.call(parentJSON, key, KeyedSeq(json).map((v, k) => fromJSWith(converter, v, k, json)).toMap());
   }
   return json;
 }


### PR DESCRIPTION
Just simple example of using `fromJS`:

    var data = Immutable.fromJS({ data: { n: 13 } });

    data.toString(); // "Map { "data": Map { "n": 13 } }"

But, if I use converter (no matter how), I'm getting another result:

    var data = Immutable.fromJS({ data: { n: 13 } }, (k, v) => v);

    data.toString(); // "Seq { "data": Seq { "n": 13 } }"

It's break my code and I need to write additional conversion `toMap`.

If you agree with importance of this PR I can add unit tests for this case.

Thanks,
Alexey Raspopov