### PR TITLE
hasIn does not take a notSetValue

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -1434,8 +1434,8 @@ declare module 'immutable' {
      * True if the result of following a path of keys or indices through nested
      * Iterables results in a set value.
      */
-    hasIn(searchKeyPath: Array<any>, notSetValue?: any): boolean;
-    hasIn(searchKeyPath: Iterable<any, any>, notSetValue?: any): boolean;
+    hasIn(searchKeyPath: Array<any>): boolean;
+    hasIn(searchKeyPath: Iterable<any, any>): boolean;
 
 
     // Conversion to JavaScript types


### PR DESCRIPTION
hasIn(searchKeyPath) {
    return this.getIn(searchKeyPath, NOT_SET) !== NOT_SET;
},