### PR TITLE
updating bower.json and package.json so tsd link picks up typscript t…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,9 @@
     "url": "git://github.com/facebook/immutable-js.git"
   },
   "main": "dist/immutable.js",
+  "typescript": {
+    "definition": "dist/immutable.d.ts"
+  },
   "ignore": [
     "**/.*",
     "__tests__",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "url": "https://github.com/facebook/immutable-js/issues"
   },
   "main": "dist/immutable.js",
+  "typescript": {
+    "definition": "dist/immutable.d.ts"
+  },
   "scripts": {
     "test": "./resources/node_test.sh",
     "perf": "node ./resources/bench.js"


### PR DESCRIPTION
The tsd type definitional manager for typescript supports a link functionality to automatically pull in d.ts files from included npm and bower dependencies if they have a "typescript" entry. https://github.com/Definitelytyped/tsd#link-to-bundled-definitions. Branch "typescript-package-link" adds these entries to both json files.