### PR TITLE
fail test

### DIFF
--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -95,4 +95,11 @@ describe('Record', () => {
     expect(t.get('c')).toBeUndefined();
   })
 
+  it('map like Map', () => {
+    var MyType = Record({a:1, b:2});
+    var res = (new MyType()).map(function(v, k) { return v * 2 })
+
+    expect(res).not.toBe(undefined);
+  })
+
 });


### PR DESCRIPTION
I've expected map behaviour like for other Iterable object instead it returns undefined.