### PR TITLE
added method keyPath to Cursor

### DIFF
--- a/contrib/cursor/__tests__/Cursor.ts
+++ b/contrib/cursor/__tests__/Cursor.ts
@@ -17,6 +17,43 @@ describe('Cursor', () => {
 
   var json = { a: { b: { c: 1 } } };
 
+  describe('keyPath', () => {
+    var root = Immutable.Map({
+      one: Immutable.Map({
+        two: { // plain object
+          list: [1, 2, 3],
+          map: Immutable.Map({cake: true}),
+          three: Immutable.List.of([
+            {done: 'nope'},
+            {done: 'almost'},
+            {done: 'just one more line'},
+            {done: 'finally'}
+          ])
+        },
+        dos: [1, 2, 3] // plain array
+      }),
+      depth: 4
+    });
+    var node = root.getIn(['one', 'two', 'three', 4]);
+
+    it('returns undefined if node is not in root', () => {
+      var keyPath = Cursor.keyPath(node, root);
+      expect(keyPath).toBe(undefined);
+    });
+
+    it('returns an empty array if root is node', () => {
+      var rootKeyPath = Cursor.keyPath(root, root);
+      expect(rootKeyPath).toBe([]);
+      var nodeKeyPath = Cursor.keyPath(node, node);
+      expect(nodeKeyPath).toBe([]);
+    });
+
+    it('returns the keypath to get from root to node', () => {
+      var keyPath = Cursor.keyPath(root, node);
+      expect(keyPath).toEqual(['one', 'two', 'three', 4]);
+    });
+  })
+
   it('gets from its path', () => {
     var data = Immutable.fromJS(json);
     var cursor = Cursor.from(data);

--- a/contrib/cursor/index.d.ts
+++ b/contrib/cursor/index.d.ts
@@ -57,6 +57,11 @@ declare module 'immutable/contrib/cursor' {
   ): Cursor;
 
 
+  export function keyPath(
+    root: <any>,
+    node: <any>
+  ): Array<any>;
+
   export interface Cursor extends Immutable.Seq<any, any> {
 
     /**

--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -340,4 +340,48 @@ function valToKeyPath(val) {
     [val];
 }
 
+function keyPathSearch(root, node) {
+  if(root === node) return [];
+  if(Immutable.List.isList(root)) {
+    var key = parent.indexOf(node);
+    if(key !==- 1) return [key];
+  } else if(Immutable.Map.isMap(root)) {
+    var key = parent.findKey(function(child) {
+      return child === node;
+    });
+    if(key) return [key];
+  } else if(typeof parent === 'object') {
+    if(Array.isArray(parent)) {
+      var key = parent.indexOf(node);
+      if(key !== -1) return [key]; 
+    } else {
+      var keys = Object.keys(parent);
+      var hits = keys.filter(function(key) {
+        return parent[key] === node;
+      });
+      if(hits.length === 1) return hits;
+    }
+  }
+  return undefined;
+}
+
+function keyPath(root, node) {
+  if(!root) return undefined;
+  var path = keyPathSearch(root, node);
+  if(path !== undefined) return path;
+
+  if(Array.isArray(root)) root = Immutable.List(root);
+  if(root.constructor === Object) root = Immutable.Map(root);  
+  if(!root.map) return undefined;
+
+  return root.map(function(child) {
+    return keyPath(child, node);
+  }).filter(function(keys) {
+    return Array.isArray(keys);
+  }).map(function(keys, key) {
+    return [key].concat(keys);
+  }).first();
+}
+
 exports.from = cursorFrom;
+exports.keyPath = keyPath;


### PR DESCRIPTION
A lot of people including myself need a way to generate a key path between a root and node of a deeply nested data structure. This method does that. See the tests for examples.

I also see you are moving toward pulling Cursor out of Immutable. That's awesome. Maybe it would be best to move keyPath to be a static method on Immutable since getIn() and friends need a keyPath, or I'll just put it into a separate module.
