### PR TITLE
Add ability to group cursor operations

### DIFF
--- a/contrib/cursor/__tests__/Cursor.ts
+++ b/contrib/cursor/__tests__/Cursor.ts
@@ -289,6 +289,38 @@ describe('Cursor', () => {
     expect(typeof mapped2.get(0).deref).toBe('function');
   });
 
+  it('can have grouped operations with cursor apply with a single callback', () => {
+    var onChange = jest.genMockFunction();
+    var data = Immutable.fromJS({'a': 1});
+
+    var c1 = Cursor.from(data, onChange);
+    var c2 = c1.groupedOperations(cursor => {
+      // Passed value should be a cursor.
+      expect(typeof cursor.deref).toBe('function');
+
+      return cursor.set('b', 2).set('c', 3).set('d', 4);
+    });
+
+    expect(c1.deref().toObject()).toEqual({'a': 1});
+    expect(c2.deref().toObject()).toEqual({'a': 1, 'b': 2, 'c': 3, 'd': 4});
+    expect(onChange.mock.calls.length).toBe(1);
+  });
+
+  it('passes cursors to grouped operations even if cursors point to scalars', () => {
+    var onChange = jest.genMockFunction();
+    var data = Immutable.fromJS({'a': 1});
+
+    var c1 = Cursor.from(data, ['a'], onChange);
+    var c2 = c1.groupedOperations(cursor => {
+      // Passed value should be a cursor.
+      expect(typeof cursor.deref).toBe('function');
+      return cursor.set(2);
+    });
+    expect(c1.deref()).toEqual(1);
+    expect(c2.deref()).toEqual(2);
+    expect(onChange.mock.calls.length).toBe(1);
+  });
+
   it('can have mutations apply with a single callback', () => {
     var onChange = jest.genMockFunction();
     var data = Immutable.fromJS({'a': 1});

--- a/contrib/cursor/index.d.ts
+++ b/contrib/cursor/index.d.ts
@@ -286,6 +286,16 @@ declare module 'immutable/contrib/cursor' {
      * callback is triggered with the final value.
      */
     withMutations(mutator: (mutable: any) => any): Cursor;
+
+    /**
+     * Every time you change a cursors value you trigger the onChange callback
+     * from Cursor creation. In addition you can get scalar values as values
+     * passed to the updater. This can sometimes be unfortunate if you want to
+     * group a set of operations on a cursor. `groupedOperations` will allow
+     * you to group a set of operations on a cursor and only trigger the
+     * change callback after the updater function is invoked.
+     */
+    groupedOperations(updater: (value: Cursor) => Cursor): Cursor;
   }
 
 }

--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -198,6 +198,16 @@ IndexedCursorPrototype.withMutations = function(fn) {
   });
 }
 
+KeyedCursorPrototype.groupedOperations =
+IndexedCursorPrototype.groupedOperations = function(fn) {
+  var silentCursor = makeCursor(this._rootData, this._keyPath);
+  return updateCursor(this, function (m) {
+    var result = fn(silentCursor);
+    if (result && result.deref) return result.deref();
+    return result;
+  });
+}
+
 KeyedCursorPrototype.cursor =
 IndexedCursorPrototype.cursor = function(subKeyPath) {
   subKeyPath = valToKeyPath(subKeyPath);


### PR DESCRIPTION
First of all, sorry for the wall of text. I'm trying to cover the argumentation, why this is needed and how this can open for more powerful patterns, so we can have a discussion around it. A lot of times there is a need to group operations on cursors, much like withMutations, but not with passed values but the actual cursors. Like so:

``` js
var data = Immutable.fromJS({'a': 1});
var c1 = Cursor.from(data, ['a'], onChange);
var c2 = c1.groupedOperations(cursor => cursor.set(2));
```

In contrast to 

``` js
var data = Immutable.fromJS({'a': 1});
var c1 = Cursor.from(data, ['a'], onChange);
var c2 = c1.withMutations(cursor => cursor.set(2)); // Would fail
// This would also fail as c1 points to a scalar
c2 = c1.withMutations(value => 2); // Would fail

// Would instead have to go "one level up" to point to a immutable structure:
c1 = Cursor.from(data, onChange);
c2 = c1.withMutations(value => value.set('a', 2)); // Would work
```

By having `groupedOperations` (or with another name?) you could have seperate operations/functions and group/compose them to one, and behave as if it was one with only one triggered `onChange`.

Problem is, if you have the following:

``` jsx
var square = cursor => cursor.update(input => input * input);
var timesTwo = cursor => cursor.update(input => input * 2);
```

you could do:

``` jsx
var c2 = square(c1);
```

and that would work as expected. You could also do:

``` js
var c2 = square(timesTwo(c1));
```

but that would trigger `onChange` twice, which is in many cases less than optimal. How ever, with `groupedOperations`, you can pass in composed functions and only trigger one update:

``` js
var c2 = c1.groupedOperations(compose(square, timesTwo));
```

As mentioned, you could do something seemingly similar with `withMutations`, but as `withMutations` pass on the cursors underlaying data and not the cursor it self, this would be "semantically different", and our functions would have to be different with composed and non-composed editions (one handling cursors, and one handling the values the cursors are pointing at).

Alternative to `groupedOperations` name can be `bulk` or `grouped`.
