### PR TITLE
Correct location of isIterable function

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -456,8 +456,8 @@ declare module 'immutable' {
      * each iterable and sets it on this Map.
      *
      * If any of the values provided to `merge` are not Iterable (would return
-     * false for `Immutable.isIterable`) then they are deeply converted via
-     * `Immutable.fromJS` before being merged. However, if the value is an
+     * false for `Immutable.Iterable.isIterable`) then they are deeply converted
+     * via `Immutable.fromJS` before being merged. However, if the value is an
      * Iterable but includes non-iterable JS objects or arrays, those nested
      * values will be preserved.
      *


### PR DESCRIPTION
Just a small docs fix. The `isIterable` function is on `Iterable` (not `Immutable`).