### PR TITLE
change findIndex in Lists default value

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -398,7 +398,7 @@ describe('List', () => {
   it('finds values using findIndex', () => {
     var v = List.of('a', 'b', 'c', 'B', 'a');
     expect(v.findIndex(value => value.toUpperCase() === value)).toBe(3);
-    expect(v.findIndex(value => value.length > 1)).toBe(-1);
+    expect(v.findIndex(value => value.length > 1)).toBe(undefined);
   });
 
   it('finds values using findEntry', () => {

--- a/src/IterableImpl.js
+++ b/src/IterableImpl.js
@@ -556,7 +556,7 @@ mixin(IndexedIterable, {
 
   findIndex(predicate, context) {
     var entry = this.findEntry(predicate, context);
-    return entry ? entry[0] : -1;
+    return entry ? entry[0] : undefined;
   },
 
   indexOf(searchValue) {


### PR DESCRIPTION
FindIndex should return something besides `-1` specially since the `get(-1)` gets the last value of the list. It just makes it confusing and not intuitive.
