### PR TITLE
Add tests that sending a null argument to List.get() should return undefined

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -80,6 +80,14 @@ describe('List', () => {
     expect(v.get(0)).toBe('value');
   });
 
+  it('returns undefined when getting a null value', () => {
+    var v = Immutable.List([1, 2, 3]);
+    expect(v.get(null)).toBe(undefined);
+
+    var o = Immutable.List([{ a: 1 },{ b: 2 }, { c: 3 }]);
+    expect(o.get(null)).toBe(undefined);
+  });
+
   it('counts from the end of the list on negative index', () => {
     var i = Immutable.List.of(1, 2, 3, 4, 5, 6, 7);
     expect(i.get(-1)).toBe(7);


### PR DESCRIPTION
Adding some tests that ensure that sending a null argument to List.get() will return undefined.

This is the expected behavior on master, but on [3.7.4](https://github.com/facebook/immutable-js/tree/3.7.4) this is currently failing.

I've created [a branch off of 3.7.4](https://github.com/kevinold/immutable-js/tree/v3.7.4_List_get_null) with [a patch](https://github.com/kevinold/immutable-js/commit/f4f123a32a5833e918cf6f5aa60acb1c6384077b) to show these tests failing.

According to a git bisect, this patch was the "good" patch that introduced the fix for this issue - https://github.com/facebook/immutable-js/commit/e4a1e34bc735055819a216764852b03c81cbc301

