### PR TITLE
Global type definition fixes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,6 +47,9 @@ module.exports = function(grunt) {
         files: [{
           src: 'type-definitions/Immutable.d.ts',
           dest: 'dist/immutable.d.ts'
+        },{
+          src: 'type-definitions/Immutable-global.d.ts',
+          dest: 'dist/immutable-global.d.ts'
         }]
       }
     },

--- a/dist/immutable-global.d.ts
+++ b/dist/immutable-global.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="Immutable.d.ts" />
+
+import Immutable = __Immutable;

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -28,7 +28,7 @@
  * [ES6]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla
  */
 
-declare module Immutable {
+declare module __Immutable {
 
   /**
    * Deeply converts plain JS objects and arrays to Immutable Maps and Lists.
@@ -2513,5 +2513,5 @@ declare module Immutable {
 }
 
 declare module "immutable" {
-  export = Immutable
+  export = __Immutable
 }

--- a/type-definitions/Immutable-global.d.ts
+++ b/type-definitions/Immutable-global.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="Immutable.d.ts" />
+
+import Immutable = __Immutable;

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -28,7 +28,7 @@
  * [ES6]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/ECMAScript_6_support_in_Mozilla
  */
 
-declare module Immutable {
+declare module __Immutable {
 
   /**
    * Deeply converts plain JS objects and arrays to Immutable Maps and Lists.
@@ -2513,5 +2513,5 @@ declare module Immutable {
 }
 
 declare module "immutable" {
-  export = Immutable
+  export = __Immutable
 }


### PR DESCRIPTION
With reference to the [current TypeScript type definition](https://github.com/facebook/immutable-js/blob/59028b5e8552339acbdaab0c3f6547bd131f8f54/type-definitions/Immutable.d.ts). 

The following code compiles:

``` typescript
/// <reference path="../jspm_packages/npm/immutable@3.7.5/dist/immutable.d.ts" />

let x = Immutable.Seq([1,2,3]);
console.log(x);
```

but fails at runtime unless you have loaded ImmutableJS elsewhere. For those, like me, who use [SystemJS](https://github.com/systemjs/systemjs) (or other modules loaders) to load modules, we need to declare dependencies via imports, and generally rely on the compiler to tell us when we have missed one (as is the case here).

This PR creates two (linked) versions of the type definition:
- For those people who are going to loaded ImmutableJS elsewhere and want to therefore take advantage of the global definitions, they should reference `Immutable-global.d.ts`
- For those people who use module loaders and want the above code to be a compile error because they haven't imported ImmutableJS, they should use `Immutable.d.ts`

A similar approach is [taken by React](https://github.com/borisyankov/DefinitelyTyped/tree/master/react).

So if instead I reference the `Immutable.d.ts` in this PR, the above code would give a compile error:

```
app/app.ts(3,9): error TS2304: Cannot find name 'Immutable'.
```

This forces me to import:

``` typescript
/// <reference path="../typings/immutable/Immutable.d.ts" />

import * as Immutable from "immutable";

let x = Immutable.Seq([1,2,3]);
console.log(x);
```

The transpiled output then includes the relevant module loading code to ensure ImmutableJS has been loaded before use (in my case I'm using [SystemJS](https://github.com/systemjs/systemjs)):

``` javascript
System.register(["immutable"], function(exports_1) {
    var Immutable;
    var x;
    return {
        setters:[
            function (Immutable_1) {
                Immutable = Immutable_1;
            }],
        execute: function() {
            x = Immutable.Seq([1, 2, 3]);
            console.log(x);
        }
    }
});
```
