### PR TITLE
Handle QualifiedNames

### DIFF
--- a/_src/src/DocVisitor.js
+++ b/_src/src/DocVisitor.js
@@ -325,9 +325,16 @@ class DocVisitor extends TypeScript.SyntaxWalker {
           };
         }
       case TypeScript.SyntaxKind.GenericType:
+        function getText(node) {
+          if (node.kind() === TypeScript.SyntaxKind.QualifiedName) {
+            return getText(node.left) + '.' + getText(node.right);
+          }
+          return node.text();
+        }
+
         var t = {
           k: TypeKind.Type,
-          name: node.name.text()
+          name: getText(node.name)
         };
         if (node.typeArgumentList) {
           t.args = node.typeArgumentList.typeArguments.map(


### PR DESCRIPTION
QualifiedName nodes don't have a `text()` method.

This change (or a similar one) is needed to generate the docs after #647. lmk if there's a better way to implement it!