### PR TITLE
Fix typo in comment describing List#forEach

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -121,7 +121,7 @@ declare module Immutable {
    *
    * Unlike a JavaScript Array, there is no distinction between an
    * "unset" index and an index set to `undefined`. `List#forEach` visits all
-   * indices from 0 to size, regardless of if they where explicitly defined.
+   * indices from 0 to size, regardless of if they were explicitly defined.
    */
   export module List {
 


### PR DESCRIPTION
Changes "regardless of if they WHERE explicitly defined," to "regardless of if they WERE explicitly defined."