### PR TITLE
Fix Record documentation.

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -1096,7 +1096,7 @@ declare module Immutable {
    * be ignored:
    *
    *     var myRecord = new ABRecord({b:3, x:10})
-   *     myRecord.get('x') // undefined
+   *     myRecord.get('y') // undefined
    *
    * Because Records have a known set of string keys, property get access works
    * as expected, however property sets will throw an Error.


### PR DESCRIPTION
The example showing how undefined values in a Record are ignored was incorrect, it was actually using a defined value.