### PR TITLE
Map is only called once

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -1161,7 +1161,7 @@ declare module Immutable {
    *
    * Once the Seq is used, it performs only the work necessary. In this
    * example, no intermediate data structures are ever created, filter is only
-   * called three times, and map is only called twice:
+   * called three times, and map is only called once:
    *
    *     console.log(evenSquares.get(1)); // 9
    *


### PR DESCRIPTION
If you put a console log into the mapper function i.e. 
```Immutable.Seq.of(1,2,3,4,5,6,7,8).filter(function(x){return x % 2}).map(function(x){console.log('mapper called'); return x * x});```
The mapper only console.logs once.

Similarly, inserting a console.log into the definition of the mappedSequence.get method in the definition of the mapFactory, only shows one invocation.

Docs for Seq should reflect the correct number of calls to map.

Currently it states that filter is called 3 times, and map is called twice.
Filter is called 3 times, but it appears map is only called once, on the single returned value from the .get call.

Screenshot of 3 filter calls and single console.log on map attached.

![screen shot 2015-12-13 at 5 58 52 pm](https://cloud.githubusercontent.com/assets/7946707/11771307/344ea45a-a1c3-11e5-9b79-3eaea658a7e9.png)
