### PR TITLE
Add explicit dependency on jest-cli, to keep npm3 happy

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "grunt-jest": "^0.1.0",
     "grunt-release": "^0.7.0",
     "jasmine-check": "^0.1.2",
+    "jest-cli": "^0.4.19",
     "magic-string": "^0.2.6",
     "microtime": "^1.2.0",
     "react-tools": "^0.11.1",


### PR DESCRIPTION
Without this, `jest-cli` is not installed when using `npm@3`, and you can't run the tests.