### PR TITLE
Removed Object.observe reference from readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ Much of what makes application development difficult is tracking mutation and
 maintaining state. Developing with immutable data encourages you to think
 differently about how data flows through your application.
 
-Subscribing to data events throughout your application, by using
-`Object.observe`, or any other mechanism, creates a huge overhead of
+Subscribing to data events throughout your application creates a huge overhead of
 book-keeping which can hurt performance, sometimes dramatically, and creates
 opportunities for areas of your application to get out of sync with each other
 due to easy to make programmer error. Since immutable data never changes,

--- a/dist/immutable.js
+++ b/dist/immutable.js
@@ -4748,9 +4748,6 @@
     lastIndexOf: function(searchValue) {
       var key = this.toKeyedSeq().reverse().keyOf(searchValue);
       return key === undefined ? -1 : key;
-
-      // var index =
-      // return this.toSeq().reverse().indexOf(searchValue);
     },
 
     reverse: function() {


### PR DESCRIPTION
Removed the reference to `Object.observe` from the readme. This method is set to be removed [1][2] and will not make for a clear reference. 

gh-pages branch should also be updated to reflect the same change to the `index.html` file, however I am unsure how pull requests work for the gh-pages branch. 

[1] https://esdiscuss.org/topic/an-update-on-object-observe
[2] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/observe