### PR TITLE
Ensure tests script fails if any tasks fail

### DIFF
--- a/resources/node_test.sh
+++ b/resources/node_test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# bail out if anything fails
+set -e
+
 # Run all tests using jest
 if [[ $TRAVIS ]]
 then jest -i # Travis tests are run inline


### PR DESCRIPTION
Without this, failing tests would not produce a non-zero exit code.