### PR TITLE
Update to use latest version of typescript

### DIFF
--- a/__tests__/zip.ts
+++ b/__tests__/zip.ts
@@ -58,7 +58,7 @@ describe('zip', () => {
     it('can zip to create immutable collections', () => {
       expect(
         I.Seq.of(1,2,3).zipWith(
-          () => I.List(arguments),
+          function () { return I.List(arguments); },
           I.Seq.of(4,5,6),
           I.Seq.of(7,8,9)
         ).toJS()

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "rollup": "0.24.0",
     "run-sequence": "1.1.5",
     "through2": "2.0.0",
-    "typescript": "~1.4.1",
+    "typescript": "1.7.5",
     "uglify-js": "2.6.1",
     "vinyl-buffer": "1.0.0",
     "vinyl-source-stream": "1.1.0"


### PR DESCRIPTION
This updates the jest preprocessor to work with the new typescript compiler, allowing us to support the newer typescript features like "this' return types.

The new typescript version found a legitimate error in a test file, which is also fixed in this rev