### PR TITLE
Use javascript import syntax in tests

### DIFF
--- a/__tests__/ArraySeq.ts
+++ b/__tests__/ArraySeq.ts
@@ -2,38 +2,38 @@
 ///<reference path='../dist/immutable.d.ts'/>
 jest.autoMockOff();
 
-import Immutable = require('immutable');
+import { Seq } from 'immutable';
 
 describe('ArraySequence', () => {
 
   it('every is true when predicate is true for all entries', () => {
-    expect(Immutable.Seq([]).every(() => false)).toBe(true);
-    expect(Immutable.Seq([1,2,3]).every(v => v > 0)).toBe(true);
-    expect(Immutable.Seq([1,2,3]).every(v => v < 3)).toBe(false);
+    expect(Seq([]).every(() => false)).toBe(true);
+    expect(Seq([1,2,3]).every(v => v > 0)).toBe(true);
+    expect(Seq([1,2,3]).every(v => v < 3)).toBe(false);
   });
 
   it('some is true when predicate is true for any entry', () => {
-    expect(Immutable.Seq([]).some(() => true)).toBe(false);
-    expect(Immutable.Seq([1,2,3]).some(v => v > 0)).toBe(true);
-    expect(Immutable.Seq([1,2,3]).some(v => v < 3)).toBe(true);
-    expect(Immutable.Seq([1,2,3]).some(v => v > 1)).toBe(true);
-    expect(Immutable.Seq([1,2,3]).some(v => v < 0)).toBe(false);
+    expect(Seq([]).some(() => true)).toBe(false);
+    expect(Seq([1,2,3]).some(v => v > 0)).toBe(true);
+    expect(Seq([1,2,3]).some(v => v < 3)).toBe(true);
+    expect(Seq([1,2,3]).some(v => v > 1)).toBe(true);
+    expect(Seq([1,2,3]).some(v => v < 0)).toBe(false);
   });
 
   it('maps', () => {
-    var i = Immutable.Seq([1,2,3]);
+    var i = Seq([1,2,3]);
     var m = i.map(x => x + x).toObject();
     expect(m).toEqual([2,4,6]);
   });
 
   it('reduces', () => {
-    var i = Immutable.Seq([1,2,3]);
+    var i = Seq([1,2,3]);
     var r = i.reduce<number>((r, x) => r + x);
     expect(r).toEqual(6);
   });
 
   it('efficiently chains iteration methods', () => {
-    var i = Immutable.Seq('abcdefghijklmnopqrstuvwxyz'.split(''));
+    var i = Seq('abcdefghijklmnopqrstuvwxyz'.split(''));
     function studly(letter, index) {
       return index % 2 === 0 ? letter : letter.toUpperCase();
     }
@@ -42,7 +42,7 @@ describe('ArraySequence', () => {
   });
 
   it('counts from the end of the sequence on negative index', () => {
-    var i = Immutable.Seq.of(1, 2, 3, 4, 5, 6, 7);
+    var i = Seq.of(1, 2, 3, 4, 5, 6, 7);
     expect(i.get(-1)).toBe(7);
     expect(i.get(-5)).toBe(3);
     expect(i.get(-9)).toBe(undefined);
@@ -52,7 +52,7 @@ describe('ArraySequence', () => {
   it('handles trailing holes', () => {
     var a = [1,2,3];
     a.length = 10;
-    var seq = Immutable.Seq(a);
+    var seq = Seq(a);
     expect(seq.size).toBe(10);
     expect(seq.toArray().length).toBe(10);
     expect(seq.map(x => x*x).size).toBe(10);
@@ -68,7 +68,7 @@ describe('ArraySequence', () => {
 
   it('can be iterated', () => {
     var a = [1,2,3];
-    var seq = Immutable.Seq(a);
+    var seq = Seq(a);
     var entries = seq.entries();
     expect(entries.next()).toEqual({ value: [0, 1], done: false });
     expect(entries.next()).toEqual({ value: [1, 2], done: false });
@@ -77,10 +77,10 @@ describe('ArraySequence', () => {
   });
 
   it('cannot be mutated after calling toArray', () => {
-    var seq = Immutable.Seq(['A', 'B', 'C']);
+    var seq = Seq(['A', 'B', 'C']);
 
-    var firstReverse = Immutable.Seq(seq.toArray().reverse());
-    var secondReverse = Immutable.Seq(seq.toArray().reverse());
+    var firstReverse = Seq(seq.toArray().reverse());
+    var secondReverse = Seq(seq.toArray().reverse());
 
     expect(firstReverse.get(0)).toEqual('C');
     expect(secondReverse.get(0)).toEqual('C');

--- a/__tests__/Conversion.ts
+++ b/__tests__/Conversion.ts
@@ -3,13 +3,10 @@
 
 jest.autoMockOff();
 
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import Immutable = require('immutable');
-import Map = Immutable.Map;
-import OrderedMap = Immutable.OrderedMap;
-import List = Immutable.List;
+import { Map, OrderedMap, List, Record, is, fromJS } from 'immutable';
 
 declare function expect(val: any): ExpectWithIs;
 
@@ -23,7 +20,7 @@ describe('Conversion', () => {
   beforeEach(function () {
     this.addMatchers({
       is: function(expected) {
-        return Immutable.is(this.actual, expected);
+        return is(this.actual, expected);
       }
     });
   });
@@ -51,7 +48,7 @@ describe('Conversion', () => {
     list: [1, 2, 3]
   };
 
-  var Point = Immutable.Record({x:0, y:0}, 'Point');
+  var Point = Record({x:0, y:0}, 'Point');
 
   var immutableData = Map({
     deepList: List.of(
@@ -123,11 +120,11 @@ describe('Conversion', () => {
   var nonStringKeyMapString = 'OrderedMap { 1: true, false: "foo" }';
 
   it('Converts deep JS to deep immutable sequences', () => {
-    expect(Immutable.fromJS(js)).is(immutableData);
+    expect(fromJS(js)).is(immutableData);
   });
 
   it('Converts deep JSON with custom conversion', () => {
-    var seq = Immutable.fromJS(js, function (key, sequence) {
+    var seq = fromJS(js, function (key, sequence) {
       if (key === 'point') {
         return new Point(sequence);
       }
@@ -152,25 +149,25 @@ describe('Conversion', () => {
   });
 
   it('JSON.stringify() respects toJSON methods on values', () => {
-    var Model = Immutable.Record({});
+    var Model = Record({});
     Model.prototype.toJSON = function() { return 'model'; }
     expect(
-      Immutable.Map({ a: new Model() }).toJS()
+      Map({ a: new Model() }).toJS()
     ).toEqual({ "a": {} });
     expect(
-      JSON.stringify(Immutable.Map({ a: new Model() }))
+      JSON.stringify(Map({ a: new Model() }))
     ).toEqual('{"a":"model"}');
   });
 
   it('is conservative with array-likes, only accepting true Arrays.', () => {
-    expect(Immutable.fromJS({1: 2, length: 3})).is(
-      Immutable.Map().set('1', 2).set('length', 3)
+    expect(fromJS({1: 2, length: 3})).is(
+      Map().set('1', 2).set('length', 3)
     );
-    expect(Immutable.fromJS('string')).toEqual('string');
+    expect(fromJS('string')).toEqual('string');
   });
 
   check.it('toJS isomorphic value', {maxSize: 30}, [gen.JSONValue], (js) => {
-    var imm = Immutable.fromJS(js);
+    var imm = fromJS(js);
     expect(imm && imm.toJS ? imm.toJS() : imm).toEqual(js);
   });
 

--- a/__tests__/Equality.ts
+++ b/__tests__/Equality.ts
@@ -3,24 +3,24 @@
 
 jest.autoMockOff();
 
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import Immutable = require('immutable');
+import { List, Map, Set, Seq, is } from 'immutable';
 
 describe('Equality', () => {
 
   function expectIs(left, right) {
-    var comparison = Immutable.is(left, right);
+    var comparison = is(left, right);
     expect(comparison).toBe(true);
-    var commutative = Immutable.is(right, left);
+    var commutative = is(right, left);
     expect(commutative).toBe(true);
   }
 
   function expectIsNot(left, right) {
-    var comparison = Immutable.is(left, right);
+    var comparison = is(left, right);
     expect(comparison).toBe(false);
-    var commutative = Immutable.is(right, left);
+    var commutative = is(right, left);
     expect(commutative).toBe(false);
   }
 
@@ -38,7 +38,7 @@ describe('Equality', () => {
     expectIs(NaN, NaN);
     expectIs(0, 0);
     expectIs(-0, -0);
-    // Note: Unlike Object.is, Immutable.is assumes 0 and -0 are the same value,
+    // Note: Unlike Object.is, is assumes 0 and -0 are the same value,
     // matching the behavior of ES6 Map key equality.
     expectIs(0, -0);
     expectIs(NaN, 0/0);
@@ -88,12 +88,12 @@ describe('Equality', () => {
   });
 
   it('compares sequences', () => {
-    var arraySeq = Immutable.Seq.of(1,2,3);
-    var arraySeq2 = Immutable.Seq([1,2,3]);
+    var arraySeq = Seq.of(1,2,3);
+    var arraySeq2 = Seq([1,2,3]);
     expectIs(arraySeq, arraySeq);
-    expectIs(arraySeq, Immutable.Seq.of(1,2,3));
+    expectIs(arraySeq, Seq.of(1,2,3));
     expectIs(arraySeq2, arraySeq2);
-    expectIs(arraySeq2, Immutable.Seq([1,2,3]));
+    expectIs(arraySeq2, Seq([1,2,3]));
     expectIsNot(arraySeq, [1,2,3]);
     expectIsNot(arraySeq2, [1,2,3]);
     expectIs(arraySeq, arraySeq2);
@@ -102,12 +102,12 @@ describe('Equality', () => {
   });
 
   it('compares lists', () => {
-    var list = Immutable.List.of(1,2,3);
+    var list = List.of(1,2,3);
     expectIs(list, list);
     expectIsNot(list, [1,2,3]);
 
-    expectIs(list, Immutable.Seq.of(1,2,3));
-    expectIs(list, Immutable.List.of(1,2,3));
+    expectIs(list, Seq.of(1,2,3));
+    expectIs(list, List.of(1,2,3));
 
     var listLonger = list.push(4);
     expectIsNot(list, listLonger);
@@ -119,17 +119,17 @@ describe('Equality', () => {
   var genSimpleVal = gen.returnOneOf(['A', 1]);
 
   var genVal = gen.oneOf([
-    gen.map(Immutable.List, gen.array(genSimpleVal, 0, 4)),
-    gen.map(Immutable.Set, gen.array(genSimpleVal, 0, 4)),
-    gen.map(Immutable.Map, gen.array(gen.array(genSimpleVal, 2), 0, 4))
+    gen.map(List, gen.array(genSimpleVal, 0, 4)),
+    gen.map(Set, gen.array(genSimpleVal, 0, 4)),
+    gen.map(Map, gen.array(gen.array(genSimpleVal, 2), 0, 4))
   ]);
 
   check.it('has symmetric equality', {times: 1000}, [genVal, genVal], (a, b) => {
-    expect(Immutable.is(a, b)).toBe(Immutable.is(b, a));
+    expect(is(a, b)).toBe(is(b, a));
   });
 
   check.it('has hash equality', {times: 1000}, [genVal, genVal], (a, b) => {
-    if (Immutable.is(a, b)) {
+    if (is(a, b)) {
       expect(a.hashCode()).toBe(b.hashCode());
     }
   });
@@ -138,9 +138,9 @@ describe('Equality', () => {
 
     it('differentiates decimals', () => {
       expect(
-        Immutable.Seq.of(1.5).hashCode()
+        Seq.of(1.5).hashCode()
       ).not.toBe(
-        Immutable.Seq.of(1.6).hashCode()
+        Seq.of(1.6).hashCode()
       );
     });
 

--- a/__tests__/IndexedSeq.ts
+++ b/__tests__/IndexedSeq.ts
@@ -2,15 +2,15 @@
 ///<reference path='../dist/immutable.d.ts'/>
 jest.autoMockOff();
 
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import Immutable = require('immutable');
+import { Seq } from 'immutable';
 
 describe('IndexedSequence', () => {
 
   it('maintains skipped offset', () => {
-    var seq = Immutable.Seq(['A', 'B', 'C', 'D', 'E']);
+    var seq = Seq(['A', 'B', 'C', 'D', 'E']);
 
     // This is what we expect for IndexedSequences
     var operated = seq.skip(1);
@@ -25,7 +25,7 @@ describe('IndexedSequence', () => {
   });
 
   it('reverses correctly', () => {
-    var seq = Immutable.Seq(['A', 'B', 'C', 'D', 'E']);
+    var seq = Seq(['A', 'B', 'C', 'D', 'E']);
 
     // This is what we expect for IndexedSequences
     var operated = seq.reverse();

--- a/__tests__/IterableSeq.ts
+++ b/__tests__/IterableSeq.ts
@@ -3,20 +3,19 @@
 declare var Symbol: any;
 jest.autoMockOff();
 
-import Immutable = require('immutable');
-
+import { Seq } from 'immutable';
 
 describe('IterableSequence', () => {
 
   it('creates a sequence from an iterable', () => {
     var i = new SimpleIterable();
-    var s = Immutable.Seq(i);
+    var s = Seq(i);
     expect(s.take(5).toArray()).toEqual([ 0,1,2,3,4 ]);
   })
 
   it('is stable', () => {
     var i = new SimpleIterable();
-    var s = Immutable.Seq(i);
+    var s = Seq(i);
     expect(s.take(5).toArray()).toEqual([ 0,1,2,3,4 ]);
     expect(s.take(5).toArray()).toEqual([ 0,1,2,3,4 ]);
     expect(s.take(5).toArray()).toEqual([ 0,1,2,3,4 ]);
@@ -24,7 +23,7 @@ describe('IterableSequence', () => {
 
   it('counts iterations', () => {
     var i = new SimpleIterable(10);
-    var s = Immutable.Seq(i);
+    var s = Seq(i);
     expect(s.forEach(x => x)).toEqual(10);
     expect(s.take(5).forEach(x => x)).toEqual(5);
     expect(s.forEach(x => x < 3)).toEqual(4);
@@ -33,7 +32,7 @@ describe('IterableSequence', () => {
   it('creates a new iterator on every operations', () => {
     var mockFn = jest.genMockFunction();
     var i = new SimpleIterable(3, mockFn);
-    var s = Immutable.Seq(i);
+    var s = Seq(i);
     expect(s.toArray()).toEqual([ 0,1,2 ]);
     expect(mockFn.mock.calls).toEqual([[0],[1],[2]]);
     // The iterator is recreated for the second time.
@@ -44,7 +43,7 @@ describe('IterableSequence', () => {
   it('can be iterated', () => {
     var mockFn = jest.genMockFunction();
     var i = new SimpleIterable(3, mockFn);
-    var seq = Immutable.Seq(i);
+    var seq = Seq(i);
     var entries = seq.entries();
     expect(entries.next()).toEqual({ value: [0, 0], done: false });
     // The iteration is lazy
@@ -65,7 +64,7 @@ describe('IterableSequence', () => {
   it('can be mapped and filtered', () => {
     var mockFn = jest.genMockFunction();
     var i = new SimpleIterable(undefined, mockFn); // infinite
-    var seq = Immutable.Seq<number, number>(i)
+    var seq = Seq<number, number>(i)
       .filter(x => x % 2 === 1)
       .map(x => x * x);
     var entries = seq.entries();
@@ -79,13 +78,13 @@ describe('IterableSequence', () => {
 
     it('creates a sequence from a raw iterable', () => {
       var i = new SimpleIterable(10);
-      var s = Immutable.Seq(i[ITERATOR_SYMBOL]());
+      var s = Seq(i[ITERATOR_SYMBOL]());
       expect(s.take(5).toArray()).toEqual([ 0,1,2,3,4 ]);
     })
 
     it('is stable', () => {
       var i = new SimpleIterable(10);
-      var s = Immutable.Seq(i[ITERATOR_SYMBOL]());
+      var s = Seq(i[ITERATOR_SYMBOL]());
       expect(s.take(5).toArray()).toEqual([ 0,1,2,3,4 ]);
       expect(s.take(5).toArray()).toEqual([ 0,1,2,3,4 ]);
       expect(s.take(5).toArray()).toEqual([ 0,1,2,3,4 ]);
@@ -93,7 +92,7 @@ describe('IterableSequence', () => {
 
     it('counts iterations', () => {
       var i = new SimpleIterable(10);
-      var s = Immutable.Seq(i[ITERATOR_SYMBOL]());
+      var s = Seq(i[ITERATOR_SYMBOL]());
       expect(s.forEach(x => x)).toEqual(10);
       expect(s.take(5).forEach(x => x)).toEqual(5);
       expect(s.forEach(x => x < 3)).toEqual(4);
@@ -102,7 +101,7 @@ describe('IterableSequence', () => {
     it('memoizes the iterator', () => {
       var mockFn = jest.genMockFunction();
       var i = new SimpleIterable(10, mockFn);
-      var s = Immutable.Seq(i[ITERATOR_SYMBOL]());
+      var s = Seq(i[ITERATOR_SYMBOL]());
       expect(s.take(3).toArray()).toEqual([ 0,1,2 ]);
       expect(mockFn.mock.calls).toEqual([[0],[1],[2]]);
 
@@ -118,7 +117,7 @@ describe('IterableSequence', () => {
     it('can be iterated', () => {
       var mockFn = jest.genMockFunction();
       var i = new SimpleIterable(3, mockFn);
-      var seq = Immutable.Seq(i[ITERATOR_SYMBOL]());
+      var seq = Seq(i[ITERATOR_SYMBOL]());
       var entries = seq.entries();
       expect(entries.next()).toEqual({ value: [0, 0], done: false });
       // The iteration is lazy
@@ -138,7 +137,7 @@ describe('IterableSequence', () => {
 
     it('can iterate an skipped seq based on an iterator', () => {
       var i = new SimpleIterable(4);
-      var seq = Immutable.Seq(i[ITERATOR_SYMBOL]());
+      var seq = Seq(i[ITERATOR_SYMBOL]());
       expect(seq.size).toBe(undefined);
       var skipped = seq.skip(2);
       expect(skipped.size).toBe(undefined);

--- a/__tests__/KeyedSeq.ts
+++ b/__tests__/KeyedSeq.ts
@@ -2,15 +2,15 @@
 ///<reference path='../dist/immutable.d.ts'/>
 jest.autoMockOff();
 
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import Immutable = require('immutable');
+import { Seq, Range } from 'immutable';
 
 describe('KeyedSeq', () => {
 
   check.it('it iterates equivalently', [gen.array(gen.int)], (ints) => {
-    var seq = Immutable.Seq(ints);
+    var seq = Seq(ints);
     var keyed = seq.toKeyedSeq();
 
     var seqEntries = seq.entries();
@@ -26,7 +26,7 @@ describe('KeyedSeq', () => {
 
   it('maintains keys', () => {
     var isEven = x => x % 2 === 0;
-    var seq = Immutable.Range(0, 100);
+    var seq = Range(0, 100);
 
     // This is what we expect for IndexedSequences
     var operated = seq.filter(isEven).skip(10).take(5);
@@ -51,7 +51,7 @@ describe('KeyedSeq', () => {
   });
 
   it('works with reverse', () => {
-    var seq = Immutable.Range(0, 100);
+    var seq = Range(0, 100);
 
     // This is what we expect for IndexedSequences
     expect(seq.reverse().take(5).entrySeq().toArray()).toEqual([
@@ -73,7 +73,7 @@ describe('KeyedSeq', () => {
   });
 
   it('works with double reverse', () => {
-    var seq = Immutable.Range(0, 100);
+    var seq = Range(0, 100);
 
     // This is what we expect for IndexedSequences
     expect(seq.reverse().skip(10).take(5).reverse().entrySeq().toArray()).toEqual([

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -3,11 +3,10 @@
 
 jest.autoMockOff();
 
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import Immutable = require('immutable');
-import List = Immutable.List;
+import { List, Range, Seq, Set, fromJS } from 'immutable';
 
 function arrayOfSize(s) {
   var a = new Array(s);
@@ -33,7 +32,7 @@ describe('List', () => {
 
   it('does not accept a scalar', () => {
     expect(() => {
-      Immutable.List(3);
+      List(3);
     }).toThrow('Expected Array or iterable object of values: 3');
   });
 
@@ -56,13 +55,13 @@ describe('List', () => {
   });
 
   it('accepts an indexed Seq', () => {
-    var seq = Immutable.Seq(['a', 'b', 'c']);
+    var seq = Seq(['a', 'b', 'c']);
     var v = List(seq);
     expect(v.toArray()).toEqual(['a', 'b', 'c']);
   });
 
   it('accepts a keyed Seq as a list of entries', () => {
-    var seq = Immutable.Seq({a:null, b:null, c:null}).flip();
+    var seq = Seq({a:null, b:null, c:null}).flip();
     var v = List(seq);
     expect(v.toArray()).toEqual([[null,'a'], [null,'b'], [null,'c']]);
     // Explicitly getting the values sequence
@@ -81,15 +80,15 @@ describe('List', () => {
   });
 
   it('returns undefined when getting a null value', () => {
-    var v = Immutable.List([1, 2, 3]);
+    var v = List([1, 2, 3]);
     expect(v.get(null)).toBe(undefined);
 
-    var o = Immutable.List([{ a: 1 },{ b: 2 }, { c: 3 }]);
+    var o = List([{ a: 1 },{ b: 2 }, { c: 3 }]);
     expect(o.get(null)).toBe(undefined);
   });
 
   it('counts from the end of the list on negative index', () => {
-    var i = Immutable.List.of(1, 2, 3, 4, 5, 6, 7);
+    var i = List.of(1, 2, 3, 4, 5, 6, 7);
     expect(i.get(-1)).toBe(7);
     expect(i.get(-5)).toBe(3);
     expect(i.get(-9)).toBe(undefined);
@@ -98,7 +97,7 @@ describe('List', () => {
 
   it('coerces numeric-string keys', () => {
     // Of course, TypeScript protects us from this, so cast to "any" to test.
-    var i: any = Immutable.List.of(1, 2, 3, 4, 5, 6);
+    var i: any = List.of(1, 2, 3, 4, 5, 6);
     expect(i.get('1')).toBe(2);
     expect(i.set('3', 10).get('3')).toBe(10);
     // Like array, string negative numbers do not qualify
@@ -108,37 +107,37 @@ describe('List', () => {
   });
 
   it('uses not set value for string index', () => {
-    var list: any = Immutable.List();
+    var list: any = List();
     expect(list.get('stringKey', 'NOT-SET')).toBe('NOT-SET');
   });
 
   it('uses not set value for index {}', () => {
-    var list: any = Immutable.List.of(1, 2, 3, 4, 5);
+    var list: any = List.of(1, 2, 3, 4, 5);
     expect(list.get({}, 'NOT-SET')).toBe('NOT-SET');
   });
 
   it('uses not set value for index void 0', () => {
-    var list: any = Immutable.List.of(1, 2, 3, 4, 5);
+    var list: any = List.of(1, 2, 3, 4, 5);
     expect(list.get(void 0, 'NOT-SET')).toBe('NOT-SET');
   });
 
   it('uses not set value for index undefined', () => {
-    var list: any = Immutable.List.of(1, 2, 3, 4, 5);
+    var list: any = List.of(1, 2, 3, 4, 5);
     expect(list.get(undefined, 'NOT-SET')).toBe('NOT-SET');
   });
 
   it('doesnt coerce empty strings to index 0', () => {
-    var list: any = Immutable.List.of(1, 2, 3);
+    var list: any = List.of(1, 2, 3);
     expect(list.has('')).toBe(false);
   });
 
   it('doesnt contain elements at non-empty string keys', () => {
-    var list: any = Immutable.List.of(1, 2, 3, 4, 5);
+    var list: any = List.of(1, 2, 3, 4, 5);
     expect(list.has('str')).toBe(false);
   });
 
   it('hasIn doesnt contain elements at non-empty string keys', () => {
-    var list: any = Immutable.List.of(1, 2, 3, 4, 5);
+    var list: any = List.of(1, 2, 3, 4, 5);
     expect(list.hasIn(('str'))).toBe(false);
   });
 
@@ -205,7 +204,7 @@ describe('List', () => {
   });
 
   it('can contain a large number of indices', () => {
-    var v = Immutable.Range(0,20000).toList();
+    var v = Range(0,20000).toList();
     var iterations = 0;
     v.forEach(v => {
       expect(v).toBe(iterations);
@@ -514,7 +513,7 @@ describe('List', () => {
 
   it('concat works like Array.prototype.concat', () => {
     var v1 = List.of(1, 2, 3);
-    var v2 = v1.concat(4, List.of(5, 6), [7, 8], Immutable.Seq({a:9,b:10}), Immutable.Set.of(11,12), null);
+    var v2 = v1.concat(4, List.of(5, 6), [7, 8], Seq({a:9,b:10}), Set.of(11,12), null);
     expect(v1.toArray()).toEqual([1, 2, 3]);
     expect(v2.toArray()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, null]);
   });
@@ -544,7 +543,7 @@ describe('List', () => {
   });
 
   it('allows size to be set', () => {
-    var v1 = Immutable.Range(0,2000).toList();
+    var v1 = Range(0,2000).toList();
     var v2 = v1.setSize(1000);
     var v3 = v2.setSize(1500);
     expect(v1.size).toBe(2000);
@@ -563,7 +562,7 @@ describe('List', () => {
 
   it('discards truncated elements when using slice', () => {
     var list = [1,2,3,4,5,6];
-    var v1 = Immutable.fromJS(list);
+    var v1 = fromJS(list);
     var v2 = v1.slice(0,3);
     var v3 = v2.setSize(6);
 
@@ -575,7 +574,7 @@ describe('List', () => {
 
   it('discards truncated elements when using setSize', () => {
     var list = [1,2,3,4,5,6];
-    var v1 = Immutable.fromJS(list);
+    var v1 = fromJS(list);
     var v2 = v1.setSize(3);
     var v3 = v2.setSize(6);
 
@@ -586,7 +585,7 @@ describe('List', () => {
   });
 
   it('can be efficiently sliced', () => {
-    var v1 = Immutable.Range(0,2000).toList();
+    var v1 = Range(0,2000).toList();
     var v2 = v1.slice(100,-100).toList();
     var v3 = v2.slice(0, Infinity);
     expect(v1.size).toBe(2000)
@@ -650,7 +649,7 @@ describe('List', () => {
     var pInt = gen.posInt;
 
     check.it('iterates through List', [pInt, pInt], (start, len) => {
-      var l = Immutable.Range(0, start + len).toList();
+      var l = Range(0, start + len).toList();
       l = <List<number>> l.slice(start, start + len);
       expect(l.size).toBe(len);
       var valueIter = l.values();
@@ -664,7 +663,7 @@ describe('List', () => {
     });
 
     check.it('iterates through List in reverse', [pInt, pInt], (start, len) => {
-      var l = Immutable.Range(0, start + len).toList();
+      var l = Range(0, start + len).toList();
       l = <List<number>> l.slice(start, start + len);
       var s = l.toSeq().reverse(); // impl calls List.__iterator(REVERSE)
       expect(s.size).toBe(len);

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -3,11 +3,10 @@
 
 jest.autoMockOff();
 
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import Immutable = require('immutable');
-import Map = Immutable.Map;
+import { Map, Seq, List, Range, is } from 'immutable';
 
 describe('Map', () => {
 
@@ -36,7 +35,7 @@ describe('Map', () => {
   });
 
   it('constructor provides initial values as sequence', () => {
-    var s = Immutable.Seq({'a': 'A', 'b': 'B', 'c': 'C'});
+    var s = Seq({'a': 'A', 'b': 'B', 'c': 'C'});
     var m = Map(s);
     expect(m.size).toBe(3);
     expect(m.get('a')).toBe('A');
@@ -45,10 +44,10 @@ describe('Map', () => {
   });
 
   it('constructor provides initial values as list of lists', () => {
-    var l = Immutable.List([
-      Immutable.List(['a', 'A']),
-      Immutable.List(['b', 'B']),
-      Immutable.List(['c', 'C'])
+    var l = List([
+      List(['a', 'A']),
+      List(['b', 'B']),
+      List(['c', 'C'])
     ]);
     var m = Map(l);
     expect(m.size).toBe(3);
@@ -170,7 +169,7 @@ describe('Map', () => {
   });
 
   check.it('deletes down to empty map', [gen.posInt], size => {
-    var m = Immutable.Range(0, size).toMap();
+    var m = Range(0, size).toMap();
     expect(m.size).toBe(size);
     for (var ii = size - 1; ii >= 0; ii--) {
       m = m.remove(ii);
@@ -190,7 +189,7 @@ describe('Map', () => {
 
   it('can map items known to hash collide', () => {
     // make a big map, so it hashmaps
-    var m: Map<any, any> = Immutable.Range(0, 32).toMap();
+    var m: Map<any, any> = Range(0, 32).toMap();
     var m = m.set('AAA', 'letters').set(64545, 'numbers');
     expect(m.size).toBe(34);
     expect(m.get('AAA')).toEqual('letters');
@@ -199,7 +198,7 @@ describe('Map', () => {
 
   it('can progressively add items known to collide', () => {
     // make a big map, so it hashmaps
-    var map: Map<any, any> = Immutable.Range(0, 32).toMap();
+    var map: Map<any, any> = Range(0, 32).toMap();
     map = map.set('@', '@');
     map = map.set(64, 64);
     map = map.set(96, 96);
@@ -256,7 +255,7 @@ describe('Map', () => {
   });
 
   check.it('works like an object', {maxSize: 50}, [gen.object(gen.JSONPrimitive)], obj => {
-    var map = Immutable.Map(obj);
+    var map = Map(obj);
     Object.keys(obj).forEach(key => {
       expect(map.get(key)).toBe(obj[key]);
       expect(map.has(key)).toBe(true);
@@ -271,17 +270,17 @@ describe('Map', () => {
   });
 
   check.it('sets', {maxSize: 5000}, [gen.posInt], len => {
-    var map = Immutable.Map();
+    var map = Map();
     for (var ii = 0; ii < len; ii++) {
       expect(map.size).toBe(ii);
       map = map.set(''+ii, ii);
     }
     expect(map.size).toBe(len);
-    expect(Immutable.is(map.toSet(), Immutable.Range(0, len).toSet())).toBe(true);
+    expect(is(map.toSet(), Range(0, len).toSet())).toBe(true);
   });
 
   check.it('has and get', {maxSize: 5000}, [gen.posInt], len => {
-    var map = Immutable.Range(0, len).toKeyedSeq().mapKeys(x => ''+x).toMap();
+    var map = Range(0, len).toKeyedSeq().mapKeys(x => ''+x).toMap();
     for (var ii = 0; ii < len; ii++) {
       expect(map.get(''+ii)).toBe(ii);
       expect(map.has(''+ii)).toBe(true);
@@ -289,7 +288,7 @@ describe('Map', () => {
   });
 
   check.it('deletes', {maxSize: 5000}, [gen.posInt], len => {
-    var map = Immutable.Range(0, len).toMap();
+    var map = Range(0, len).toMap();
     for (var ii = 0; ii < len; ii++) {
       expect(map.size).toBe(len - ii);
       map = map.remove(ii);
@@ -299,7 +298,7 @@ describe('Map', () => {
   });
 
   check.it('deletes from transient', {maxSize: 5000}, [gen.posInt], len => {
-    var map = Immutable.Range(0, len).toMap().asMutable();
+    var map = Range(0, len).toMap().asMutable();
     for (var ii = 0; ii < len; ii++) {
       expect(map.size).toBe(len - ii);
       map.remove(ii);
@@ -309,7 +308,7 @@ describe('Map', () => {
   });
 
   check.it('iterates through all entries', [gen.posInt], len => {
-    var v = Immutable.Range(0, len).toMap();
+    var v = Range(0, len).toMap();
     var a = v.toArray();
     var iter = v.entries();
     for (var ii = 0; ii < len; ii++) {
@@ -333,7 +332,7 @@ describe('Map', () => {
   it('expresses value equality with unordered sequences', () => {
     var m1 = Map({ A: 1, B: 2, C: 3 });
     var m2 = Map({ C: 3, B: 2, A: 1 });
-    expect(Immutable.is(m1, m2)).toBe(true);
+    expect(is(m1, m2)).toBe(true);
   });
 
 });

--- a/__tests__/ObjectSeq.ts
+++ b/__tests__/ObjectSeq.ts
@@ -3,43 +3,43 @@
 
 jest.autoMockOff();
 
-import Immutable = require('immutable');
+import { Seq } from 'immutable';
 
 describe('ObjectSequence', () => {
 
   it('maps', () => {
-    var i = Immutable.Seq({'a': 'A', 'b': 'B', 'c': 'C'});
+    var i = Seq({'a': 'A', 'b': 'B', 'c': 'C'});
     var m = i.map(x => x + x).toObject();
     expect(m).toEqual({'a': 'AA', 'b': 'BB', 'c': 'CC'});
   });
 
   it('reduces', () => {
-    var i = Immutable.Seq({'a': 'A', 'b': 'B', 'c': 'C'});
+    var i = Seq({'a': 'A', 'b': 'B', 'c': 'C'});
     var r = i.reduce<string>((r, x) => r + x, '');
     expect(r).toEqual('ABC');
   });
 
   it('extracts keys', () => {
-    var i = Immutable.Seq({'a': 'A', 'b': 'B', 'c': 'C'});
+    var i = Seq({'a': 'A', 'b': 'B', 'c': 'C'});
     var k = i.keySeq().toArray();
     expect(k).toEqual(['a', 'b', 'c']);
   });
 
   it('is reversable', () => {
-    var i = Immutable.Seq({'a': 'A', 'b': 'B', 'c': 'C'});
+    var i = Seq({'a': 'A', 'b': 'B', 'c': 'C'});
     var k = i.reverse().toArray();
     expect(k).toEqual(['C', 'B', 'A']);
   });
 
   it('can double reversable', () => {
-    var i = Immutable.Seq({'a': 'A', 'b': 'B', 'c': 'C'});
+    var i = Seq({'a': 'A', 'b': 'B', 'c': 'C'});
     var k = i.reverse().reverse().toArray();
     expect(k).toEqual(['A', 'B', 'C']);
   });
 
   it('can be iterated', () => {
     var obj = { a: 1, b: 2, c: 3 };
-    var seq = Immutable.Seq(obj);
+    var seq = Seq(obj);
     var entries = seq.entries();
     expect(entries.next()).toEqual({ value: ['a', 1], done: false });
     expect(entries.next()).toEqual({ value: ['b', 2], done: false });
@@ -48,11 +48,11 @@ describe('ObjectSequence', () => {
   });
 
   it('cannot be mutated after calling toObject', () => {
-    var seq = Immutable.Seq({ a: 1, b: 2, c: 3 });
+    var seq = Seq({ a: 1, b: 2, c: 3 });
 
     var obj = seq.toObject();
     obj['c'] = 10;
-    var seq2 = Immutable.Seq(obj);
+    var seq2 = Seq(obj);
 
     expect(seq.get('c')).toEqual(3);
     expect(seq2.get('c')).toEqual(10);

--- a/__tests__/OrderedMap.ts
+++ b/__tests__/OrderedMap.ts
@@ -3,8 +3,7 @@
 
 jest.autoMockOff();
 
-import Immutable = require('immutable');
-import OrderedMap = Immutable.OrderedMap;
+import { OrderedMap, Seq } from 'immutable';
 
 describe('OrderedMap', () => {
 
@@ -35,7 +34,7 @@ describe('OrderedMap', () => {
   });
 
   it('constructor accepts sequences', () => {
-    var s = Immutable.Seq({'c': 'C', 'b': 'B', 'a': 'A'});
+    var s = Seq({'c': 'C', 'b': 'B', 'a': 'A'});
     var m = OrderedMap(s);
     expect(m.get('a')).toBe('A');
     expect(m.get('b')).toBe('B');

--- a/__tests__/OrderedSet.ts
+++ b/__tests__/OrderedSet.ts
@@ -3,8 +3,7 @@
 
 jest.autoMockOff();
 
-import Immutable = require('immutable');
-import OrderedSet = Immutable.OrderedSet;
+import { OrderedSet } from 'immutable';
 
 describe('OrderedSet', () => {
 

--- a/__tests__/Range.ts
+++ b/__tests__/Range.ts
@@ -3,11 +3,10 @@
 
 jest.autoMockOff();
 
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import Immutable = require('immutable');
-import Range = Immutable.Range;
+import { Range} from 'immutable';
 
 describe('Range', () => {
 

--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -3,8 +3,7 @@
 
 jest.autoMockOff();
 
-import Immutable = require('immutable');
-import Record = Immutable.Record;
+import { Record, Seq } from 'immutable';
 
 describe('Record', () => {
 
@@ -73,21 +72,21 @@ describe('Record', () => {
 
   it('converts sequences to records', () => {
     var MyType = Record({a:1, b:2, c:3});
-    var seq = Immutable.Seq({a: 10, b:20});
+    var seq = Seq({a: 10, b:20});
     var t = new MyType(seq);
     expect(t.toObject()).toEqual({a:10, b:20, c:3})
   })
 
   it('allows for functional construction', () => {
     var MyType = Record({a:1, b:2, c:3});
-    var seq = Immutable.Seq({a: 10, b:20});
+    var seq = Seq({a: 10, b:20});
     var t = MyType(seq);
     expect(t.toObject()).toEqual({a:10, b:20, c:3})
   })
 
   it('skips unknown keys', () => {
     var MyType = Record({a:1, b:2});
-    var seq = Immutable.Seq({b:20, c:30});
+    var seq = Seq({b:20, c:30});
     var t = new MyType(seq);
 
     expect(t.get('a')).toEqual(1);

--- a/__tests__/Repeat.ts
+++ b/__tests__/Repeat.ts
@@ -3,8 +3,7 @@
 
 jest.autoMockOff();
 
-import Immutable = require('immutable');
-import Repeat = Immutable.Repeat;
+import { Repeat } from 'immutable';
 
 describe('Repeat', () => {
 

--- a/__tests__/Seq.ts
+++ b/__tests__/Seq.ts
@@ -3,24 +3,24 @@
 
 jest.autoMockOff();
 
-import Immutable = require('immutable');
+import { Iterable, Seq } from 'immutable';
 
 describe('Seq', () => {
 
   it('can be empty', () => {
-    expect(Immutable.Seq().size).toBe(0);
+    expect(Seq().size).toBe(0);
   });
 
   it('accepts an array', () => {
-    expect(Immutable.Seq([1,2,3]).size).toBe(3);
+    expect(Seq([1,2,3]).size).toBe(3);
   });
 
   it('accepts an object', () => {
-    expect(Immutable.Seq({a:1,b:2,c:3}).size).toBe(3);
+    expect(Seq({a:1,b:2,c:3}).size).toBe(3);
   });
 
   it('accepts an iterable string', () => {
-    expect(Immutable.Seq('foo').size).toBe(3);
+    expect(Seq('foo').size).toBe(3);
   });
 
   it('accepts arbitrary objects', () => {
@@ -28,20 +28,20 @@ describe('Seq', () => {
       this.bar = 'bar';
       this.baz = 'baz';
     }
-    expect(Immutable.Seq(new Foo()).size).toBe(2);
+    expect(Seq(new Foo()).size).toBe(2);
   });
 
   it('of accepts varargs', () => {
-    expect(Immutable.Seq.of(1,2,3).size).toBe(3);
+    expect(Seq.of(1,2,3).size).toBe(3);
   });
 
   it('accepts another sequence', () => {
-    var seq = Immutable.Seq.of(1,2,3);
-    expect(Immutable.Seq(seq).size).toBe(3);
+    var seq = Seq.of(1,2,3);
+    expect(Seq(seq).size).toBe(3);
   });
 
   it('accepts a string', () => {
-    var seq = Immutable.Seq('abc');
+    var seq = Seq('abc');
     expect(seq.size).toBe(3);
     expect(seq.get(1)).toBe('b');
     expect(seq.join('')).toBe('abc');
@@ -49,22 +49,22 @@ describe('Seq', () => {
 
   it('accepts an array-like', () => {
     var alike = { length: 2, 0: 'a', 1: 'b' };
-    var seq = Immutable.Seq(alike);
-    expect(Immutable.Iterable.isIndexed(seq)).toBe(true);
+    var seq = Seq(alike);
+    expect(Iterable.isIndexed(seq)).toBe(true);
     expect(seq.size).toBe(2);
     expect(seq.get(1)).toBe('b');
   });
 
   it('does not accept a scalar', () => {
     expect(() => {
-      Immutable.Seq(3);
+      Seq(3);
     }).toThrow('Expected Array or iterable object of values, or keyed object: 3');
   });
 
   it('temporarily warns about iterable length', function () {
     this.spyOn(console, 'warn');
 
-    var seq = Immutable.Seq.of(1,2,3);
+    var seq = Seq.of(1,2,3);
 
     // Note: `length` has been removed from the type definitions.
     var length = (<any>seq).length;
@@ -79,26 +79,26 @@ describe('Seq', () => {
   });
 
   it('detects sequences', () => {
-    var seq = Immutable.Seq.of(1,2,3);
-    expect(Immutable.Seq.isSeq(seq)).toBe(true);
-    expect(Immutable.Iterable.isIterable(seq)).toBe(true);
+    var seq = Seq.of(1,2,3);
+    expect(Seq.isSeq(seq)).toBe(true);
+    expect(Iterable.isIterable(seq)).toBe(true);
   });
 
   it('Does not infinite loop when sliced with NaN', () => {
-    var list = Immutable.Seq([1, 2, 3, 4, 5]);
+    var list = Seq([1, 2, 3, 4, 5]);
     expect(list.slice(0, NaN).toJS()).toEqual([]);
     expect(list.slice(NaN).toJS()).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('Does not infinite loop when spliced with negative number #559', () => {
-    var dog = Immutable.Seq(['d', 'o', 'g']);
+    var dog = Seq(['d', 'o', 'g']);
     var dg = dog.filter(c => c !== 'o');
     var dig = (<any>dg).splice(-1, 0, 'i');
     expect(dig.toJS()).toEqual(['d', 'i', 'g']);
   });
 
   it('Does not infinite loop when an undefined number is passed to take', () => {
-    var list = Immutable.Seq([1, 2, 3, 4, 5]);
+    var list = Seq([1, 2, 3, 4, 5]);
     expect(list.take(NaN).toJS()).toEqual([]);
   });
 

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -3,8 +3,7 @@
 declare var Symbol: any;
 jest.autoMockOff();
 
-import Immutable = require('immutable');
-import Set = Immutable.Set;
+import { List, Map, OrderedSet, Seq, Set, is } from 'immutable';
 
 declare function expect(val: any): ExpectWithIs;
 
@@ -18,7 +17,7 @@ describe('Set', () => {
   beforeEach(function () {
     this.addMatchers({
       is: function(expected) {
-        return Immutable.is(this.actual, expected);
+        return is(this.actual, expected);
       }
     })
   })
@@ -49,7 +48,7 @@ describe('Set', () => {
   });
 
   it('accepts sequence of values', () => {
-    var seq = Immutable.Seq.of(1,2,3);
+    var seq = Seq.of(1,2,3);
     var s = Set(seq);
     expect(s.has(1)).toBe(true);
     expect(s.has(2)).toBe(true);
@@ -58,7 +57,7 @@ describe('Set', () => {
   });
 
   it('accepts a keyed Seq as a set of entries', () => {
-    var seq = Immutable.Seq({a:null, b:null, c:null}).flip();
+    var seq = Seq({a:null, b:null, c:null}).flip();
     var s = Set(seq);
     expect(s.toArray()).toEqual([[null,'a'], [null,'b'], [null,'c']]);
     // Explicitly getting the values sequence
@@ -78,7 +77,7 @@ describe('Set', () => {
   });
 
   it('accepts sequence keys', () => {
-    var seq = Immutable.Seq({a:null, b:null, c:null});
+    var seq = Seq({a:null, b:null, c:null});
     var s = Set.fromKeys(seq);
     expect(s.has('a')).toBe(true);
     expect(s.has('b')).toBe(true);
@@ -139,16 +138,16 @@ describe('Set', () => {
   it('unions a set and an iterable and returns a set', () => {
     var s1 = Set([1,2,3]);
     var emptySet = Set();
-    var l = Immutable.List([1,2,3]);
+    var l = List([1,2,3]);
     var s2 = s1.union(l);
     var s3 = emptySet.union(l);
-    var o = Immutable.OrderedSet([1,2,3]);
+    var o = OrderedSet([1,2,3]);
     var s4 = s1.union(o);
     var s5 = emptySet.union(o);
     expect(Set.isSet(s2)).toBe(true);
     expect(Set.isSet(s3)).toBe(true);
-    expect(Set.isSet(s4) && !Immutable.OrderedSet.isOrderedSet(s4)).toBe(true);
-    expect(Set.isSet(s5) && !Immutable.OrderedSet.isOrderedSet(s5)).toBe(true);
+    expect(Set.isSet(s4) && !OrderedSet.isOrderedSet(s4)).toBe(true);
+    expect(Set.isSet(s5) && !OrderedSet.isOrderedSet(s5)).toBe(true);
   });
 
   it('is persistent to adds', () => {
@@ -205,16 +204,16 @@ describe('Set', () => {
 
     var s2 = Set.of('C', 'B', 'A');
     expect(s1 === s2).toBe(false);
-    expect(Immutable.is(s1, s2)).toBe(true);
+    expect(is(s1, s2)).toBe(true);
     expect(s1.equals(s2)).toBe(true);
 
     // Map and Set are not the same (keyed vs unkeyed)
-    var v1 = Immutable.Map({ A: 'A', C: 'C', B: 'B' });
-    expect(Immutable.is(s1, v1)).toBe(false);
+    var v1 = Map({ A: 'A', C: 'C', B: 'B' });
+    expect(is(s1, v1)).toBe(false);
   });
 
   it('can use union in a withMutation', () => {
-    var js = Immutable.Set().withMutations(set => {
+    var js = Set().withMutations(set => {
       set.union([ 'a' ]);
       set.add('b');
     }).toJS();
@@ -242,7 +241,7 @@ describe('Set', () => {
       var b = Symbol();
       var c = Symbol();
 
-      var symbolSet = Immutable.Set([ a, b, c, a, b, c, a, b, c, a, b, c ]);
+      var symbolSet = Set([ a, b, c, a, b, c, a, b, c, a, b, c ]);
       expect(symbolSet.size).toBe(3);
       expect(symbolSet.has(b)).toBe(true);
       expect(symbolSet.get(c)).toEqual(c);
@@ -256,7 +255,7 @@ describe('Set', () => {
         Symbol('a'), Symbol('b'), Symbol('c'),
       ];
 
-      var symbolSet = Immutable.Set(manySymbols);
+      var symbolSet = Set(manySymbols);
       expect(symbolSet.size).toBe(12);
       expect(symbolSet.has(manySymbols[10])).toBe(true);
       expect(symbolSet.get(manySymbols[10])).toEqual(manySymbols[10]);

--- a/__tests__/Stack.ts
+++ b/__tests__/Stack.ts
@@ -3,11 +3,10 @@
 
 jest.autoMockOff();
 
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import Immutable = require('immutable');
-import Stack = Immutable.Stack;
+import { Seq, Stack } from 'immutable';
 
 function arrayOfSize(s) {
   var a = new Array(s);
@@ -37,13 +36,13 @@ describe('Stack', () => {
   });
 
   it('accepts a Seq', () => {
-    var seq = Immutable.Seq(['a', 'b', 'c']);
+    var seq = Seq(['a', 'b', 'c']);
     var s = Stack(seq);
     expect(s.toArray()).toEqual(['a', 'b', 'c']);
   });
 
   it('accepts a keyed Seq', () => {
-    var seq = Immutable.Seq({a:null, b:null, c:null}).flip();
+    var seq = Seq({a:null, b:null, c:null}).flip();
     var s = Stack(seq);
     expect(s.toArray()).toEqual([[null,'a'], [null,'b'], [null,'c']]);
     // Explicit values
@@ -84,14 +83,14 @@ describe('Stack', () => {
       [1,'b'],
       [2,'c'],
     ]);
-    
+
     // map will cause reverse iterate
     expect(s.map(val => val + val).toArray()).toEqual([
       'aa',
       'bb',
       'cc',
     ]);
-    
+
     var iteratorResults = [];
     var iterator = s.entries();
     var step;
@@ -103,7 +102,7 @@ describe('Stack', () => {
       [1,'b'],
       [2,'c'],
     ]);
-    
+
     iteratorResults = [];
     iterator = s.toSeq().reverse().entries();
     while (!(step = iterator.next()).done) {

--- a/__tests__/concat.ts
+++ b/__tests__/concat.ts
@@ -3,8 +3,7 @@
 
 jest.autoMockOff();
 
-import I = require('immutable');
-import Seq = I.Seq;
+import { Seq, Set, List, is } from 'immutable';
 
 declare function expect(val: any): ExpectWithIs;
 
@@ -18,7 +17,7 @@ describe('concat', () => {
   beforeEach(function () {
     this.addMatchers({
       is: function(expected) {
-        return I.is(this.actual, expected);
+        return is(this.actual, expected);
       }
     })
   })
@@ -106,11 +105,11 @@ describe('concat', () => {
   })
 
   it('always returns the same type', () => {
-    var a = I.Set.of(1,2,3);
-    var b = I.List();
+    var a = Set.of(1,2,3);
+    var b = List();
     expect(b.concat(a)).not.toBe(a);
-    expect(I.List.isList(b.concat(a))).toBe(true);
-    expect(b.concat(a)).is(I.List.of(1,2,3));
+    expect(List.isList(b.concat(a))).toBe(true);
+    expect(b.concat(a)).is(List.of(1,2,3));
   })
 
   it('iterates repeated keys', () => {
@@ -141,7 +140,7 @@ describe('concat', () => {
   })
 
   it('counts from the end of the indexed sequence on negative index', () => {
-    var i = I.List.of(9, 5, 3, 1).map(x => - x);
+    var i = List.of(9, 5, 3, 1).map(x => - x);
     expect(i.get(0)).toBe(-9);
     expect(i.get(-1)).toBe(-1);
     expect(i.get(-4)).toBe(-9);

--- a/__tests__/count.ts
+++ b/__tests__/count.ts
@@ -3,24 +3,24 @@
 
 jest.autoMockOff();
 
-import I = require('immutable');
+import { Seq, Range } from 'immutable';
 
 describe('count', () => {
 
   it('counts sequences with known lengths', () => {
-    expect(I.Seq.of(1,2,3,4,5).size).toBe(5);
-    expect(I.Seq.of(1,2,3,4,5).count()).toBe(5);
+    expect(Seq.of(1,2,3,4,5).size).toBe(5);
+    expect(Seq.of(1,2,3,4,5).count()).toBe(5);
   })
 
   it('counts sequences with unknown lengths, resulting in a cached size', () => {
-    var seq = I.Seq.of(1,2,3,4,5,6).filter(x => x % 2 === 0);
+    var seq = Seq.of(1,2,3,4,5,6).filter(x => x % 2 === 0);
     expect(seq.size).toBe(undefined);
     expect(seq.count()).toBe(3);
     expect(seq.size).toBe(3);
   })
 
   it('counts sequences with a specific predicate', () => {
-    var seq = I.Seq.of(1,2,3,4,5,6);
+    var seq = Seq.of(1,2,3,4,5,6);
     expect(seq.size).toBe(6);
     expect(seq.count(x => x > 3)).toBe(3);
   })
@@ -28,14 +28,14 @@ describe('count', () => {
   describe('countBy', () => {
 
     it('counts by keyed sequence', () => {
-      var grouped = I.Seq({a:1,b:2,c:3,d:4}).countBy(x => x % 2);
+      var grouped = Seq({a:1,b:2,c:3,d:4}).countBy(x => x % 2);
       expect(grouped.toJS()).toEqual({1:2, 0:2});
       expect(grouped.get(1)).toEqual(2);
     })
 
     it('counts by indexed sequence', () => {
       expect(
-        I.Seq.of(1,2,3,4,5,6).countBy(x => x % 2).toJS()
+        Seq.of(1,2,3,4,5,6).countBy(x => x % 2).toJS()
       ).toEqual(
         {1:3, 0:3}
       );
@@ -43,7 +43,7 @@ describe('count', () => {
 
     it('counts by specific keys', () => {
       expect(
-        I.Seq.of(1,2,3,4,5,6).countBy(x => x % 2 ? 'odd' : 'even').toJS()
+        Seq.of(1,2,3,4,5,6).countBy(x => x % 2 ? 'odd' : 'even').toJS()
       ).toEqual(
         {odd:3, even:3}
       );
@@ -54,32 +54,32 @@ describe('count', () => {
   describe('isEmpty', () => {
 
     it('is O(1) on sequences with known lengths', () => {
-      expect(I.Seq.of(1,2,3,4,5).size).toBe(5);
-      expect(I.Seq.of(1,2,3,4,5).isEmpty()).toBe(false);
-      expect(I.Seq().size).toBe(0);
-      expect(I.Seq().isEmpty()).toBe(true);
+      expect(Seq.of(1,2,3,4,5).size).toBe(5);
+      expect(Seq.of(1,2,3,4,5).isEmpty()).toBe(false);
+      expect(Seq().size).toBe(0);
+      expect(Seq().isEmpty()).toBe(true);
     })
 
     it('lazily evaluates Seq with unknown length', () => {
-      var seq = I.Seq.of(1,2,3,4,5,6).filter(x => x % 2 === 0);
+      var seq = Seq.of(1,2,3,4,5,6).filter(x => x % 2 === 0);
       expect(seq.size).toBe(undefined);
       expect(seq.isEmpty()).toBe(false);
       expect(seq.size).toBe(undefined);
 
-      var seq = I.Seq.of(1,2,3,4,5,6).filter(x => x > 10);
+      var seq = Seq.of(1,2,3,4,5,6).filter(x => x > 10);
       expect(seq.size).toBe(undefined);
       expect(seq.isEmpty()).toBe(true);
       expect(seq.size).toBe(undefined);
     })
 
     it('with infinitely long sequences of known length', () => {
-      var seq = I.Range();
+      var seq = Range();
       expect(seq.size).toBe(Infinity);
       expect(seq.isEmpty()).toBe(false);
     })
 
     it('with infinitely long sequences of unknown length', () => {
-      var seq = I.Range().filter(x => x % 2 === 0);
+      var seq = Range().filter(x => x % 2 === 0);
       expect(seq.size).toBe(undefined);
       expect(seq.isEmpty()).toBe(false);
       expect(seq.size).toBe(undefined);

--- a/__tests__/flatten.ts
+++ b/__tests__/flatten.ts
@@ -3,48 +3,48 @@
 
 jest.autoMockOff();
 
-import I = require('immutable');
-
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-type SeqType = number | number[] | I.Iterable<number,number>;
+import { Iterable, Seq, Range, List, fromJS } from 'immutable';
+
+type SeqType = number | number[] | Iterable<number,number>;
 
 describe('flatten', () => {
 
   it('flattens sequences one level deep', () => {
-    var nested = I.fromJS([[1,2],[3,4],[5,6]]);
+    var nested = fromJS([[1,2],[3,4],[5,6]]);
     var flat = nested.flatten();
     expect(flat.toJS()).toEqual([1,2,3,4,5,6]);
   })
 
   it('flattening a List returns a List', () => {
-    var nested = I.fromJS([[1],2,3,[4,5,6]]);
+    var nested = fromJS([[1],2,3,[4,5,6]]);
     var flat = nested.flatten();
     expect(flat.toString()).toEqual("List [ 1, 2, 3, 4, 5, 6 ]");
   })
 
   it('gives the correct iteration count', () => {
-    var nested = I.fromJS([[1,2,3],[4,5,6]]);
+    var nested = fromJS([[1,2,3],[4,5,6]]);
     var flat = nested.flatten();
     expect(flat.forEach(x => x < 4)).toEqual(4);
   })
 
   it('flattens only Sequences (not sequenceables)', () => {
-    var nested = I.Seq.of<SeqType>(I.Range(1,3),[3,4],I.List.of(5,6,7),8);
+    var nested = Seq.of<SeqType>(Range(1,3),[3,4],List.of(5,6,7),8);
     var flat = nested.flatten();
     expect(flat.toJS()).toEqual([1,2,[3,4],5,6,7,8]);
   })
 
   it('can be reversed', () => {
-    var nested = I.Seq.of<SeqType>(I.Range(1,3),[3,4],I.List.of(5,6,7),8);
+    var nested = Seq.of<SeqType>(Range(1,3),[3,4],List.of(5,6,7),8);
     var flat = nested.flatten();
     var reversed = flat.reverse();
     expect(reversed.toJS()).toEqual([8,7,6,5,[3,4],2,1]);
   })
 
   it('can flatten at various levels of depth', () => {
-    var deeplyNested = I.fromJS(
+    var deeplyNested = fromJS(
       [
         [
           [
@@ -114,8 +114,8 @@ describe('flatten', () => {
   describe('flatMap', () => {
 
     it('first maps, then shallow flattens', () => {
-      var numbers = I.Range(97, 100);
-      var letters = numbers.flatMap(v => I.fromJS([
+      var numbers = Range(97, 100);
+      var letters = numbers.flatMap(v => fromJS([
         String.fromCharCode(v),
         String.fromCharCode(v).toUpperCase(),
       ]));
@@ -125,7 +125,7 @@ describe('flatten', () => {
     });
 
     it('maps to sequenceables, not only Sequences.', () => {
-      var numbers = I.Range(97, 100);
+      var numbers = Range(97, 100);
       // the map function returns an Array, rather than an Iterable.
       // Array is sequenceable, so this works just fine.
       var letters = numbers.flatMap(v => [

--- a/__tests__/get.ts
+++ b/__tests__/get.ts
@@ -3,52 +3,52 @@
 
 jest.autoMockOff();
 
-import I = require('immutable');
+import { Range } from 'immutable';
 
 describe('get', () => {
 
   it('gets any index', () => {
-    var seq = I.Range(0, 100);
+    var seq = Range(0, 100);
     expect(seq.get(20)).toBe(20);
   });
 
   it('gets first', () => {
-    var seq = I.Range(0, 100);
+    var seq = Range(0, 100);
     expect(seq.first()).toBe(0);
   });
 
   it('gets last', () => {
-    var seq = I.Range(0, 100);
+    var seq = Range(0, 100);
     expect(seq.last()).toBe(99);
   });
 
   it('gets any index after reversing', () => {
-    var seq = I.Range(0, 100).reverse();
+    var seq = Range(0, 100).reverse();
     expect(seq.get(20)).toBe(79);
   });
 
   it('gets first after reversing', () => {
-    var seq = I.Range(0, 100).reverse();
+    var seq = Range(0, 100).reverse();
     expect(seq.first()).toBe(99);
   });
 
   it('gets last after reversing', () => {
-    var seq = I.Range(0, 100).reverse();
+    var seq = Range(0, 100).reverse();
     expect(seq.last()).toBe(0);
   });
 
   it('gets any index when size is unknown', () => {
-    var seq = I.Range(0, 100).filter(x => x % 2 === 1);
+    var seq = Range(0, 100).filter(x => x % 2 === 1);
     expect(seq.get(20)).toBe(41);
   });
 
   it('gets first when size is unknown', () => {
-    var seq = I.Range(0, 100).filter(x => x % 2 === 1);
+    var seq = Range(0, 100).filter(x => x % 2 === 1);
     expect(seq.first()).toBe(1);
   });
 
   it('gets last when size is unknown', () => {
-    var seq = I.Range(0, 100).filter(x => x % 2 === 1);
+    var seq = Range(0, 100).filter(x => x % 2 === 1);
     expect(seq.last()).toBe(99); // Note: this is O(N)
   });
 

--- a/__tests__/groupBy.ts
+++ b/__tests__/groupBy.ts
@@ -3,12 +3,12 @@
 
 jest.autoMockOff();
 
-import I = require('immutable');
+import { Iterable, Seq, Map } from 'immutable';
 
 describe('groupBy', () => {
 
   it('groups keyed sequence', () => {
-    var grouped = I.Seq({a:1,b:2,c:3,d:4}).groupBy(x => x % 2);
+    var grouped = Seq({a:1,b:2,c:3,d:4}).groupBy(x => x % 2);
     expect(grouped.toJS()).toEqual({1:{a:1,c:3}, 0:{b:2,d:4}});
 
     // Each group should be a keyed sequence, not an indexed sequence
@@ -17,7 +17,7 @@ describe('groupBy', () => {
 
   it('groups indexed sequence', () => {
     expect(
-      I.Seq.of(1,2,3,4,5,6).groupBy(x => x % 2).toJS()
+      Seq.of(1,2,3,4,5,6).groupBy(x => x % 2).toJS()
     ).toEqual(
       {1:[1,3,5], 0:[2,4,6]}
     );
@@ -25,7 +25,7 @@ describe('groupBy', () => {
 
   it('groups to keys', () => {
     expect(
-      I.Seq.of(1,2,3,4,5,6).groupBy(x => x % 2 ? 'odd' : 'even').toJS()
+      Seq.of(1,2,3,4,5,6).groupBy(x => x % 2 ? 'odd' : 'even').toJS()
     ).toEqual(
       {odd:[1,3,5], even:[2,4,6]}
     );
@@ -33,7 +33,7 @@ describe('groupBy', () => {
 
   it('groups indexed sequences, maintaining indicies', () => {
     expect(
-      I.Seq.of(1,2,3,4,5,6).toKeyedSeq().groupBy(x => x % 2).toJS()
+      Seq.of(1,2,3,4,5,6).toKeyedSeq().groupBy(x => x % 2).toJS()
     ).toEqual(
       {1:[1,,3,,5,,,], 0:[,2,,4,,6]}
     );
@@ -41,22 +41,22 @@ describe('groupBy', () => {
 
   it('has groups that can be mapped', () => {
     expect(
-      I.Seq.of(1,2,3,4,5,6).groupBy(x => x % 2).map(group => group.map(value => value * 10)).toJS()
+      Seq.of(1,2,3,4,5,6).groupBy(x => x % 2).map(group => group.map(value => value * 10)).toJS()
     ).toEqual(
       {1:[10,30,50], 0:[20,40,60]}
     );
   })
 
   it('returns an ordered map from an ordered collection', () => {
-    var seq = I.Seq.of('Z','Y','X','Z','Y','X');
-    expect(I.Iterable.isOrdered(seq)).toBe(true);
+    var seq = Seq.of('Z','Y','X','Z','Y','X');
+    expect(Iterable.isOrdered(seq)).toBe(true);
     var seqGroups = seq.groupBy(x => x);
-    expect(I.Iterable.isOrdered(seqGroups)).toBe(true);
+    expect(Iterable.isOrdered(seqGroups)).toBe(true);
 
-    var map = I.Map({ x: 1, y: 2 });
-    expect(I.Iterable.isOrdered(map)).toBe(false);
+    var map = Map({ x: 1, y: 2 });
+    expect(Iterable.isOrdered(map)).toBe(false);
     var mapGroups = map.groupBy(x => x);
-    expect(I.Iterable.isOrdered(mapGroups)).toBe(false);
+    expect(Iterable.isOrdered(mapGroups)).toBe(false);
   })
 
 })

--- a/__tests__/interpose.ts
+++ b/__tests__/interpose.ts
@@ -3,12 +3,12 @@
 
 jest.autoMockOff();
 
-import I = require('immutable');
+import { Range } from 'immutable';
 
 describe('interpose', () => {
 
   it('separates with a value', () => {
-    var range = I.Range(10, 15);
+    var range = Range(10, 15);
     var interposed = range.interpose(0);
     expect(interposed.toArray()).toEqual(
       [ 10, 0, 11, 0, 12, 0, 13, 0, 14 ]
@@ -16,7 +16,7 @@ describe('interpose', () => {
   })
 
   it('can be iterated', () => {
-    var range = I.Range(10, 15);
+    var range = Range(10, 15);
     var interposed = range.interpose(0);
     var values = interposed.values();
     expect(values.next()).toEqual({ value: 10, done: false });

--- a/__tests__/join.ts
+++ b/__tests__/join.ts
@@ -3,33 +3,33 @@
 
 jest.autoMockOff();
 
-import I = require('immutable');
-
 import jasmineCheck = require('jasmine-check');
 jasmineCheck.install();
+
+import { Seq } from 'immutable';
 
 describe('join', () => {
 
   it('string-joins sequences with commas by default', () => {
-    expect(I.Seq.of(1,2,3,4,5).join()).toBe('1,2,3,4,5');
+    expect(Seq.of(1,2,3,4,5).join()).toBe('1,2,3,4,5');
   })
 
   it('string-joins sequences with any string', () => {
-    expect(I.Seq.of(1,2,3,4,5).join('foo')).toBe('1foo2foo3foo4foo5');
+    expect(Seq.of(1,2,3,4,5).join('foo')).toBe('1foo2foo3foo4foo5');
   })
 
   it('string-joins sequences with empty string', () => {
-    expect(I.Seq.of(1,2,3,4,5).join('')).toBe('12345');
+    expect(Seq.of(1,2,3,4,5).join('')).toBe('12345');
   })
 
   it('joins sparse-sequences like Array.join', () => {
     var a = [1,,2,,3,,4,,5,,,];
-    expect(I.Seq(a).join()).toBe(a.join());
+    expect(Seq(a).join()).toBe(a.join());
   })
 
   check.it('behaves the same as Array.join',
     [gen.array(gen.primitive), gen.primitive], (array, joiner) => {
-      expect(I.Seq(array).join(joiner)).toBe(array.join(joiner));
+      expect(Seq(array).join(joiner)).toBe(array.join(joiner));
   })
 
 })

--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -3,7 +3,7 @@
 
 jest.autoMockOff();
 
-import I = require('immutable');
+import { List, Map, fromJS, is } from 'immutable';
 
 declare function expect(val: any): ExpectWithIs;
 
@@ -17,92 +17,92 @@ describe('merge', () => {
   beforeEach(function () {
     this.addMatchers({
       is: function(expected) {
-        return I.is(this.actual, expected);
+        return is(this.actual, expected);
       }
     })
   })
 
   it('merges two maps', () => {
-    var m1 = I.Map({a:1,b:2,c:3});
-    var m2 = I.Map({d:10,b:20,e:30});
-    expect(m1.merge(m2)).is(I.Map({a:1,b:20,c:3,d:10,e:30}));
+    var m1 = Map({a:1,b:2,c:3});
+    var m2 = Map({d:10,b:20,e:30});
+    expect(m1.merge(m2)).is(Map({a:1,b:20,c:3,d:10,e:30}));
   })
 
   it('can merge in an explicitly undefined value', () => {
-    var m1 = I.Map({a:1,b:2});
-    var m2 = I.Map({a:undefined});
-    expect(m1.merge(m2)).is(I.Map({a:undefined,b:2}));
+    var m1 = Map({a:1,b:2});
+    var m2 = Map({a:undefined});
+    expect(m1.merge(m2)).is(Map({a:undefined,b:2}));
   })
 
   it('merges two maps with a merge function', () => {
-    var m1 = I.Map({a:1,b:2,c:3});
-    var m2 = I.Map({d:10,b:20,e:30});
-    expect(m1.mergeWith((a, b) => a + b, m2)).is(I.Map({a:1,b:22,c:3,d:10,e:30}));
+    var m1 = Map({a:1,b:2,c:3});
+    var m2 = Map({d:10,b:20,e:30});
+    expect(m1.mergeWith((a, b) => a + b, m2)).is(Map({a:1,b:22,c:3,d:10,e:30}));
   })
 
   it('provides key as the third argument of merge function', () => {
-    var m1 = I.Map({id:'temp',  b:2,  c:3});
-    var m2 = I.Map({id:10,  b:20, e:30});
+    var m1 = Map({id:'temp',  b:2,  c:3});
+    var m2 = Map({id:10,  b:20, e:30});
     var add = (a, b) => a + b
     expect(
       m1.mergeWith((a, b, key) => key !== 'id' ? add(a, b) : b, m2)
-    ).is(I.Map({id:10,b:22,c:3,e:30}));
+    ).is(Map({id:10,b:22,c:3,e:30}));
   })
 
   it('deep merges two maps', () => {
-    var m1 = I.fromJS({a:{b:{c:1,d:2}}});
-    var m2 = I.fromJS({a:{b:{c:10,e:20},f:30},g:40});
-    expect(m1.mergeDeep(m2)).is(I.fromJS({a:{b:{c:10,d:2,e:20},f:30},g:40}));
+    var m1 = fromJS({a:{b:{c:1,d:2}}});
+    var m2 = fromJS({a:{b:{c:10,e:20},f:30},g:40});
+    expect(m1.mergeDeep(m2)).is(fromJS({a:{b:{c:10,d:2,e:20},f:30},g:40}));
   })
 
   it('deep merge uses is() for return-self optimization', () =>  {
     var date1 = new Date(1234567890000);
     var date2 = new Date(1234567890000);
-    var m = I.Map().setIn(['a', 'b', 'c'], date1);
+    var m = Map().setIn(['a', 'b', 'c'], date1);
     var m2 = m.mergeDeep({a:{b:{c: date2 }}});
     expect(m2 === m).toBe(true);
   })
 
   it('deep merges raw JS', () => {
-    var m1 = I.fromJS({a:{b:{c:1,d:2}}});
+    var m1 = fromJS({a:{b:{c:1,d:2}}});
     var js = {a:{b:{c:10,e:20},f:30},g:40};
-    expect(m1.mergeDeep(js)).is(I.fromJS({a:{b:{c:10,d:2,e:20},f:30},g:40}));
+    expect(m1.mergeDeep(js)).is(fromJS({a:{b:{c:10,d:2,e:20},f:30},g:40}));
   })
 
   it('deep merges raw JS with a merge function', () => {
-    var m1 = I.fromJS({a:{b:{c:1,d:2}}});
+    var m1 = fromJS({a:{b:{c:1,d:2}}});
     var js = {a:{b:{c:10,e:20},f:30},g:40};
     expect(
       m1.mergeDeepWith((a, b) => a + b, js)
-    ).is(I.fromJS(
+    ).is(fromJS(
       {a:{b:{c:11,d:2,e:20},f:30},g:40}
     ));
   })
 
   it('returns self when a deep merges is a no-op', () => {
-    var m1 = I.fromJS({a:{b:{c:1,d:2}}});
+    var m1 = fromJS({a:{b:{c:1,d:2}}});
     expect(
       m1.mergeDeep({a:{b:{c:1}}})
     ).toBe(m1);
   })
 
   it('returns arg when a deep merges is a no-op', () => {
-    var m1 = I.fromJS({a:{b:{c:1,d:2}}});
+    var m1 = fromJS({a:{b:{c:1,d:2}}});
     expect(
-      I.Map().mergeDeep(m1)
+      Map().mergeDeep(m1)
     ).toBe(m1);
   })
 
   it('can overwrite existing maps', () => {
     expect(
-      I.fromJS({ a: { x: 1, y: 1 }, b: { x: 2, y: 2 } })
+      fromJS({ a: { x: 1, y: 1 }, b: { x: 2, y: 2 } })
         .merge({ a: null, b: { x: 10 } })
         .toJS()
     ).toEqual(
       { a: null, b: { x: 10 } }
     );
     expect(
-      I.fromJS({ a: { x: 1, y: 1 }, b: { x: 2, y: 2 } })
+      fromJS({ a: { x: 1, y: 1 }, b: { x: 2, y: 2 } })
         .mergeDeep({ a: null, b: { x: 10 } })
         .toJS()
     ).toEqual(
@@ -111,8 +111,8 @@ describe('merge', () => {
   })
 
   it('can overwrite existing maps with objects', () => {
-    var m1 = I.fromJS({ a: { x: 1, y: 1 } }); // deep conversion.
-    var m2 = I.Map({ a: { z: 10 } }); // shallow conversion to Map.
+    var m1 = fromJS({ a: { x: 1, y: 1 } }); // deep conversion.
+    var m2 = Map({ a: { z: 10 } }); // shallow conversion to Map.
 
     // raw object simply replaces map.
     expect(m1.merge(m2).get('a')).toEqual({z: 10}) // raw object.
@@ -121,24 +121,24 @@ describe('merge', () => {
 
   it('merges map entries with Vector values', () => {
     expect(
-      I.fromJS({a:[1]}).merge({b:[2]})
-    ).is(I.fromJS(
+      fromJS({a:[1]}).merge({b:[2]})
+    ).is(fromJS(
       {a:[1], b:[2]}
     ));
     expect(
-      I.fromJS({a:[1]}).mergeDeep({b:[2]})
-    ).is(I.fromJS(
+      fromJS({a:[1]}).mergeDeep({b:[2]})
+    ).is(fromJS(
       {a:[1], b:[2]}
     ));
   })
 
   it('maintains JS values inside immutable collections', () => {
-    var m1 = I.fromJS({a:{b:[{imm:'map'}]}});
+    var m1 = fromJS({a:{b:[{imm:'map'}]}});
     var m2 = m1.mergeDeep(
-      I.Map({a: I.Map({b: I.List.of( {plain:'obj'} )})})
+      Map({a: Map({b: List.of( {plain:'obj'} )})})
     );
 
-    expect(m1.getIn(['a', 'b', 0])).is(I.Map([['imm', 'map']]));
+    expect(m1.getIn(['a', 'b', 0])).is(Map([['imm', 'map']]));
     expect(m2.getIn(['a', 'b', 0])).toEqual({plain: 'obj'});
   })
 

--- a/__tests__/minmax.ts
+++ b/__tests__/minmax.ts
@@ -3,11 +3,10 @@
 
 jest.autoMockOff();
 
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import I = require('immutable');
-import Seq = I.Seq;
+import { Seq, is } from 'immutable';
 
 var genHeterogeneousishArray = gen.oneOf([
   gen.array(gen.oneOf([gen.string, gen.undefined])),
@@ -25,7 +24,7 @@ describe('max', () => {
   });
 
   it('by a mapper', () => {
-    var family = I.Seq([
+    var family = Seq([
       { name: 'Oakley', age: 7 },
       { name: 'Dakota', age: 7 },
       { name: 'Casey', age: 34 },
@@ -35,7 +34,7 @@ describe('max', () => {
   });
 
   it('by a mapper and a comparator', () => {
-    var family = I.Seq([
+    var family = Seq([
       { name: 'Oakley', age: 7 },
       { name: 'Dakota', age: 7 },
       { name: 'Casey', age: 34 },
@@ -46,30 +45,30 @@ describe('max', () => {
 
   it('surfaces NaN, null, and undefined', () => {
     expect(
-      I.is(NaN, I.Seq.of(1, 2, 3, 4, 5, NaN).max())
+      is(NaN, Seq.of(1, 2, 3, 4, 5, NaN).max())
     ).toBe(true);
     expect(
-      I.is(NaN, I.Seq.of(NaN, 1, 2, 3, 4, 5).max())
+      is(NaN, Seq.of(NaN, 1, 2, 3, 4, 5).max())
     ).toBe(true);
     expect(
-      I.is(null, I.Seq.of('A', 'B', 'C', 'D', null).max())
+      is(null, Seq.of('A', 'B', 'C', 'D', null).max())
     ).toBe(true);
     expect(
-      I.is(null, I.Seq.of(null, 'A', 'B', 'C', 'D').max())
+      is(null, Seq.of(null, 'A', 'B', 'C', 'D').max())
     ).toBe(true);
   });
 
   it('null treated as 0 in default iterator', () => {
     expect(
-      I.is(2, I.Seq.of(-1, -2, null, 1, 2).max())
+      is(2, Seq.of(-1, -2, null, 1, 2).max())
     ).toBe(true);
   });
 
   check.it('is not dependent on order', [genHeterogeneousishArray], vals => {
     expect(
-      I.is(
-        I.Seq(shuffle(vals.slice())).max(),
-        I.Seq(vals).max()
+      is(
+        Seq(shuffle(vals.slice())).max(),
+        Seq(vals).max()
       )
     ).toEqual(true);
   });
@@ -87,7 +86,7 @@ describe('min', () => {
   });
 
   it('by a mapper', () => {
-    var family = I.Seq([
+    var family = Seq([
       { name: 'Oakley', age: 7 },
       { name: 'Dakota', age: 7 },
       { name: 'Casey', age: 34 },
@@ -97,7 +96,7 @@ describe('min', () => {
   });
 
   it('by a mapper and a comparator', () => {
-    var family = I.Seq([
+    var family = Seq([
       { name: 'Oakley', age: 7 },
       { name: 'Dakota', age: 7 },
       { name: 'Casey', age: 34 },
@@ -108,9 +107,9 @@ describe('min', () => {
 
   check.it('is not dependent on order', [genHeterogeneousishArray], vals => {
     expect(
-      I.is(
-        I.Seq(shuffle(vals.slice())).min(),
-        I.Seq(vals).min()
+      is(
+        Seq(shuffle(vals.slice())).min(),
+        Seq(vals).min()
       )
     ).toEqual(true);
   });

--- a/__tests__/slice.ts
+++ b/__tests__/slice.ts
@@ -3,12 +3,10 @@
 
 jest.autoMockOff();
 
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import I = require('immutable');
-import Seq = I.Seq;
-import List = I.List;
+import { List, Range, Seq } from 'immutable';
 
 describe('slice', () => {
 
@@ -92,7 +90,7 @@ describe('slice', () => {
   })
 
   it('has the same behavior as array slice in known edge cases', () => {
-    var a = I.Range(0, 33).toArray();
+    var a = Range(0, 33).toArray();
     var v = List(a);
     expect(v.slice(31).toList().toArray()).toEqual(a.slice(31));
   })
@@ -125,7 +123,7 @@ describe('slice', () => {
   check.it('works like Array.prototype.slice',
            [gen.int, gen.array(gen.oneOf([gen.int, gen.undefined]), 0, 3)],
            (valuesLen, args) => {
-    var a = I.Range(0, valuesLen).toArray();
+    var a = Range(0, valuesLen).toArray();
     var v = List(a);
     var slicedV = v.slice.apply(v, args);
     var slicedA = a.slice.apply(a, args);
@@ -147,7 +145,7 @@ describe('slice', () => {
   describe('take', () => {
 
     check.it('takes the first n from a list', [gen.int, gen.posInt], (len, num) => {
-      var a = I.Range(0, len).toArray();
+      var a = Range(0, len).toArray();
       var v = List(a);
       expect(v.take(num).toArray()).toEqual(a.slice(0, num));
     })

--- a/__tests__/sort.ts
+++ b/__tests__/sort.ts
@@ -3,11 +3,7 @@
 
 jest.autoMockOff();
 
-import I = require('immutable');
-import Seq = I.Seq;
-import List = I.List;
-import OrderedMap = I.OrderedMap;
-import Range = I.Range;
+import { Seq, List, OrderedMap, Range } from 'immutable';
 
 describe('sort', () => {
 

--- a/__tests__/splice.ts
+++ b/__tests__/splice.ts
@@ -3,12 +3,10 @@
 
 jest.autoMockOff();
 
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import I = require('immutable');
-import Seq = I.Seq;
-import List = I.List;
+import { List, Range, Seq } from 'immutable';
 
 describe('splice', () => {
 
@@ -28,7 +26,7 @@ describe('splice', () => {
 
   it('has the same behavior as array splice in known edge cases', () => {
     // arbitary numbers that sum to 31
-    var a = I.Range(0, 49).toArray();
+    var a = Range(0, 49).toArray();
     var v = List(a);
     a.splice(-18, 0, 0);
     expect(v.splice(-18, 0, 0).toList().toArray()).toEqual(a);

--- a/__tests__/updateIn.ts
+++ b/__tests__/updateIn.ts
@@ -3,48 +3,48 @@
 
 jest.autoMockOff();
 
-import I = require('immutable');
+import { Map, Set, fromJS } from 'immutable';
 
 describe('updateIn', () => {
 
   it('deep get', () => {
-    var m = I.fromJS({a: {b: {c: 10}}});
+    var m = fromJS({a: {b: {c: 10}}});
     expect(m.getIn(['a', 'b', 'c'])).toEqual(10);
   })
 
   it('deep get with list as keyPath', () => {
-    var m = I.fromJS({a: {b: {c: 10}}});
-    expect(m.getIn(I.fromJS(['a', 'b', 'c']))).toEqual(10);
+    var m = fromJS({a: {b: {c: 10}}});
+    expect(m.getIn(fromJS(['a', 'b', 'c']))).toEqual(10);
   })
 
   it('deep get throws without list or array-like', () => {
     // need to cast these as TypeScript first prevents us from such clownery.
     expect(() =>
-      I.Map().getIn(<any>undefined)
+      Map().getIn(<any>undefined)
     ).toThrow('Expected iterable or array-like: undefined');
     expect(() =>
-      I.Map().getIn(<any>{ a: 1, b: 2 })
+      Map().getIn(<any>{ a: 1, b: 2 })
     ).toThrow('Expected iterable or array-like: [object Object]');
   })
 
   it('deep has throws without list or array-like', () => {
     // need to cast these as TypeScript first prevents us from such clownery.
     expect(() =>
-      I.Map().hasIn(<any>undefined)
+      Map().hasIn(<any>undefined)
     ).toThrow('Expected iterable or array-like: undefined');
     expect(() =>
-      I.Map().hasIn(<any>{ a: 1, b: 2 })
+      Map().hasIn(<any>{ a: 1, b: 2 })
     ).toThrow('Expected iterable or array-like: [object Object]');
   })
 
   it('deep get returns not found if path does not match', () => {
-    var m = I.fromJS({a: {b: {c: 10}}});
+    var m = fromJS({a: {b: {c: 10}}});
     expect(m.getIn(['a', 'b', 'z'])).toEqual(undefined);
     expect(m.getIn(['a', 'b', 'c', 'd'])).toEqual(undefined);
   })
 
   it('deep edit', () => {
-    var m = I.fromJS({a: {b: {c: 10}}});
+    var m = fromJS({a: {b: {c: 10}}});
     expect(
       m.updateIn(['a', 'b', 'c'], value => value * 2).toJS()
     ).toEqual(
@@ -53,9 +53,9 @@ describe('updateIn', () => {
   })
 
   it('deep edit with list as keyPath', () => {
-    var m = I.fromJS({a: {b: {c: 10}}});
+    var m = fromJS({a: {b: {c: 10}}});
     expect(
-      m.updateIn(I.fromJS(['a', 'b', 'c']), value => value * 2).toJS()
+      m.updateIn(fromJS(['a', 'b', 'c']), value => value * 2).toJS()
     ).toEqual(
       {a: {b: {c: 20}}}
     );
@@ -64,16 +64,16 @@ describe('updateIn', () => {
   it('deep edit throws without list or array-like', () => {
     // need to cast these as TypeScript first prevents us from such clownery.
     expect(() =>
-      I.Map().updateIn(<any>undefined, x => x)
+      Map().updateIn(<any>undefined, x => x)
     ).toThrow('Expected iterable or array-like: undefined');
     expect(() =>
-      I.Map().updateIn(<any>{ a: 1, b: 2 }, x => x)
+      Map().updateIn(<any>{ a: 1, b: 2 }, x => x)
     ).toThrow('Expected iterable or array-like: [object Object]');
   })
 
 
   it('deep remove', () => {
-    var m = I.fromJS({a: {b: {c: 10}}});
+    var m = fromJS({a: {b: {c: 10}}});
     expect(
       m.updateIn(['a', 'b'], map => map.remove('c')).toJS()
     ).toEqual(
@@ -82,7 +82,7 @@ describe('updateIn', () => {
   })
 
   it('deep set', () => {
-    var m = I.fromJS({a: {b: {c: 10}}});
+    var m = fromJS({a: {b: {c: 10}}});
     expect(
       m.updateIn(['a', 'b'], map => map.set('d', 20)).toJS()
     ).toEqual(
@@ -91,7 +91,7 @@ describe('updateIn', () => {
   })
 
   it('deep push', () => {
-    var m = I.fromJS({a: {b: [1,2,3]}});
+    var m = fromJS({a: {b: [1,2,3]}});
     expect(
       m.updateIn(['a', 'b'], list => list.push(4)).toJS()
     ).toEqual(
@@ -100,7 +100,7 @@ describe('updateIn', () => {
   })
 
   it('deep map', () => {
-    var m = I.fromJS({a: {b: [1,2,3]}});
+    var m = fromJS({a: {b: [1,2,3]}});
     expect(
       m.updateIn(['a', 'b'], list => list.map(value => value * 10)).toJS()
     ).toEqual(
@@ -109,23 +109,23 @@ describe('updateIn', () => {
   })
 
   it('creates new maps if path contains gaps', () => {
-    var m = I.fromJS({a: {b: {c: 10}}});
+    var m = fromJS({a: {b: {c: 10}}});
     expect(
-      m.updateIn(['a', 'z'], I.Map(), map => map.set('d', 20)).toJS()
+      m.updateIn(['a', 'z'], Map(), map => map.set('d', 20)).toJS()
     ).toEqual(
       {a: {b: {c: 10}, z: {d: 20}}}
     );
   })
 
   it('throws if path cannot be set', () => {
-    var m = I.fromJS({a: {b: {c: 10}}});
+    var m = fromJS({a: {b: {c: 10}}});
     expect(() => {
       m.updateIn(['a', 'b', 'c', 'd'], v => 20).toJS()
     }).toThrow();
   })
 
   it('updates self for empty path', () => {
-    var m = I.fromJS({a: 1, b: 2, c: 3});
+    var m = fromJS({a: 1, b: 2, c: 3});
     expect(
       m.updateIn([], map => map.set('b', 20)).toJS()
     ).toEqual(
@@ -134,21 +134,21 @@ describe('updateIn', () => {
   })
 
   it('does not perform edit when new value is the same as old value', () => {
-    var m = I.fromJS({a: {b: {c: 10}}});
+    var m = fromJS({a: {b: {c: 10}}});
     var m2 = m.updateIn(['a', 'b', 'c'], id => id);
     expect(m2).toBe(m);
   })
 
   it('does not perform edit when notSetValue is what you return from updater', () => {
-    var m = I.Map();
+    var m = Map();
     var spiedOnID;
-    var m2 = m.updateIn(['a', 'b', 'c'], I.Set(), id => (spiedOnID = id));
+    var m2 = m.updateIn(['a', 'b', 'c'], Set(), id => (spiedOnID = id));
     expect(m2).toBe(m);
-    expect(spiedOnID).toBe(I.Set());
+    expect(spiedOnID).toBe(Set());
   })
 
   it('provides default notSetValue of undefined', () => {
-    var m = I.Map();
+    var m = Map();
     var spiedOnID;
     var m2 = m.updateIn(['a', 'b', 'c'], id => (spiedOnID = id));
     expect(m2).toBe(m);
@@ -158,22 +158,22 @@ describe('updateIn', () => {
   describe('setIn', () => {
 
     it('provides shorthand for updateIn to set a single value', () => {
-      var m = I.Map().setIn(['a','b','c'], 'X');
+      var m = Map().setIn(['a','b','c'], 'X');
       expect(m.toJS()).toEqual({a:{b:{c:'X'}}});
     })
 
     it('accepts a list as a keyPath', () => {
-      var m = I.Map().setIn(I.fromJS(['a','b','c']), 'X');
+      var m = Map().setIn(fromJS(['a','b','c']), 'X');
       expect(m.toJS()).toEqual({a:{b:{c:'X'}}});
     })
 
     it('returns value when setting empty path', () => {
-      var m = I.Map();
+      var m = Map();
       expect(m.setIn([], 'X')).toBe('X')
     })
 
     it('can setIn undefined', () => {
-      var m = I.Map().setIn(['a','b','c'], undefined);
+      var m = Map().setIn(['a','b','c'], undefined);
       expect(m.toJS()).toEqual({a:{b:{c:undefined}}});
     });
 
@@ -182,22 +182,22 @@ describe('updateIn', () => {
   describe('removeIn', () => {
 
     it('provides shorthand for updateIn to remove a single value', () => {
-      var m = I.fromJS({a:{b:{c:'X', d:'Y'}}});
+      var m = fromJS({a:{b:{c:'X', d:'Y'}}});
       expect(m.removeIn(['a','b','c']).toJS()).toEqual({a:{b:{d:'Y'}}});
     })
 
     it('accepts a list as a keyPath', () => {
-      var m = I.fromJS({a:{b:{c:'X', d:'Y'}}});
-      expect(m.removeIn(I.fromJS(['a','b','c'])).toJS()).toEqual({a:{b:{d:'Y'}}});
+      var m = fromJS({a:{b:{c:'X', d:'Y'}}});
+      expect(m.removeIn(fromJS(['a','b','c'])).toJS()).toEqual({a:{b:{d:'Y'}}});
     })
 
     it('does not create empty maps for an unset path', () => {
-      var m = I.Map();
+      var m = Map();
       expect(m.removeIn(['a','b','c']).toJS()).toEqual({});
     })
 
     it('removes itself when removing empty path', () => {
-      var m = I.Map();
+      var m = Map();
       expect(m.removeIn([])).toBe(undefined)
     })
 
@@ -206,30 +206,30 @@ describe('updateIn', () => {
   describe('mergeIn', () => {
 
     it('provides shorthand for updateIn to merge a nested value', () => {
-      var m1 = I.fromJS({x:{a:1,b:2,c:3}});
-      var m2 = I.fromJS({d:10,b:20,e:30});
+      var m1 = fromJS({x:{a:1,b:2,c:3}});
+      var m2 = fromJS({d:10,b:20,e:30});
       expect(m1.mergeIn(['x'], m2).toJS()).toEqual(
         {x: {a:1,b:20,c:3,d:10,e:30}}
       );
     })
 
     it('accepts a list as a keyPath', () => {
-      var m1 = I.fromJS({x:{a:1,b:2,c:3}});
-      var m2 = I.fromJS({d:10,b:20,e:30});
-      expect(m1.mergeIn(I.fromJS(['x']), m2).toJS()).toEqual(
+      var m1 = fromJS({x:{a:1,b:2,c:3}});
+      var m2 = fromJS({d:10,b:20,e:30});
+      expect(m1.mergeIn(fromJS(['x']), m2).toJS()).toEqual(
         {x: {a:1,b:20,c:3,d:10,e:30}}
       );
     })
 
     it('does not create empty maps for a no-op merge', () => {
-      var m = I.Map();
-      expect(m.mergeIn(['a','b','c'], I.Map()).toJS()).toEqual({});
+      var m = Map();
+      expect(m.mergeIn(['a','b','c'], Map()).toJS()).toEqual({});
     })
 
     it('merges into itself for empty path', () => {
-      var m = I.Map({a:1,b:2,c:3});
+      var m = Map({a:1,b:2,c:3});
       expect(
-        m.mergeIn([], I.Map({d:10,b:20,e:30})).toJS()
+        m.mergeIn([], Map({d:10,b:20,e:30})).toJS()
       ).toEqual(
         {a:1,b:20,c:3,d:10,e:30}
       )
@@ -240,30 +240,30 @@ describe('updateIn', () => {
   describe('mergeDeepIn', () => {
 
     it('provides shorthand for updateIn to merge a nested value', () => {
-      var m1 = I.fromJS({x:{a:1,b:2,c:3}});
-      var m2 = I.fromJS({d:10,b:20,e:30});
+      var m1 = fromJS({x:{a:1,b:2,c:3}});
+      var m2 = fromJS({d:10,b:20,e:30});
       expect(m1.mergeDeepIn(['x'], m2).toJS()).toEqual(
         {x: {a:1,b:20,c:3,d:10,e:30}}
       );
     })
 
     it('accepts a list as a keyPath', () => {
-      var m1 = I.fromJS({x:{a:1,b:2,c:3}});
-      var m2 = I.fromJS({d:10,b:20,e:30});
-      expect(m1.mergeDeepIn(I.fromJS(['x']), m2).toJS()).toEqual(
+      var m1 = fromJS({x:{a:1,b:2,c:3}});
+      var m2 = fromJS({d:10,b:20,e:30});
+      expect(m1.mergeDeepIn(fromJS(['x']), m2).toJS()).toEqual(
         {x: {a:1,b:20,c:3,d:10,e:30}}
       );
     })
 
     it('does not create empty maps for a no-op merge', () => {
-      var m = I.Map();
-      expect(m.mergeDeepIn(['a','b','c'], I.Map()).toJS()).toEqual({});
+      var m = Map();
+      expect(m.mergeDeepIn(['a','b','c'], Map()).toJS()).toEqual({});
     })
 
     it('merges into itself for empty path', () => {
-      var m = I.Map({a:1,b:2,c:3});
+      var m = Map({a:1,b:2,c:3});
       expect(
-        m.mergeDeepIn([], I.Map({d:10,b:20,e:30})).toJS()
+        m.mergeDeepIn([], Map({d:10,b:20,e:30})).toJS()
       ).toEqual(
         {a:1,b:20,c:3,d:10,e:30}
       )

--- a/__tests__/zip.ts
+++ b/__tests__/zip.ts
@@ -3,16 +3,16 @@
 
 jest.autoMockOff();
 
-import I = require('immutable');
-
-import jasmineCheck = require('jasmine-check');
+import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
+
+import { Iterable, List, Range, Seq } from 'immutable';
 
 describe('zip', () => {
 
   it('zips lists into a list of tuples', () => {
     expect(
-      I.Seq.of(1,2,3).zip(I.Seq.of(4,5,6)).toArray()
+      Seq.of(1,2,3).zip(Seq.of(4,5,6)).toArray()
     ).toEqual(
       [[1,4],[2,5],[3,6]]
     );
@@ -20,14 +20,14 @@ describe('zip', () => {
 
   it('zips with infinite lists', () => {
     expect(
-      I.Range().zip(I.Seq.of('A','B','C')).toArray()
+      Range().zip(Seq.of('A','B','C')).toArray()
     ).toEqual(
       [[0,'A'],[1,'B'],[2,'C']]
     );
   });
 
   it('has unknown size when zipped with unknown size', () => {
-    var seq = I.Range(0, 10);
+    var seq = Range(0, 10);
     var zipped = seq.zip(seq.filter(n => n % 2 === 0));
     expect(zipped.size).toBe(undefined);
     expect(zipped.count()).toBe(5);
@@ -35,7 +35,7 @@ describe('zip', () => {
 
   check.it('is always the size of the smaller sequence',
     [gen.notEmpty(gen.array(gen.posInt))], (lengths) => {
-      var ranges = lengths.map(l => I.Range(0, l));
+      var ranges = lengths.map(l => Range(0, l));
       var first = ranges.shift();
       var zipped = first.zip.apply(first, ranges);
       var shortestLength = Math.min.apply(Math, lengths);
@@ -46,9 +46,9 @@ describe('zip', () => {
 
     it('zips with a custom function', () => {
       expect(
-        I.Seq.of(1,2,3).zipWith<number, number>(
+        Seq.of(1,2,3).zipWith<number, number>(
           (a, b) => a + b,
-          I.Seq.of(4,5,6)
+          Seq.of(4,5,6)
         ).toArray()
       ).toEqual(
         [5,7,9]
@@ -57,10 +57,10 @@ describe('zip', () => {
 
     it('can zip to create immutable collections', () => {
       expect(
-        I.Seq.of(1,2,3).zipWith(
-          function () { return I.List(arguments); },
-          I.Seq.of(4,5,6),
-          I.Seq.of(7,8,9)
+        Seq.of(1,2,3).zipWith(
+          function () { return List(arguments); },
+          Seq.of(4,5,6),
+          Seq.of(7,8,9)
         ).toJS()
       ).toEqual(
         [[1,4,7],[2,5,8],[3,6,9]]
@@ -73,9 +73,9 @@ describe('zip', () => {
 
     it('interleaves multiple collections', () => {
       expect(
-        I.Seq.of(1,2,3).interleave(
-          I.Seq.of(4,5,6),
-          I.Seq.of(7,8,9)
+        Seq.of(1,2,3).interleave(
+          Seq.of(4,5,6),
+          Seq.of(7,8,9)
         ).toArray()
       ).toEqual(
         [1,4,7,2,5,8,3,6,9]
@@ -83,9 +83,9 @@ describe('zip', () => {
     });
 
     it('stops at the shortest collection', () => {
-      var i = I.Seq.of(1,2,3).interleave(
-        I.Seq.of(4,5),
-        I.Seq.of(7,8,9)
+      var i = Seq.of(1,2,3).interleave(
+        Seq.of(4,5),
+        Seq.of(7,8,9)
       );
       expect(i.size).toBe(6);
       expect(i.toArray()).toEqual(
@@ -94,8 +94,8 @@ describe('zip', () => {
     });
 
     it('with infinite lists', () => {
-      var r: I.Iterable.Indexed<any> = I.Range();
-      var i = r.interleave(I.Seq.of('A','B','C'));
+      var r: Iterable.Indexed<any> = Range();
+      var i = r.interleave(Seq.of('A','B','C'));
       expect(i.size).toBe(6);
       expect(i.toArray()).toEqual(
         [0,'A',1,'B',2,'C']


### PR DESCRIPTION
More recent versions of typescript support standardized import syntax. This leverages it in tests, which reduces namespacing noise.