### PR TITLE
Cursor: adding function to be able to easily identify an object as a cursor

### DIFF
--- a/contrib/cursor/index.d.ts
+++ b/contrib/cursor/index.d.ts
@@ -55,6 +55,9 @@ declare module 'immutable/contrib/cursor' {
     key: any,
     onChange?: (newValue: any, oldValue?: any, keyPath?: Array<any>) => any
   ): Cursor;
+  export function isCursor(
+    obj: any
+  ): boolean;
 
 
   export interface Cursor extends Immutable.Seq<any, any> {

--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -340,4 +340,9 @@ function valToKeyPath(val) {
     [val];
 }
 
+function isCursor(obj) {
+  return obj.__proto__ == IndexedCursorPrototype || obj.__proto__ == KeyedCursorPrototype;
+}
+
 exports.from = cursorFrom;
+exports.isCursor = isCursor;


### PR DESCRIPTION
Exposing function for easily identifying if an object is a cursor. This was necessary for me to identify props that were cursors passed down through react elements to determine if I should update based off differences of internal state.
