### PR TITLE
Make cursor typescript definition accessible from other ambient external modules

### DIFF
--- a/contrib/cursor/index.d.ts
+++ b/contrib/cursor/index.d.ts
@@ -35,11 +35,9 @@
  * update the rest of your application.
  */
 
+/// <reference path='../../dist/immutable.d.ts'/>
+
 declare module __Cursor {
-
-  ///<reference path='../../dist/immutable.d.ts'/>
-  import Immutable = require('immutable');
-
 
   export function from(
     collection: Immutable.Collection<any, any>,

--- a/contrib/cursor/index.d.ts
+++ b/contrib/cursor/index.d.ts
@@ -35,7 +35,7 @@
  * update the rest of your application.
  */
 
-declare module 'immutable/contrib/cursor' {
+declare module __Cursor {
 
   ///<reference path='../../dist/immutable.d.ts'/>
   import Immutable = require('immutable');
@@ -288,4 +288,8 @@ declare module 'immutable/contrib/cursor' {
     withMutations(mutator: (mutable: any) => any): Cursor;
   }
 
+}
+
+declare module 'immutable/contrib/cursor' {
+  export = __Cursor
 }


### PR DESCRIPTION
`cursor/index.d.ts` definitions are inaccessible from other ambient external modules. This is needed, for example, to write definitions for `immstruct`.