### PR TITLE
Add eslintrc file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,19 @@
+{
+  "extends": "./node_modules/fbjs-scripts/eslint/.eslintrc",
+  "rules": {
+    // These are functional errors that could either be fixed or be locally disabled in specific
+    // files
+    "no-bitwise": 0,
+    "constructor-super": 0,
+    "no-this-before-super": 0,
+    "no-self-compare": 0,
+    "operator-assignment": 0,
+    "consistent-return": 0,
+
+    // These are stylistic errors that could be easily fixed
+    "semi": 0,
+    "comma-dangle": 0,
+    "space-before-function-paren": 0,
+    "curly": 0,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "acorn": "0.11.x",
+    "babel-eslint": "^4.1.8",
     "benchmark": "^1.0.0",
     "bluebird": "3.1.1",
     "browser-sync": "2.11.0",
@@ -42,7 +43,9 @@
     "colors": "1.1.2",
     "del": "2.2.0",
     "es6-transpiler": "0.7.18",
+    "eslint": "^1.10.3",
     "estraverse": "1.9.3",
+    "fbjs-scripts": "^0.5.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "0.7.0",


### PR DESCRIPTION
This adds an eslintrc file, extended from the fbjs-scripts base eslintrc (which React and Jest also use). I disabled rules that were currently failing, and the `src/` directory lints with no errors.

It doesn't add any automated linting yet, but does allow editors configured for linting to lint individual files.

Related to #742.