### PR TITLE
Fix links

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@ and research in persistent data structures.</p>
 <p><a href="https://github.com/hughfdjackson/">Hugh Jackson</a>, for providing the npm package
 name. If you&#39;re looking for his unsupported package, see <a href="https://www.npmjs.org/package/immutable/1.4.1">v1.4.1</a>.</p>
 <h2 id="license">License</h2>
-<p><code><span class="token qualifier" >Immutable</span></code> is <a href="./LICENSE">BSD-licensed</a>. We also provide an additional <a href="https://github.com/facebook/immutable-js/blob/master/PATENTS">patent grant</a>.</p>
+<p><code><span class="token qualifier" >Immutable</span></code> is <a href="https://github.com/facebook/immutable-js/blob/master/LICENSE">BSD-licensed</a>. We also provide an additional <a href="https://github.com/facebook/immutable-js/blob/master/PATENTS">patent grant</a>.</p>
 </div></div></div></div></div>
     <script src="//cdn.jsdelivr.net/react/0.12.1/react-with-addons.min.js"></script>
     <script src="bundle.js"></script>

--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@ and research in persistent data structures.</p>
 <p><a href="https://github.com/hughfdjackson/">Hugh Jackson</a>, for providing the npm package
 name. If you&#39;re looking for his unsupported package, see <a href="https://www.npmjs.org/package/immutable/1.4.1">v1.4.1</a>.</p>
 <h2 id="license">License</h2>
-<p><code><span class="token qualifier" >Immutable</span></code> is <a href="./LICENSE">BSD-licensed</a>. We also provide an additional <a href="./PATENTS">patent grant</a>.</p>
+<p><code><span class="token qualifier" >Immutable</span></code> is <a href="./LICENSE">BSD-licensed</a>. We also provide an additional <a href="https://github.com/facebook/immutable-js/blob/master/PATENTS">patent grant</a>.</p>
 </div></div></div></div></div>
     <script src="//cdn.jsdelivr.net/react/0.12.1/react-with-addons.min.js"></script>
     <script src="bundle.js"></script>


### PR DESCRIPTION
Why:
Website was linking to 404 pages.

How:
Change links to absolute links rather than relative links since the website has a different root than the Readme file. 