### PR TITLE
Rebuild and reload typedefs in dev server on change

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -237,8 +237,8 @@ gulp.task('dev', ['default'], function() {
   gulp.watch('./app/docs/src/**/*.js', ['rebuild-js-docs']);
   gulp.watch('./app/**/*.html', ['pre-render', 'pre-render-docs']);
   gulp.watch('./app/static/**/*', ['statics', 'statics-docs']);
-  gulp.watch('./type-definitions/*', ['typedefs', 'rebuild-js-docs'], function () {
-    browserSync.reload();
+  gulp.watch('./type-definitions/*', function () {
+    sequence('typedefs', 'rebuild-js-docs');
   });
 });
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -237,6 +237,9 @@ gulp.task('dev', ['default'], function() {
   gulp.watch('./app/docs/src/**/*.js', ['rebuild-js-docs']);
   gulp.watch('./app/**/*.html', ['pre-render', 'pre-render-docs']);
   gulp.watch('./app/static/**/*', ['statics', 'statics-docs']);
+  gulp.watch('./type-definitions/*', ['typedefs', 'rebuild-js-docs'], function () {
+    browserSync.reload();
+  });
 });
 
 gulp.task('rebuild-js', function (done) {


### PR DESCRIPTION
This PR adds a watcher for any file in the `/type-definitions/` folder and rebuilds the docs on changes. This makes it easier to work on docs and seeing the results without constantly having to rebuild manually.
