### PR TITLE
Improve Flow libdefs

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -430,7 +430,7 @@ declare class List<T> extends IndexedCollection<T> {
   remove(index: number): this;
   insert<U>(index: number, value: U): List<T|U>;
   clear(): this;
-  push<U>(...values: U[]): List<U>;
+  push<U>(...values: U[]): List<T|U>;
   pop(): this;
   unshift<U>(...values: U[]): List<T|U>;
   shift(): this;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -327,12 +327,12 @@ declare class IndexedIterable<T> extends Iterable<number,T> {
   filter(
     predicate: (value: T, index: number, iter: this) => mixed,
     context?: any
-  ): IndexedIterable;
+  ): IndexedIterable<any>;
 
   filterNot(
     predicate: (value: T, index: number, iter: this) => mixed,
     context?: any
-  ): IndexedIterable;
+  ): IndexedIterable<any>;
 
   flatten(depth?: number): /*this*/IndexedIterable<any>;
   flatten(shallow?: boolean): /*this*/IndexedIterable<any>;
@@ -363,12 +363,12 @@ declare class SetIterable<T> extends Iterable<T,T> {
   filter(
     predicate: (value: T, key: T, iter: this) => mixed,
     context?: any
-  ): SetIterable;
+  ): SetIterable<any>;
 
   filterNot(
     predicate: (value: T, key: T, iter: this) => mixed,
     context?: any
-  ): SetIterable;
+  ): SetIterable<any>;
 
   flatten(depth?: number): /*this*/SetIterable<any>;
   flatten(shallow?: boolean): /*this*/SetIterable<any>;
@@ -482,12 +482,12 @@ declare class List<T> extends IndexedCollection<T> {
   filter(
     predicate: (value: T, index: number, iter: this) => mixed,
     context?: any
-  ): List;
+  ): List<any>;
 
   filterNot(
     predicate: (value: T, index: number, iter: this) => mixed,
     context?: any
-  ): List;
+  ): List<any>;
 
   flatten(depth?: number): /*this*/List<any>;
   flatten(shallow?: boolean): /*this*/List<any>;
@@ -615,12 +615,12 @@ declare class Set<T> extends SetCollection<T> {
   filter(
     predicate: (value: T, value: T, iter: this) => mixed,
     context?: any
-  ): Set;
+  ): Set<any>;
 
   filterNot(
     predicate: (value: T, value: T, iter: this) => mixed,
     context?: any
-  ): Set;
+  ): Set<any>;
 
   flatten(depth?: number): /*this*/Set<any>;
   flatten(shallow?: boolean): /*this*/Set<any>;
@@ -665,12 +665,12 @@ declare class Stack<T> extends IndexedCollection<T> {
   filter(
     predicate: (value: T, index: number, iter: this) => mixed,
     context?: any
-  ): Stack;
+  ): Stack<any>;
 
   filterNot(
     predicate: (value: T, index: number, iter: this) => mixed,
     context?: any
-  ): Stack;
+  ): Stack<any>;
 
   flatten(depth?: number): /*this*/Stack<any>;
   flatten(shallow?: boolean): /*this*/Stack<any>;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -110,6 +110,16 @@ declare class _Iterable<K, V, KI, II, SI> {
   flatten(depth?: number): /*this*/Iterable<any,any>;
   flatten(shallow?: boolean): /*this*/Iterable<any,any>;
 
+  filter(
+    predicate: (value: V, key: K, iter: this) => mixed,
+    context?: any
+  ): this;
+
+  filterNot(
+    predicate: (value: V, key: K, iter: this) => mixed,
+    context?: any
+  ): this;
+
   reduce<R>(
     reducer: (reduction: R, value: V, key: K, iter: this) => R,
     initialReduction?: R,
@@ -205,16 +215,6 @@ declare class KeyedIterable<K,V> extends Iterable<K,V> {
     mapper: (value: V, key: K, iter: this) => ESIterable<[K_,V_]>,
     context?: any
   ): /*this*/KeyedIterable<K_,V_>;
-
-  filter(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any
-  ): KeyedIterable<K, any>;
-
-  filterNot(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any
-  ): KeyedIterable<K, any>;
 
   flatten(depth?: number): /*this*/KeyedIterable<any,any>;
   flatten(shallow?: boolean): /*this*/KeyedIterable<any,any>;
@@ -324,16 +324,6 @@ declare class IndexedIterable<T> extends Iterable<number,T> {
     context?: any
   ): /*this*/IndexedIterable<U>;
 
-  filter(
-    predicate: (value: T, index: number, iter: this) => mixed,
-    context?: any
-  ): IndexedIterable<any>;
-
-  filterNot(
-    predicate: (value: T, index: number, iter: this) => mixed,
-    context?: any
-  ): IndexedIterable<any>;
-
   flatten(depth?: number): /*this*/IndexedIterable<any>;
   flatten(shallow?: boolean): /*this*/IndexedIterable<any>;
 }
@@ -359,16 +349,6 @@ declare class SetIterable<T> extends Iterable<T,T> {
     mapper: (value: T, value: T, iter: this) => ESIterable<U>,
     context?: any
   ): /*this*/SetIterable<U>;
-
-  filter(
-    predicate: (value: T, key: T, iter: this) => mixed,
-    context?: any
-  ): SetIterable<any>;
-
-  filterNot(
-    predicate: (value: T, key: T, iter: this) => mixed,
-    context?: any
-  ): SetIterable<any>;
 
   flatten(depth?: number): /*this*/SetIterable<any>;
   flatten(shallow?: boolean): /*this*/SetIterable<any>;
@@ -479,16 +459,6 @@ declare class List<T> extends IndexedCollection<T> {
     context?: any
   ): List<M>;
 
-  filter(
-    predicate: (value: T, index: number, iter: this) => mixed,
-    context?: any
-  ): List<any>;
-
-  filterNot(
-    predicate: (value: T, index: number, iter: this) => mixed,
-    context?: any
-  ): List<any>;
-
   flatten(depth?: number): /*this*/List<any>;
   flatten(shallow?: boolean): /*this*/List<any>;
 }
@@ -560,16 +530,6 @@ declare class Map<K,V> extends KeyedCollection<K,V> {
     context?: any
   ): Map<K_,V>;
 
-  filter(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any
-  ): Map<K, any>;
-
-  filterNot(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any
-  ): Map<K, any>;
-
   flatten(depth?: number): /*this*/Map<any,any>;
   flatten(shallow?: boolean): /*this*/Map<any,any>;
 }
@@ -612,16 +572,6 @@ declare class Set<T> extends SetCollection<T> {
     context?: any
   ): Set<M>;
 
-  filter(
-    predicate: (value: T, value: T, iter: this) => mixed,
-    context?: any
-  ): Set<any>;
-
-  filterNot(
-    predicate: (value: T, value: T, iter: this) => mixed,
-    context?: any
-  ): Set<any>;
-
   flatten(depth?: number): /*this*/Set<any>;
   flatten(shallow?: boolean): /*this*/Set<any>;
 }
@@ -661,16 +611,6 @@ declare class Stack<T> extends IndexedCollection<T> {
     mapper: (value: T, index: number, iter: this) => ESIterable<U>,
     context?: any
   ): Stack<U>;
-
-  filter(
-    predicate: (value: T, index: number, iter: this) => mixed,
-    context?: any
-  ): Stack<any>;
-
-  filterNot(
-    predicate: (value: T, index: number, iter: this) => mixed,
-    context?: any
-  ): Stack<any>;
 
   flatten(depth?: number): /*this*/Stack<any>;
   flatten(shallow?: boolean): /*this*/Stack<any>;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -29,9 +29,9 @@
  */
 type ESIterable<T> = $Iterable<T,void,void>;
 
-declare class Iterable<K, V> extends _Iterable<K, V, typeof KeyedIterable, typeof IndexedIterable,  typeof SetIterable> {}
+declare class Iterable<K, V> extends _Iterable<K, V, typeof KeyedIterable, typeof IndexedIterable, typeof SetIterable> {}
 
-declare class _Iterable<K,V, KI, II, SI> {
+declare class _Iterable<K, V, KI, II, SI> {
   static Keyed:   KI;
   static Indexed: II;
   static Set:     SI;
@@ -44,8 +44,8 @@ declare class _Iterable<K,V, KI, II, SI> {
 
   equals(other: Iterable<K,V>): boolean;
   hashCode(): number;
+  get(key: K): V;
   get<V_>(key: K, notSetValue: V_): V|V_;
-  get(key: K): ?V;
   has(key: K): boolean;
   includes(value: V): boolean;
   contains(value: V): boolean;
@@ -53,7 +53,7 @@ declare class _Iterable<K,V, KI, II, SI> {
   last(): V;
 
   getIn<T>(searchKeyPath: ESIterable<any>, notSetValue: T): T;
-  getIn<T>(searchKeyPath: ESIterable<any>): ?T;
+  getIn<T>(searchKeyPath: ESIterable<any>): T;
   hasIn(searchKeyPath: ESIterable<any>): boolean;
 
   toJS(): any;
@@ -77,16 +77,6 @@ declare class _Iterable<K,V, KI, II, SI> {
   keySeq(): IndexedSeq<K>;
   valueSeq(): IndexedSeq<V>;
   entrySeq(): IndexedSeq<[K,V]>;
-
-  filter(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any
-  ): this;
-
-  filterNot(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any
-  ): this;
 
   reverse(): this;
   sort(comparator?: (valueA: V, valueB: V) => number): this;
@@ -139,25 +129,26 @@ declare class _Iterable<K,V, KI, II, SI> {
   count(predicate?: (value: V, key: K, iter: this) => mixed, context?: any): number;
   countBy<G>(grouper: (value: V, key: K, iter: this) => G, context?: any): Map<G,number>;
 
+  find(
+    predicate: (value: V, key: K, iter: this) => mixed,
+    context?: any,
+  ): ?V;
   find<V_>(
     predicate: (value: V, key: K, iter: this) => mixed,
     context: any,
     notSetValue: V_
   ): V|V_;
-  find<V_>(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any,
-  ): ?V;
 
+  findLast(
+    predicate: (value: V, key: K, iter: this) => mixed,
+    context?: any,
+  ): ?V;
   findLast<V_>(
     predicate: (value: V, key: K, iter: this) => mixed,
     context: any,
     notSetValue: V_
   ): V|V_;
-  findLast<V_>(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any,
-  ): ?V;
+
 
   findEntry(predicate: (value: V, key: K, iter: this) => mixed): ?[K,V];
   findLastEntry(predicate: (value: V, key: K, iter: this) => mixed): ?[K,V];
@@ -214,6 +205,19 @@ declare class KeyedIterable<K,V> extends Iterable<K,V> {
     mapper: (value: V, key: K, iter: this) => ESIterable<[K_,V_]>,
     context?: any
   ): /*this*/KeyedIterable<K_,V_>;
+
+  filter(
+    predicate: (value: V, key: K, iter: this) => mixed,
+    context?: any
+  ): KeyedIterable<K, any>;
+
+  filterNot(
+    predicate: (value: V, key: K, iter: this) => mixed,
+    context?: any
+  ): KeyedIterable<K, any>;
+
+  flatten(depth?: number): /*this*/KeyedIterable<any,any>;
+  flatten(shallow?: boolean): /*this*/KeyedIterable<any,any>;
 }
 
 declare class IndexedIterable<T> extends Iterable<number,T> {
@@ -319,6 +323,19 @@ declare class IndexedIterable<T> extends Iterable<number,T> {
     mapper: (value: T, index: number, iter: this) => ESIterable<U>,
     context?: any
   ): /*this*/IndexedIterable<U>;
+
+  filter(
+    predicate: (value: T, index: number, iter: this) => mixed,
+    context?: any
+  ): IndexedIterable;
+
+  filterNot(
+    predicate: (value: T, index: number, iter: this) => mixed,
+    context?: any
+  ): IndexedIterable;
+
+  flatten(depth?: number): /*this*/IndexedIterable<any>;
+  flatten(shallow?: boolean): /*this*/IndexedIterable<any>;
 }
 
 declare class SetIterable<T> extends Iterable<T,T> {
@@ -342,9 +359,22 @@ declare class SetIterable<T> extends Iterable<T,T> {
     mapper: (value: T, value: T, iter: this) => ESIterable<U>,
     context?: any
   ): /*this*/SetIterable<U>;
+
+  filter(
+    predicate: (value: T, key: T, iter: this) => mixed,
+    context?: any
+  ): SetIterable;
+
+  filterNot(
+    predicate: (value: T, key: T, iter: this) => mixed,
+    context?: any
+  ): SetIterable;
+
+  flatten(depth?: number): /*this*/SetIterable<any>;
+  flatten(shallow?: boolean): /*this*/SetIterable<any>;
 }
 
-declare class Collection<K,V> extends _Iterable<K,V, typeof KeyedCollection, typeof IndexedCollection,  typeof SetCollection> {
+declare class Collection<K,V> extends _Iterable<K,V, typeof KeyedCollection, typeof IndexedCollection, typeof SetCollection> {
   size: number;
 }
 
@@ -390,7 +420,7 @@ declare class SetSeq<T> extends Seq<T,T> mixins SetIterable<T> {
 }
 
 declare class List<T> extends IndexedCollection<T> {
-  static <T>(iterable?: ESIterable<T>): List<T>;
+  static (iterable?: ESIterable<T>): List<T>;
 
   static isList(maybeList: any): boolean;
   static of<T>(...values: T[]): List<T>;
@@ -400,7 +430,7 @@ declare class List<T> extends IndexedCollection<T> {
   remove(index: number): this;
   insert<U>(index: number, value: U): List<T|U>;
   clear(): this;
-  push<U>(...values: U[]): List<T|U>;
+  push<U>(...values: U[]): List<U>;
   pop(): this;
   unshift<U>(...values: U[]): List<T|U>;
   shift(): this;
@@ -439,7 +469,6 @@ declare class List<T> extends IndexedCollection<T> {
   asImmutable(): this;
 
   // Overrides that specialize return types
-
   map<M>(
     mapper: (value: T, index: number, iter: this) => M,
     context?: any
@@ -449,15 +478,29 @@ declare class List<T> extends IndexedCollection<T> {
     mapper: (value: T, index: number, iter: this) => ESIterable<M>,
     context?: any
   ): List<M>;
+
+  filter(
+    predicate: (value: T, index: number, iter: this) => mixed,
+    context?: any
+  ): List;
+
+  filterNot(
+    predicate: (value: T, index: number, iter: this) => mixed,
+    context?: any
+  ): List;
+
+  flatten(depth?: number): /*this*/List<any>;
+  flatten(shallow?: boolean): /*this*/List<any>;
 }
 
 declare class Map<K,V> extends KeyedCollection<K,V> {
+  static <K, V>(): Map<K, V>;
   static <V>(obj?: {[key: string]: V}): Map<string, V>;
   static <K, V>(iterable?: ESIterable<[K,V]>): Map<K, V>;
 
   static isMap(maybeMap: any): boolean;
 
-  set<K_,V_>(key: K_, value: V_): Map<K|K_,V|V_>;
+  set<K_, V_>(key: K_, value: V_): Map<K|K_, V|V_>;
   delete(key: K): this;
   remove(key: K): this;
   clear(): this;
@@ -516,6 +559,19 @@ declare class Map<K,V> extends KeyedCollection<K,V> {
     mapper: (key: K, value: V, iter: this) => K_,
     context?: any
   ): Map<K_,V>;
+
+  filter(
+    predicate: (value: V, key: K, iter: this) => mixed,
+    context?: any
+  ): Map<K, any>;
+
+  filterNot(
+    predicate: (value: V, key: K, iter: this) => mixed,
+    context?: any
+  ): Map<K, any>;
+
+  flatten(depth?: number): /*this*/Map<any,any>;
+  flatten(shallow?: boolean): /*this*/Map<any,any>;
 }
 
 // OrderedMaps have nothing that Maps do not have. We do not need to override constructor & other statics
@@ -555,6 +611,19 @@ declare class Set<T> extends SetCollection<T> {
     mapper: (value: T, value: T, iter: this) => ESIterable<M>,
     context?: any
   ): Set<M>;
+
+  filter(
+    predicate: (value: T, value: T, iter: this) => mixed,
+    context?: any
+  ): Set;
+
+  filterNot(
+    predicate: (value: T, value: T, iter: this) => mixed,
+    context?: any
+  ): Set;
+
+  flatten(depth?: number): /*this*/Set<any>;
+  flatten(shallow?: boolean): /*this*/Set<any>;
 }
 
 // OrderedSets have nothing that Sets do not have. We do not need to override constructor & other statics
@@ -592,6 +661,19 @@ declare class Stack<T> extends IndexedCollection<T> {
     mapper: (value: T, index: number, iter: this) => ESIterable<U>,
     context?: any
   ): Stack<U>;
+
+  filter(
+    predicate: (value: T, index: number, iter: this) => mixed,
+    context?: any
+  ): Stack;
+
+  filterNot(
+    predicate: (value: T, index: number, iter: this) => mixed,
+    context?: any
+  ): Stack;
+
+  flatten(depth?: number): /*this*/Stack<any>;
+  flatten(shallow?: boolean): /*this*/Stack<any>;
 }
 
 declare function Range(start?: number, end?: number, step?: number): IndexedSeq<number>;


### PR DESCRIPTION
filter is no longer declared on Iterable.
This is to degrade the Type of a Iterable to any. Mainly to allow following:
```javascript
function foo(): List<number> {
   return List([undefined, 1, 2]).filter(i => i); //List no longer contains undefined. Without degrade to generic List it would error.
}
```
flatten is also declared on each Class to return the "correct" type. Before Iterable was returned. This results in missing chaining.
```javascript
List().flatten().map() // Errored before as map is not defined on Iterable
```
get no longer returns ?T but T.
Technically it is not correct, but it allows common use cases and is in sync with the typescript libdef.

Also fixed bugs with get introducing undefined into the Type of a Iterable. (Ordering of overloaded function declarations is important)