### PR TITLE
Update Immutable example console version to 3.8.1

### DIFF
--- a/pages/src/docs/index.html
+++ b/pages/src/docs/index.html
@@ -12,7 +12,7 @@
   <body>
     <!-- React(./src/index.js) -->
     <script src="//cdn.jsdelivr.net/react/0.12.1/react-with-addons.min.js"></script>
-    <script src="//cdn.jsdelivr.net/immutable.js/3.7.6/immutable.min.js"></script>
+    <script src="//cdn.jsdelivr.net/immutable.js/3.8.1/immutable.min.js"></script>
     <script src="bundle.js"></script>
     <!-- ReactRender() -->
     <script>

--- a/pages/src/index.html
+++ b/pages/src/index.html
@@ -14,7 +14,7 @@
     <script src="//cdn.jsdelivr.net/react/0.12.1/react-with-addons.min.js"></script>
     <script src="bundle.js"></script>
     <!-- ReactRender() -->
-    <script src="//cdn.jsdelivr.net/immutable.js/3.7.6/immutable.min.js"></script>
+    <script src="//cdn.jsdelivr.net/immutable.js/3.8.1/immutable.min.js"></script>
     <script>
       //<![CDATA[
       console.log(


### PR DESCRIPTION
I wanted to try the changes with the new version quickly, but saw that in the console it was still running the 3.7.6 version.

Not sure if there is something else to change, and everything was working fine locally.
