### PR TITLE
Use latest version of Immutable in docs

### DIFF
--- a/pages/src/docs/index.html
+++ b/pages/src/docs/index.html
@@ -12,7 +12,7 @@
   <body>
     <!-- React(./src/index.js) -->
     <script src="//cdn.jsdelivr.net/react/0.12.1/react-with-addons.min.js"></script>
-    <script src="//cdn.jsdelivr.net/immutable.js/3.8.1/immutable.min.js"></script>
+    <script src="//cdn.jsdelivr.net/immutable.js/latest/immutable.min.js"></script>
     <script src="bundle.js"></script>
     <!-- ReactRender() -->
     <script>

--- a/pages/src/index.html
+++ b/pages/src/index.html
@@ -14,7 +14,7 @@
     <script src="//cdn.jsdelivr.net/react/0.12.1/react-with-addons.min.js"></script>
     <script src="bundle.js"></script>
     <!-- ReactRender() -->
-    <script src="//cdn.jsdelivr.net/immutable.js/3.8.1/immutable.min.js"></script>
+    <script src="//cdn.jsdelivr.net/immutable.js/latest/immutable.min.js"></script>
     <script>
       //<![CDATA[
       console.log(


### PR DESCRIPTION
I got a bit confused seeing `Immutable.Map.of()` was not available in the console until I realised the docs had a previous version of Immutable.
