### PR TITLE
Fix flow nullable type definitions

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -79,69 +79,69 @@ declare class _Iterable<K, V, KI, II, SI> {
   entrySeq(): IndexedSeq<[K,V]>;
 
   reverse(): this;
-  sort(comparator?: (valueA: V, valueB: V) => number): this;
+  sort(comparator: ?(valueA: V, valueB: V) => number): this;
 
   sortBy<C>(
     comparatorValueMapper: (value: V, key: K, iter: this) => C,
-    comparator?: (valueA: C, valueB: C) => number
+    comparator: ?(valueA: C, valueB: C) => number
   ): this;
 
   groupBy<G>(
     grouper: (value: V, key: K, iter: this) => G,
-    context?: any
+    context: ?any
   ): KeyedSeq<G, this>;
 
   forEach(
     sideEffect: (value: V, key: K, iter: this) => any,
-    context?: any
+    context: ?any
   ): number;
 
-  slice(begin?: number, end?: number): this;
+  slice(begin: ?number, end: ?number): this;
   rest(): this;
   butLast(): this;
   skip(amount: number): this;
   skipLast(amount: number): this;
-  skipWhile(predicate: (value: V, key: K, iter: this) => mixed, context?: any): this;
-  skipUntil(predicate: (value: V, key: K, iter: this) => mixed, context?: any): this;
+  skipWhile(predicate: (value: V, key: K, iter: this) => mixed, context: ?any): this;
+  skipUntil(predicate: (value: V, key: K, iter: this) => mixed, context: ?any): this;
   take(amount: number): this;
   takeLast(amount: number): this;
-  takeWhile(predicate: (value: V, key: K, iter: this) => mixed, context?: any): this;
-  takeUntil(predicate: (value: V, key: K, iter: this) => mixed, context?: any): this;
-  flatten(depth?: number): /*this*/Iterable<any,any>;
-  flatten(shallow?: boolean): /*this*/Iterable<any,any>;
+  takeWhile(predicate: (value: V, key: K, iter: this) => mixed, context: ?any): this;
+  takeUntil(predicate: (value: V, key: K, iter: this) => mixed, context: ?any): this;
+  flatten(depth: ?number): /*this*/Iterable<any,any>;
+  flatten(shallow: ?boolean): /*this*/Iterable<any,any>;
 
   filter(
     predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any
+    context: ?any
   ): this;
 
   filterNot(
     predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any
+    context: ?any
   ): this;
 
   reduce<R>(
     reducer: (reduction: R, value: V, key: K, iter: this) => R,
-    initialReduction?: R,
-    context?: any,
+    initialReduction: ?R,
+    context: ?any,
   ): R;
 
   reduceRight<R>(
     reducer: (reduction: R, value: V, key: K, iter: this) => R,
-    initialReduction?: R,
-    context?: any,
+    initialReduction: ?R,
+    context: ?any,
   ): R;
 
-  every(predicate: (value: V, key: K, iter: this) => mixed, context?: any): boolean;
-  some(predicate: (value: V, key: K, iter: this) => mixed, context?: any): boolean;
-  join(separator?: string): string;
+  every(predicate: (value: V, key: K, iter: this) => mixed, context: ?any): boolean;
+  some(predicate: (value: V, key: K, iter: this) => mixed, context: ?any): boolean;
+  join(separator: ?string): string;
   isEmpty(): boolean;
-  count(predicate?: (value: V, key: K, iter: this) => mixed, context?: any): number;
-  countBy<G>(grouper: (value: V, key: K, iter: this) => G, context?: any): Map<G,number>;
+  count(predicate: ?(value: V, key: K, iter: this) => mixed, context: ?any): number;
+  countBy<G>(grouper: (value: V, key: K, iter: this) => G, context: ?any): Map<G,number>;
 
   find(
     predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any,
+    context: ?any,
   ): ?V;
   find<V_>(
     predicate: (value: V, key: K, iter: this) => mixed,
@@ -151,7 +151,7 @@ declare class _Iterable<K, V, KI, II, SI> {
 
   findLast(
     predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any,
+    context: ?any,
   ): ?V;
   findLast<V_>(
     predicate: (value: V, key: K, iter: this) => mixed,
@@ -163,21 +163,21 @@ declare class _Iterable<K, V, KI, II, SI> {
   findEntry(predicate: (value: V, key: K, iter: this) => mixed): ?[K,V];
   findLastEntry(predicate: (value: V, key: K, iter: this) => mixed): ?[K,V];
 
-  findKey(predicate: (value: V, key: K, iter: this) => mixed, context?: any): ?K;
-  findLastKey(predicate: (value: V, key: K, iter: this) => mixed, context?: any): ?K;
+  findKey(predicate: (value: V, key: K, iter: this) => mixed, context: ?any): ?K;
+  findLastKey(predicate: (value: V, key: K, iter: this) => mixed, context: ?any): ?K;
 
   keyOf(searchValue: V): ?K;
   lastKeyOf(searchValue: V): ?K;
 
-  max(comparator?: (valueA: V, valueB: V) => number): V;
+  max(comparator: ?(valueA: V, valueB: V) => number): V;
   maxBy<C>(
     comparatorValueMapper: (value: V, key: K, iter: this) => C,
-    comparator?: (valueA: C, valueB: C) => number
+    comparator: ?(valueA: C, valueB: C) => number
   ): V;
-  min(comparator?: (valueA: V, valueB: V) => number): V;
+  min(comparator: ?(valueA: V, valueB: V) => number): V;
   minBy<C>(
     comparatorValueMapper: (value: V, key: K, iter: this) => C,
-    comparator?: (valueA: C, valueB: C) => number
+    comparator: ?(valueA: C, valueB: C) => number
   ): V;
 
   isSubset(iter: Iterable<any, V>): boolean;
@@ -187,8 +187,8 @@ declare class _Iterable<K, V, KI, II, SI> {
 }
 
 declare class KeyedIterable<K,V> extends Iterable<K,V> {
-  static <K,V>(iter?: ESIterable<[K,V]>): KeyedIterable<K,V>;
-  static <K,V>(obj?: { [key: K]: V }): KeyedIterable<K,V>;
+  static <K,V>(iter: ?ESIterable<[K,V]>): KeyedIterable<K,V>;
+  static <K,V>(obj: ?{ [key: K]: V }): KeyedIterable<K,V>;
 
   @@iterator(): Iterator<[K,V]>;
   toSeq(): KeyedSeq<K,V>;
@@ -196,32 +196,32 @@ declare class KeyedIterable<K,V> extends Iterable<K,V> {
 
   mapKeys<K_>(
     mapper: (key: K, value: V, iter: this) => K_,
-    context?: any
+    context: ?any
   ): /*this*/KeyedIterable<K_,V>;
 
   mapEntries<K_,V_>(
     mapper: (entry: [K,V], index: number, iter: this) => [K_,V_],
-    context?: any
+    context: ?any
   ): /*this*/KeyedIterable<K_,V_>;
 
   concat(...iters: ESIterable<[K,V]>[]): this;
 
   map<V_>(
     mapper: (value: V, key: K, iter: this) => V_,
-    context?: any
+    context: ?any
   ): /*this*/KeyedIterable<K,V_>;
 
   flatMap<K_, V_>(
     mapper: (value: V, key: K, iter: this) => ESIterable<[K_,V_]>,
-    context?: any
+    context: ?any
   ): /*this*/KeyedIterable<K_,V_>;
 
-  flatten(depth?: number): /*this*/KeyedIterable<any,any>;
-  flatten(shallow?: boolean): /*this*/KeyedIterable<any,any>;
+  flatten(depth: ?number): /*this*/KeyedIterable<any,any>;
+  flatten(shallow: ?boolean): /*this*/KeyedIterable<any,any>;
 }
 
 declare class IndexedIterable<T> extends Iterable<number,T> {
-  static <T>(iter?: ESIterable<T>): IndexedIterable<T>;
+  static <T>(iter: ?ESIterable<T>): IndexedIterable<T>;
 
   @@iterator(): Iterator<T>;
   toSeq(): IndexedSeq<T>;
@@ -236,25 +236,25 @@ declare class IndexedIterable<T> extends Iterable<number,T> {
 
   zip<A>(
     a: ESIterable<A>,
-    $?: null
+    $: ?null
   ): IndexedIterable<[T,A]>;
   zip<A,B>(
     a: ESIterable<A>,
     b: ESIterable<B>,
-    $?: null
+    $: ?null
   ): IndexedIterable<[T,A,B]>;
   zip<A,B,C>(
     a: ESIterable<A>,
     b: ESIterable<B>,
     c: ESIterable<C>,
-    $?: null
+    $: ?null
   ): IndexedIterable<[T,A,B,C]>;
   zip<A,B,C,D>(
     a: ESIterable<A>,
     b: ESIterable<B>,
     c: ESIterable<C>,
     d: ESIterable<D>,
-    $?: null
+    $: ?null
   ): IndexedIterable<[T,A,B,C,D]>;
   zip<A,B,C,D,E>(
     a: ESIterable<A>,
@@ -262,26 +262,26 @@ declare class IndexedIterable<T> extends Iterable<number,T> {
     c: ESIterable<C>,
     d: ESIterable<D>,
     e: ESIterable<E>,
-    $?: null
+    $: ?null
   ): IndexedIterable<[T,A,B,C,D,E]>;
 
   zipWith<A,R>(
     zipper: (value: T, a: A) => R,
     a: ESIterable<A>,
-    $?: null
+    $: ?null
   ): IndexedIterable<R>;
   zipWith<A,B,R>(
     zipper: (value: T, a: A, b: B) => R,
     a: ESIterable<A>,
     b: ESIterable<B>,
-    $?: null
+    $: ?null
   ): IndexedIterable<R>;
   zipWith<A,B,C,R>(
     zipper: (value: T, a: A, b: B, c: C) => R,
     a: ESIterable<A>,
     b: ESIterable<B>,
     c: ESIterable<C>,
-    $?: null
+    $: ?null
   ): IndexedIterable<R>;
   zipWith<A,B,C,D,R>(
     zipper: (value: T, a: A, b: B, c: C, d: D) => R,
@@ -289,7 +289,7 @@ declare class IndexedIterable<T> extends Iterable<number,T> {
     b: ESIterable<B>,
     c: ESIterable<C>,
     d: ESIterable<D>,
-    $?: null
+    $: ?null
   ): IndexedIterable<R>;
   zipWith<A,B,C,D,E,R>(
     zipper: (value: T, a: A, b: B, c: C, d: D, e: E) => R,
@@ -298,38 +298,38 @@ declare class IndexedIterable<T> extends Iterable<number,T> {
     c: ESIterable<C>,
     d: ESIterable<D>,
     e: ESIterable<E>,
-    $?: null
+    $: ?null
   ): IndexedIterable<R>;
 
   indexOf(searchValue: T): number;
   lastIndexOf(searchValue: T): number;
   findIndex(
     predicate: (value: T, index: number, iter: this) => mixed,
-    context?: any
+    context: ?any
   ): number;
   findLastIndex(
     predicate: (value: T, index: number, iter: this) => mixed,
-    context?: any
+    context: ?any
   ): number;
 
   concat(...iters: ESIterable<T>[]): this;
 
   map<U>(
     mapper: (value: T, index: number, iter: this) => U,
-    context?: any
+    context: ?any
   ): /*this*/IndexedIterable<U>;
 
   flatMap<U>(
     mapper: (value: T, index: number, iter: this) => ESIterable<U>,
-    context?: any
+    context: ?any
   ): /*this*/IndexedIterable<U>;
 
-  flatten(depth?: number): /*this*/IndexedIterable<any>;
-  flatten(shallow?: boolean): /*this*/IndexedIterable<any>;
+  flatten(depth: ?number): /*this*/IndexedIterable<any>;
+  flatten(shallow: ?boolean): /*this*/IndexedIterable<any>;
 }
 
 declare class SetIterable<T> extends Iterable<T,T> {
-  static <T>(iter?: ESIterable<T>): SetIterable<T>;
+  static <T>(iter: ?ESIterable<T>): SetIterable<T>;
 
   @@iterator(): Iterator<T>;
   toSeq(): SetSeq<T>;
@@ -342,16 +342,16 @@ declare class SetIterable<T> extends Iterable<T,T> {
   // and key types *must* match.
   map<U>(
     mapper: (value: T, value: T, iter: this) => U,
-    context?: any
+    context: ?any
   ): /*this*/SetIterable<U>;
 
   flatMap<U>(
     mapper: (value: T, value: T, iter: this) => ESIterable<U>,
-    context?: any
+    context: ?any
   ): /*this*/SetIterable<U>;
 
-  flatten(depth?: number): /*this*/SetIterable<any>;
-  flatten(shallow?: boolean): /*this*/SetIterable<any>;
+  flatten(depth: ?number): /*this*/SetIterable<any>;
+  flatten(shallow: ?boolean): /*this*/SetIterable<any>;
 }
 
 declare class Collection<K,V> extends _Iterable<K,V, typeof KeyedCollection, typeof IndexedCollection, typeof SetCollection> {
@@ -373,7 +373,7 @@ declare class SetCollection<T> extends Collection<T,T> mixins SetIterable<T> {
 declare class Seq<K,V> extends _Iterable<K,V, typeof KeyedSeq, typeof IndexedSeq, typeof SetSeq> {
   static <K,V>(iter: KeyedSeq<K,V>):   KeyedSeq<K,V>;
   static <T>  (iter: SetSeq<T>):       SetSeq<K,V>;
-  static <T>  (iter?: ESIterable<T>):  IndexedSeq<T>;
+  static <T>  (iter: ?ESIterable<T>):  IndexedSeq<T>;
   static <K,V>(iter: { [key: K]: V }): KeyedSeq<K,V>;
 
   static isSeq(maybeSeq: any): boolean;
@@ -385,22 +385,22 @@ declare class Seq<K,V> extends _Iterable<K,V, typeof KeyedSeq, typeof IndexedSeq
 }
 
 declare class KeyedSeq<K,V> extends Seq<K,V> mixins KeyedIterable<K,V> {
-  static <K,V>(iter?: ESIterable<[K,V]>): KeyedSeq<K,V>;
-  static <K,V>(iter?: { [key: K]: V }): KeyedSeq<K,V>;
+  static <K,V>(iter: ?ESIterable<[K,V]>): KeyedSeq<K,V>;
+  static <K,V>(iter: ?{ [key: K]: V }): KeyedSeq<K,V>;
 }
 
 declare class IndexedSeq<T> extends Seq<number,T> mixins IndexedIterable<T> {
-  static <T>(iter?: ESIterable<T>): IndexedSeq<T>;
+  static <T>(iter: ?ESIterable<T>): IndexedSeq<T>;
   static of<T>(...values: T[]): IndexedSeq<T>;
 }
 
 declare class SetSeq<T> extends Seq<T,T> mixins SetIterable<T> {
-  static <T>(iter?: ESIterable<T>): IndexedSeq<T>;
+  static <T>(iter: ?ESIterable<T>): IndexedSeq<T>;
   static of<T>(...values: T[]): SetSeq<T>;
 }
 
 declare class List<T> extends IndexedCollection<T> {
-  static (iterable?: ESIterable<T>): List<T>;
+  static (iterable: ?ESIterable<T>): List<T>;
 
   static isList(maybeList: any): boolean;
   static of<T>(...values: T[]): List<T>;
@@ -451,22 +451,22 @@ declare class List<T> extends IndexedCollection<T> {
   // Overrides that specialize return types
   map<M>(
     mapper: (value: T, index: number, iter: this) => M,
-    context?: any
+    context: ?any
   ): List<M>;
 
   flatMap<M>(
     mapper: (value: T, index: number, iter: this) => ESIterable<M>,
-    context?: any
+    context: ?any
   ): List<M>;
 
-  flatten(depth?: number): /*this*/List<any>;
-  flatten(shallow?: boolean): /*this*/List<any>;
+  flatten(depth: ?number): /*this*/List<any>;
+  flatten(shallow: ?boolean): /*this*/List<any>;
 }
 
 declare class Map<K,V> extends KeyedCollection<K,V> {
   static <K, V>(): Map<K, V>;
-  static <V>(obj?: {[key: string]: V}): Map<string, V>;
-  static <K, V>(iterable?: ESIterable<[K,V]>): Map<K, V>;
+  static <V>(obj: ?{[key: string]: V}): Map<string, V>;
+  static <K, V>(iterable: ?ESIterable<[K,V]>): Map<K, V>;
 
   static isMap(maybeMap: any): boolean;
 
@@ -515,23 +515,23 @@ declare class Map<K,V> extends KeyedCollection<K,V> {
 
   map<V_>(
     mapper: (value: V, key: K, iter: this) => V_,
-    context?: any
+    context: ?any
   ): Map<K,V_>;
 
   flatMap<K_,V_>(
     mapper: (value: V, key: K, iter: this) => ESIterable<[K_,V_]>,
-    context?: any
+    context: ?any
   ): Map<K_,V_>;
 
   flip(): Map<V,K>;
 
   mapKeys<K_>(
     mapper: (key: K, value: V, iter: this) => K_,
-    context?: any
+    context: ?any
   ): Map<K_,V>;
 
-  flatten(depth?: number): /*this*/Map<any,any>;
-  flatten(shallow?: boolean): /*this*/Map<any,any>;
+  flatten(depth: ?number): /*this*/Map<any,any>;
+  flatten(shallow: ?boolean): /*this*/Map<any,any>;
 }
 
 // OrderedMaps have nothing that Maps do not have. We do not need to override constructor & other statics
@@ -540,7 +540,7 @@ declare class OrderedMap<K,V> extends Map<K,V> {
 }
 
 declare class Set<T> extends SetCollection<T> {
-  static <T>(iterable?: ESIterable<T>): Set<T>;
+  static <T>(iterable: ?ESIterable<T>): Set<T>;
 
   static isSet(maybeSet: any): boolean;
   static of<T>(...values: T[]): Set<T>;
@@ -564,16 +564,16 @@ declare class Set<T> extends SetCollection<T> {
 
   map<M>(
     mapper: (value: T, value: T, iter: this) => M,
-    context?: any
+    context: ?any
   ): Set<M>;
 
   flatMap<M>(
     mapper: (value: T, value: T, iter: this) => ESIterable<M>,
-    context?: any
+    context: ?any
   ): Set<M>;
 
-  flatten(depth?: number): /*this*/Set<any>;
-  flatten(shallow?: boolean): /*this*/Set<any>;
+  flatten(depth: ?number): /*this*/Set<any>;
+  flatten(shallow: ?boolean): /*this*/Set<any>;
 }
 
 // OrderedSets have nothing that Sets do not have. We do not need to override constructor & other statics
@@ -582,7 +582,7 @@ declare class OrderedSet<T> extends Set<T> {
 }
 
 declare class Stack<T> extends IndexedCollection<T> {
-  static <T>(iterable?: ESIterable<T>): Stack<T>;
+  static <T>(iterable: ?ESIterable<T>): Stack<T>;
 
   static isStack(maybeStack: any): boolean;
   static of<T>(...values: T[]): Stack<T>;
@@ -604,31 +604,31 @@ declare class Stack<T> extends IndexedCollection<T> {
 
   map<U>(
     mapper: (value: T, index: number, iter: this) => U,
-    context?: any
+    context: ?any
   ): Stack<U>;
 
   flatMap<U>(
     mapper: (value: T, index: number, iter: this) => ESIterable<U>,
-    context?: any
+    context: ?any
   ): Stack<U>;
 
-  flatten(depth?: number): /*this*/Stack<any>;
-  flatten(shallow?: boolean): /*this*/Stack<any>;
+  flatten(depth: ?number): /*this*/Stack<any>;
+  flatten(shallow: ?boolean): /*this*/Stack<any>;
 }
 
-declare function Range(start?: number, end?: number, step?: number): IndexedSeq<number>;
-declare function Repeat<T>(value: T, times?: number): IndexedSeq<T>;
+declare function Range(start: ? number, end: ? number, step: ?number): IndexedSeq<number>;
+declare function Repeat<T>(value: T, times: ?number): IndexedSeq<T>;
 
 //TODO: Once flow can extend normal Objects we can change this back to actually reflect Record behavior.
 // For now fallback to any to not break existing Code
 declare class Record<T: Object> {
-  static <T: Object>(spec: T, name?: string): /*T & Record<T>*/any;
+  static <T: Object>(spec: T, name: ?string): /*T & Record<T>*/any;
   get<A>(key: $Keys<T>): A;
   set<A>(key: $Keys<T>, value: A): /*T & Record<T>*/this;
   remove(key: $Keys<T>): /*T & Record<T>*/this;
 }
 
-declare function fromJS(json: any, reviver?: (k: any, v: Iterable<any,any>) => any): any;
+declare function fromJS(json: any, reviver: ?(k: any, v: Iterable<any,any>) => any): any;
 declare function is(first: any, second: any): boolean;
 
 export {


### PR DESCRIPTION
Flow uses parameter: ?type for nullable types (instead of parameter? :type as used before.
I came across the warning when checking react-native
(react-native/Libraries/CustomComponents/Navigator/Navigation/NavigationRouteStack.js:121)
and slice was passed a nullable value which resulted in errors.
