### PR TITLE
Website fixup: don't overlap the footer with sidebar

### DIFF
--- a/pages/src/docs/src/style.less
+++ b/pages/src/docs/src/style.less
@@ -19,6 +19,8 @@
   padding: 1em;
   text-align: center;
   font-size: 0.8em;
+  position: relative;
+  z-index: 1;
 }
 
 @media only screen and (max-width: 680px) {


### PR DESCRIPTION
Now you can't click `issues` link because of overlapping.
<img width="673" alt="screen shot 2016-05-12 at 15 09 23" src="https://cloud.githubusercontent.com/assets/492261/15215619/b0bff3c0-1853-11e6-909e-ee1c3dc8fdcb.png">

Fixed by adding `z-index` property to the footer with a value bigger then the sidebar has.
