### PR TITLE
Flow type declarations test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
-node_js: stable
+node_js:
+    - '6'
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ env:
     - CXX=g++-4.9
     - secure: "VDsxy30sE9ivdqoXkaKXo0czbS4brNpwKEIblu7f1gVLx7OD9pjTc78cdwrVbZDBYroSiYVYuUrLDjpVjH88lL/LxRrru3V0CIlAqqa+ssXcqycCaT/6ds+ZymuTTGRh+Mf12pIKO+yc8jTov2M7AzPJdpS+ORP5dImYyE3ex9s="
 
-script: ./test_type_defs.sh
-
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
     - CXX=g++-4.9
     - secure: "VDsxy30sE9ivdqoXkaKXo0czbS4brNpwKEIblu7f1gVLx7OD9pjTc78cdwrVbZDBYroSiYVYuUrLDjpVjH88lL/LxRrru3V0CIlAqqa+ssXcqycCaT/6ds+ZymuTTGRh+Mf12pIKO+yc8jTov2M7AzPJdpS+ORP5dImYyE3ex9s="
 
+script: ./test_type_defs.sh
+
 addons:
   apt:
     sources:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "build": "grunt default && gulp default",
     "lint": "eslint src/ && grunt lint && gulp lint",
     "testonly": "./resources/node_test.sh",
-    "test": "npm run lint && npm run testonly",
+    "test": "npm run lint && npm run testonly && npm run type-check",
+    "type-check": "cd type-definitions/tests && flow check",
     "perf": "node ./resources/bench.js",
     "start": "npm run build && node ./pages/resources/start.js",
     "deploy": "(cd ./pages/out && git init && git config user.name \"Travis CI\" && git config user.email \"github@fb.com\" && git add . && git commit -m \"Deploy to GitHub Pages\" && git push --force --quiet \"https://${GH_TOKEN}@github.com/facebook/immutable-js.git\" master:gh-pages > /dev/null 2>1)"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "estraverse": "1.9.3",
     "express": "^4.13.4",
     "fbjs-scripts": "^0.5.0",
+    "flow-bin": "^0.36.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "0.7.0",

--- a/test_type_defs.sh
+++ b/test_type_defs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -o errexit
+
+npm install
+cd type-definitions/tests
+../../node_modules/flow-bin/cli.js
+

--- a/test_type_defs.sh
+++ b/test_type_defs.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -o errexit
-
-npm install
-cd type-definitions/tests
-../../node_modules/flow-bin/cli.js
-

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -27,7 +27,28 @@
  *
  * Note that Immutable values implement the `ESIterable` interface.
  */
-type ESIterable<T> = $Iterable<T,void,void>;
+
+type IteratorResult<Yield,Return> = {
+  done: true,
+  value?: Return,
+} | {
+  done: false,
+  value: Yield,
+};
+
+
+interface _Iterator<Yield,Return,Next> {
+    @@iterator(): _Iterator<Yield,Return,Next>;
+    next(value?: Next): IteratorResult<Yield,Return>;
+}
+
+
+interface _ESIterable<Yield,Return,Next> {
+    @@iterator(): _Iterator<Yield,Return,Next>;
+}
+
+type Iterator<T> = _Iterator<T, void, void>
+type ESIterable<T> = _ESIterable<T,void,void>;
 
 declare class Iterable<K, V> extends _Iterable<K, V, typeof KeyedIterable, typeof IndexedIterable, typeof SetIterable> {}
 

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -639,8 +639,8 @@ declare module 'immutable' {
   declare function Range(start?: number, end?: number, step?: number): IndexedSeq<number>;
   declare function Repeat<T>(value: T, times?: number): IndexedSeq<T>;
 
-  //TODO: Once flow can extend normal Objects we can change this back to actually reflect Record behavior.
-  // For now fallback to any to not break existing Code
+  // TODO: Once flow can extend normal Objects we can change this back to actually reflect Record behavior.
+  // For now fallback to any to not break existing code
   declare class Record<T: Object> {
     static <T: Object>(spec: T, name?: string): /*T & Record<T>*/any;
     get<A>(key: $Keys<T>): A;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -485,9 +485,8 @@ declare class List<T> extends IndexedCollection<T> {
 }
 
 declare class Map<K,V> extends KeyedCollection<K,V> {
-  static <K,V>(_: void): Map<K,V>;
-  static <V>(obj?: {[key: string]: V}): Map<string, V>;
-  static <K, V>(iterable?: ESIterable<[K,V]>): Map<K, V>;
+  static <K, V>(obj?: {[key: K]: V}): Map<K, V>;
+  static <K, V>(iterable: ESIterable<[K,V]>): Map<K, V>;
 
   static isMap(maybeMap: any): boolean;
 
@@ -561,12 +560,12 @@ declare class OrderedMap<K,V> extends Map<K,V> {
 }
 
 declare class Set<T> extends SetCollection<T> {
-  static <T>(iterable?: ESIterable<T>): Set<T>;
-
+  static <T>(iterable: ESIterable<T>): Set<T>;  
   static isSet(maybeSet: any): boolean;
   static of<T>(...values: T[]): Set<T>;
   static fromKeys<T>(iter: ESIterable<[T,any]>): Set<T>;
-  static fromKeys(iter: { [key: string]: any }): Set<string>;
+  static fromKeys<K>(object: { [key: K]: V }): Set<K>;
+  static (_: void): Set<any>;      
 
   add<U>(value: U): Set<T|U>;
   delete(value: T): this;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -21,663 +21,634 @@
  * @flow
  */
 
-/*
- * Alias for ECMAScript `Iterable` type, declared in
- * https://github.com/facebook/flow/blob/master/lib/core.js
- *
- * Note that Immutable values implement the `ESIterable` interface.
- */
+ /*
+  * Alias for ECMAScript `Iterable` type, declared in
+  * https://github.com/facebook/flow/blob/master/lib/core.js
+  *
+  * Note that Immutable values implement the `ESIterable` interface.
+  */
 
 type IteratorResult<Yield,Return> = {
-  done: true,
-  value?: Return,
+ done: true,
+ value?: Return,
 } | {
-  done: false,
-  value: Yield,
+ done: false,
+ value: Yield,
 };
 
 
 interface _Iterator<Yield,Return,Next> {
-    @@iterator(): _Iterator<Yield,Return,Next>;
-    next(value?: Next): IteratorResult<Yield,Return>;
+   @@iterator(): _Iterator<Yield,Return,Next>;
+   next(value?: Next): IteratorResult<Yield,Return>;
 }
 
 
 interface _ESIterable<Yield,Return,Next> {
-    @@iterator(): _Iterator<Yield,Return,Next>;
+   @@iterator(): _Iterator<Yield,Return,Next>;
 }
 
 type Iterator<T> = _Iterator<T, void, void>
 type ESIterable<T> = _ESIterable<T,void,void>;
 
-declare class Iterable<K, V> extends _Iterable<K, V, typeof KeyedIterable, typeof IndexedIterable, typeof SetIterable> {}
-
-declare class _Iterable<K, V, KI, II, SI> {
-  static Keyed:   KI;
-  static Indexed: II;
-  static Set:     SI;
-
-  static isIterable(maybeIterable: any): boolean;
-  static isKeyed(maybeKeyed: any): boolean;
-  static isIndexed(maybeIndexed: any): boolean;
-  static isAssociative(maybeAssociative: any): boolean;
-  static isOrdered(maybeOrdered: any): boolean;
-
-  equals(other: Iterable<K,V>): boolean;
-  hashCode(): number;
-  get(key: K): V;
-  get<V_>(key: K, notSetValue: V_): V|V_;
-  has(key: K): boolean;
-  includes(value: V): boolean;
-  contains(value: V): boolean;
-  first(): V;
-  last(): V;
-
-  getIn<T>(searchKeyPath: ESIterable<any>, notSetValue: T): T;
-  getIn<T>(searchKeyPath: ESIterable<any>): T;
-  hasIn(searchKeyPath: ESIterable<any>): boolean;
-
-  toJS(): any;
-  toArray(): V[];
-  toObject(): { [key: string]: V };
-  toMap(): Map<K,V>;
-  toOrderedMap(): Map<K,V>;
-  toSet(): Set<V>;
-  toOrderedSet(): Set<V>;
-  toList(): List<V>;
-  toStack(): Stack<V>;
-  toSeq(): Seq<K,V>;
-  toKeyedSeq(): KeyedSeq<K,V>;
-  toIndexedSeq(): IndexedSeq<V>;
-  toSetSeq(): SetSeq<V>;
-
-  keys(): Iterator<K>;
-  values(): Iterator<V>;
-  entries(): Iterator<[K,V]>;
-
-  keySeq(): IndexedSeq<K>;
-  valueSeq(): IndexedSeq<V>;
-  entrySeq(): IndexedSeq<[K,V]>;
-
-  reverse(): this;
-  sort(comparator?: (valueA: V, valueB: V) => number): this;
-
-  sortBy<C>(
-    comparatorValueMapper: (value: V, key: K, iter: this) => C,
-    comparator?: (valueA: C, valueB: C) => number
-  ): this;
-
-  groupBy<G>(
-    grouper: (value: V, key: K, iter: this) => G,
-    context?: any
-  ): KeyedSeq<G, this>;
-
-  forEach(
-    sideEffect: (value: V, key: K, iter: this) => any,
-    context?: any
-  ): number;
-
-  slice(begin?: number, end?: number): this;
-  rest(): this;
-  butLast(): this;
-  skip(amount: number): this;
-  skipLast(amount: number): this;
-  skipWhile(predicate: (value: V, key: K, iter: this) => mixed, context?: any): this;
-  skipUntil(predicate: (value: V, key: K, iter: this) => mixed, context?: any): this;
-  take(amount: number): this;
-  takeLast(amount: number): this;
-  takeWhile(predicate: (value: V, key: K, iter: this) => mixed, context?: any): this;
-  takeUntil(predicate: (value: V, key: K, iter: this) => mixed, context?: any): this;
-  flatten(depth?: number): /*this*/Iterable<any,any>;
-  flatten(shallow?: boolean): /*this*/Iterable<any,any>;
-
-  filter(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any
-  ): this;
-
-  filterNot(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any
-  ): this;
-
-  reduce<R>(
-    reducer: (reduction: R, value: V, key: K, iter: this) => R,
-    initialReduction?: R,
-    context?: any,
-  ): R;
-
-  reduceRight<R>(
-    reducer: (reduction: R, value: V, key: K, iter: this) => R,
-    initialReduction?: R,
-    context?: any,
-  ): R;
-
-  every(predicate: (value: V, key: K, iter: this) => mixed, context?: any): boolean;
-  some(predicate: (value: V, key: K, iter: this) => mixed, context?: any): boolean;
-  join(separator?: string): string;
-  isEmpty(): boolean;
-  count(predicate?: (value: V, key: K, iter: this) => mixed, context?: any): number;
-  countBy<G>(grouper: (value: V, key: K, iter: this) => G, context?: any): Map<G,number>;
-
-  find(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any,
-  ): ?V;
-  find<V_>(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context: any,
-    notSetValue: V_
-  ): V|V_;
-
-  findLast(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context?: any,
-  ): ?V;
-  findLast<V_>(
-    predicate: (value: V, key: K, iter: this) => mixed,
-    context: any,
-    notSetValue: V_
-  ): V|V_;
-
-
-  findEntry(predicate: (value: V, key: K, iter: this) => mixed): ?[K,V];
-  findLastEntry(predicate: (value: V, key: K, iter: this) => mixed): ?[K,V];
-
-  findKey(predicate: (value: V, key: K, iter: this) => mixed, context?: any): ?K;
-  findLastKey(predicate: (value: V, key: K, iter: this) => mixed, context?: any): ?K;
-
-  keyOf(searchValue: V): ?K;
-  lastKeyOf(searchValue: V): ?K;
-
-  max(comparator?: (valueA: V, valueB: V) => number): V;
-  maxBy<C>(
-    comparatorValueMapper: (value: V, key: K, iter: this) => C,
-    comparator?: (valueA: C, valueB: C) => number
-  ): V;
-  min(comparator?: (valueA: V, valueB: V) => number): V;
-  minBy<C>(
-    comparatorValueMapper: (value: V, key: K, iter: this) => C,
-    comparator?: (valueA: C, valueB: C) => number
-  ): V;
-
-  isSubset(iter: Iterable<any, V>): boolean;
-  isSubset(iter: ESIterable<V>): boolean;
-  isSuperset(iter: Iterable<any, V>): boolean;
-  isSuperset(iter: ESIterable<V>): boolean;
-}
-
-declare class KeyedIterable<K,V> extends Iterable<K,V> {
-  static <K,V>(iter?: ESIterable<[K,V]>): KeyedIterable<K,V>;
-  static <K,V>(obj?: { [key: K]: V }): KeyedIterable<K,V>;
-
-  @@iterator(): Iterator<[K,V]>;
-  toSeq(): KeyedSeq<K,V>;
-  flip(): /*this*/KeyedIterable<V,K>;
-
-  mapKeys<K_>(
-    mapper: (key: K, value: V, iter: this) => K_,
-    context?: any
-  ): /*this*/KeyedIterable<K_,V>;
-
-  mapEntries<K_,V_>(
-    mapper: (entry: [K,V], index: number, iter: this) => [K_,V_],
-    context?: any
-  ): /*this*/KeyedIterable<K_,V_>;
-
-  concat(...iters: ESIterable<[K,V]>[]): this;
-
-  map<V_>(
-    mapper: (value: V, key: K, iter: this) => V_,
-    context?: any
-  ): /*this*/KeyedIterable<K,V_>;
-
-  flatMap<K_, V_>(
-    mapper: (value: V, key: K, iter: this) => ESIterable<[K_,V_]>,
-    context?: any
-  ): /*this*/KeyedIterable<K_,V_>;
-
-  flatten(depth?: number): /*this*/KeyedIterable<any,any>;
-  flatten(shallow?: boolean): /*this*/KeyedIterable<any,any>;
-}
-
-declare class IndexedIterable<T> extends Iterable<number,T> {
-  static <T>(iter?: ESIterable<T>): IndexedIterable<T>;
-
-  @@iterator(): Iterator<T>;
-  toSeq(): IndexedSeq<T>;
-  fromEntrySeq<K,V>(): KeyedSeq<K,V>;
-  interpose(separator: T): this;
-  interleave(...iterables: ESIterable<T>[]): this;
-  splice(
-    index: number,
-    removeNum: number,
-    ...values: T[]
-  ): this;
-
-  zip<A>(
-    a: ESIterable<A>,
-    $?: null
-  ): IndexedIterable<[T,A]>;
-  zip<A,B>(
-    a: ESIterable<A>,
-    b: ESIterable<B>,
-    $?: null
-  ): IndexedIterable<[T,A,B]>;
-  zip<A,B,C>(
-    a: ESIterable<A>,
-    b: ESIterable<B>,
-    c: ESIterable<C>,
-    $?: null
-  ): IndexedIterable<[T,A,B,C]>;
-  zip<A,B,C,D>(
-    a: ESIterable<A>,
-    b: ESIterable<B>,
-    c: ESIterable<C>,
-    d: ESIterable<D>,
-    $?: null
-  ): IndexedIterable<[T,A,B,C,D]>;
-  zip<A,B,C,D,E>(
-    a: ESIterable<A>,
-    b: ESIterable<B>,
-    c: ESIterable<C>,
-    d: ESIterable<D>,
-    e: ESIterable<E>,
-    $?: null
-  ): IndexedIterable<[T,A,B,C,D,E]>;
-
-  zipWith<A,R>(
-    zipper: (value: T, a: A) => R,
-    a: ESIterable<A>,
-    $?: null
-  ): IndexedIterable<R>;
-  zipWith<A,B,R>(
-    zipper: (value: T, a: A, b: B) => R,
-    a: ESIterable<A>,
-    b: ESIterable<B>,
-    $?: null
-  ): IndexedIterable<R>;
-  zipWith<A,B,C,R>(
-    zipper: (value: T, a: A, b: B, c: C) => R,
-    a: ESIterable<A>,
-    b: ESIterable<B>,
-    c: ESIterable<C>,
-    $?: null
-  ): IndexedIterable<R>;
-  zipWith<A,B,C,D,R>(
-    zipper: (value: T, a: A, b: B, c: C, d: D) => R,
-    a: ESIterable<A>,
-    b: ESIterable<B>,
-    c: ESIterable<C>,
-    d: ESIterable<D>,
-    $?: null
-  ): IndexedIterable<R>;
-  zipWith<A,B,C,D,E,R>(
-    zipper: (value: T, a: A, b: B, c: C, d: D, e: E) => R,
-    a: ESIterable<A>,
-    b: ESIterable<B>,
-    c: ESIterable<C>,
-    d: ESIterable<D>,
-    e: ESIterable<E>,
-    $?: null
-  ): IndexedIterable<R>;
-
-  indexOf(searchValue: T): number;
-  lastIndexOf(searchValue: T): number;
-  findIndex(
-    predicate: (value: T, index: number, iter: this) => mixed,
-    context?: any
-  ): number;
-  findLastIndex(
-    predicate: (value: T, index: number, iter: this) => mixed,
-    context?: any
-  ): number;
-
-  concat(...iters: ESIterable<T>[]): this;
-
-  map<U>(
-    mapper: (value: T, index: number, iter: this) => U,
-    context?: any
-  ): /*this*/IndexedIterable<U>;
-
-  flatMap<U>(
-    mapper: (value: T, index: number, iter: this) => ESIterable<U>,
-    context?: any
-  ): /*this*/IndexedIterable<U>;
-
-  flatten(depth?: number): /*this*/IndexedIterable<any>;
-  flatten(shallow?: boolean): /*this*/IndexedIterable<any>;
-}
-
-declare class SetIterable<T> extends Iterable<T,T> {
-  static <T>(iter?: ESIterable<T>): SetIterable<T>;
-
-  @@iterator(): Iterator<T>;
-  toSeq(): SetSeq<T>;
-
-  concat(...iters: ESIterable<T>[]): this;
-
-  // `map` and `flatMap` cannot be defined further up the hiearchy, because the
-  // implementation for `KeyedIterable` allows the value type to change without
-  // constraining the key type. That does not work for `SetIterable` - the value
-  // and key types *must* match.
-  map<U>(
-    mapper: (value: T, value: T, iter: this) => U,
-    context?: any
-  ): /*this*/SetIterable<U>;
-
-  flatMap<U>(
-    mapper: (value: T, value: T, iter: this) => ESIterable<U>,
-    context?: any
-  ): /*this*/SetIterable<U>;
-
-  flatten(depth?: number): /*this*/SetIterable<any>;
-  flatten(shallow?: boolean): /*this*/SetIterable<any>;
-}
-
-declare class Collection<K,V> extends _Iterable<K,V, typeof KeyedCollection, typeof IndexedCollection, typeof SetCollection> {
-  size: number;
-}
-
-declare class KeyedCollection<K,V> extends Collection<K,V> mixins KeyedIterable<K,V> {
-  toSeq(): KeyedSeq<K,V>;
-}
-
-declare class IndexedCollection<T> extends Collection<number,T> mixins IndexedIterable<T> {
-  toSeq(): IndexedSeq<T>;
-}
-
-declare class SetCollection<T> extends Collection<T,T> mixins SetIterable<T> {
-  toSeq(): SetSeq<T>;
-}
-
-declare class Seq<K,V> extends _Iterable<K,V, typeof KeyedSeq, typeof IndexedSeq, typeof SetSeq> {
-  static <K,V>(iter: KeyedSeq<K,V>):   KeyedSeq<K,V>;
-  static <T>  (iter: SetSeq<T>):       SetSeq<K,V>;
-  static <T>  (iter?: ESIterable<T>):  IndexedSeq<T>;
-  static <K,V>(iter: { [key: K]: V }): KeyedSeq<K,V>;
-
-  static isSeq(maybeSeq: any): boolean;
-  static of<T>(...values: T[]): IndexedSeq<T>;
-
-  size: ?number;
-  cacheResult(): this;
-  toSeq(): this;
-}
-
-declare class KeyedSeq<K,V> extends Seq<K,V> mixins KeyedIterable<K,V> {
-  static <K,V>(iter?: ESIterable<[K,V]>): KeyedSeq<K,V>;
-  static <K,V>(iter?: { [key: K]: V }): KeyedSeq<K,V>;
-}
-
-declare class IndexedSeq<T> extends Seq<number,T> mixins IndexedIterable<T> {
-  static <T>(iter?: ESIterable<T>): IndexedSeq<T>;
-  static of<T>(...values: T[]): IndexedSeq<T>;
-}
-
-declare class SetSeq<T> extends Seq<T,T> mixins SetIterable<T> {
-  static <T>(iter?: ESIterable<T>): IndexedSeq<T>;
-  static of<T>(...values: T[]): SetSeq<T>;
-}
-
-declare class List<T> extends IndexedCollection<T> {
-  static (iterable?: ESIterable<T>): List<T>;
-
-  static isList(maybeList: any): boolean;
-  static of<T>(...values: T[]): List<T>;
-
-  set<U>(index: number, value: U): List<T|U>;
-  delete(index: number): this;
-  remove(index: number): this;
-  insert<U>(index: number, value: U): List<T|U>;
-  clear(): this;
-  push<U>(...values: U[]): List<T|U>;
-  pop(): this;
-  unshift<U>(...values: U[]): List<T|U>;
-  shift(): this;
-
-  update<U>(updater: (value: this) => List<U>): List<U>;
-  update<U>(index: number, updater: (value: T) => U): List<T|U>;
-  update<U>(index: number, notSetValue: U, updater: (value: T) => U): List<T|U>;
-
-  merge<U>(...iterables: ESIterable<U>[]): List<T|U>;
-
-  mergeWith<U,V>(
-    merger: (previous: T, next: U, key: number) => V,
-    ...iterables: ESIterable<U>[]
-  ): List<T|U|V>;
-
-  mergeDeep<U>(...iterables: ESIterable<U>[]): List<T|U>;
-
-  mergeDeepWith<U,V>(
-    merger: (previous: T, next: U, key: number) => V,
-    ...iterables: ESIterable<U>[]
-  ): List<T|U|V>;
-
-  setSize(size: number): List<?T>;
-  setIn(keyPath: ESIterable<any>, value: any): List<T>;
-  deleteIn(keyPath: ESIterable<any>, value: any): this;
-  removeIn(keyPath: ESIterable<any>, value: any): this;
-
-  updateIn(keyPath: ESIterable<any>, notSetValue: any, value: any): List<T>;
-  updateIn(keyPath: ESIterable<any>, value: any): List<T>;
-
-  mergeIn(keyPath: ESIterable<any>, ...iterables: ESIterable<any>[]): List<T>;
-  mergeDeepIn(keyPath: ESIterable<any>, ...iterables: ESIterable<any>[]): List<T>;
-
-  withMutations(mutator: (mutable: this) => any): this;
-  asMutable(): this;
-  asImmutable(): this;
-
-  // Overrides that specialize return types
-  map<M>(
-    mapper: (value: T, index: number, iter: this) => M,
-    context?: any
-  ): List<M>;
-
-  flatMap<M>(
-    mapper: (value: T, index: number, iter: this) => ESIterable<M>,
-    context?: any
-  ): List<M>;
-
-  flatten(depth?: number): /*this*/List<any>;
-  flatten(shallow?: boolean): /*this*/List<any>;
-}
-
-declare class Map<K,V> extends KeyedCollection<K,V> {
-  static <K, V>(obj?: {[key: K]: V}): Map<K, V>;
-  static <K, V>(iterable: ESIterable<[K,V]>): Map<K, V>;
-
-  static isMap(maybeMap: any): boolean;
-
-  set<K_, V_>(key: K_, value: V_): Map<K|K_, V|V_>;
-  delete(key: K): this;
-  remove(key: K): this;
-  clear(): this;
-
-  update<K_,V_>(updater: (value: this) => Map<K_,V_>): Map<K_,V_>;
-  update<V_>(key: K, updater: (value: V) => V_): Map<K,V|V_>;
-  update<V_>(key: K, notSetValue: V_, updater: (value: V) => V_): Map<K,V|V_>;
-
-  merge<K_,V_>(
-    ...iterables: (ESIterable<[K_,V_]> | { [key: K_]: V_ })[]
-  ): Map<K|K_,V|V_>;
-
-  mergeWith<K_,W,X>(
-    merger: (previous: V, next: W, key: number) => X,
-    ...iterables: ESIterable<W>[]
-  ): Map<K,V|W|X>;
-
-  mergeDeep<K_,V_>(
-    ...iterables: (ESIterable<[K_,V_]> | { [key: K_]: V_ })[]
-  ): Map<K|K_,V|V_>;
-
-  mergeDeepWith<K_,W,X>(
-    merger: (previous: V, next: W, key: number) => X,
-    ...iterables: ESIterable<W>[]
-  ): Map<K,V|W|X>;
-
-  setIn(keyPath: ESIterable<any>, value: any): Map<K,V>;
-  deleteIn(keyPath: ESIterable<any>, value: any): this;
-  removeIn(keyPath: ESIterable<any>, value: any): this;
-
-  updateIn(keyPath: ESIterable<any>, notSetValue: any, value: any): Map<K,V>;
-  updateIn(keyPath: ESIterable<any>, value: any): Map<K,V>;
-
-  mergeIn(keyPath: ESIterable<any>, ...iterables: ESIterable<any>[]): Map<K,V>;
-  mergeDeepIn(keyPath: ESIterable<any>, ...iterables: ESIterable<any>[]): Map<K,V>;
-
-  withMutations(mutator: (mutable: this) => any): this;
-  asMutable(): this;
-  asImmutable(): this;
-
-  // Overrides that specialize return types
-
-  map<V_>(
-    mapper: (value: V, key: K, iter: this) => V_,
-    context?: any
-  ): Map<K,V_>;
-
-  flatMap<K_,V_>(
-    mapper: (value: V, key: K, iter: this) => ESIterable<[K_,V_]>,
-    context?: any
-  ): Map<K_,V_>;
-
-  flip(): Map<V,K>;
-
-  mapKeys<K_>(
-    mapper: (key: K, value: V, iter: this) => K_,
-    context?: any
-  ): Map<K_,V>;
-
-  flatten(depth?: number): /*this*/Map<any,any>;
-  flatten(shallow?: boolean): /*this*/Map<any,any>;
-}
-
-// OrderedMaps have nothing that Maps do not have. We do not need to override constructor & other statics
-declare class OrderedMap<K,V> extends Map<K,V> {
-  static isOrderedMap(maybeOrderedMap: any): bool;
-}
-
-declare class Set<T> extends SetCollection<T> {
-  static <T>(iterable: ESIterable<T>): Set<T>;  
-  static isSet(maybeSet: any): boolean;
-  static of<T>(...values: T[]): Set<T>;
-  static fromKeys<T>(iter: ESIterable<[T,any]>): Set<T>;
-  static fromKeys<K>(object: { [key: K]: V }): Set<K>;
-  static (_: void): Set<any>;      
-
-  add<U>(value: U): Set<T|U>;
-  delete(value: T): this;
-  remove(value: T): this;
-  clear(): this;
-  union<U>(...iterables: ESIterable<U>[]): Set<T|U>;
-  merge<U>(...iterables: ESIterable<U>[]): Set<T|U>;
-  intersect<U>(...iterables: ESIterable<U>[]): Set<T&U>;
-  subtract<U>(...iterables: ESIterable<U>[]): Set<T>;
-
-  withMutations(mutator: (mutable: this) => any): this;
-  asMutable(): this;
-  asImmutable(): this;
-
-  // Overrides that specialize return types
-
-  map<M>(
-    mapper: (value: T, value: T, iter: this) => M,
-    context?: any
-  ): Set<M>;
-
-  flatMap<M>(
-    mapper: (value: T, value: T, iter: this) => ESIterable<M>,
-    context?: any
-  ): Set<M>;
-
-  flatten(depth?: number): /*this*/Set<any>;
-  flatten(shallow?: boolean): /*this*/Set<any>;
-}
-
-// OrderedSets have nothing that Sets do not have. We do not need to override constructor & other statics
-declare class OrderedSet<T> extends Set<T> {
-  static isOrderedSet(maybeOrderedSet: any): bool;
-}
-
-declare class Stack<T> extends IndexedCollection<T> {
-  static <T>(iterable?: ESIterable<T>): Stack<T>;
-
-  static isStack(maybeStack: any): boolean;
-  static of<T>(...values: T[]): Stack<T>;
-
-  peek(): T;
-  clear(): this;
-  unshift<U>(...values: U[]): Stack<T|U>;
-  unshiftAll<U>(iter: ESIterable<U>): Stack<T|U>;
-  shift(): this;
-  push<U>(...values: U[]): Stack<T|U>;
-  pushAll<U>(iter: ESIterable<U>): Stack<T|U>;
-  pop(): this;
-
-  withMutations(mutator: (mutable: this) => any): this;
-  asMutable(): this;
-  asImmutable(): this;
-
-  // Overrides that specialize return types
-
-  map<U>(
-    mapper: (value: T, index: number, iter: this) => U,
-    context?: any
-  ): Stack<U>;
-
-  flatMap<U>(
-    mapper: (value: T, index: number, iter: this) => ESIterable<U>,
-    context?: any
-  ): Stack<U>;
-
-  flatten(depth?: number): /*this*/Stack<any>;
-  flatten(shallow?: boolean): /*this*/Stack<any>;
-}
-
-declare function Range(start?: number, end?: number, step?: number): IndexedSeq<number>;
-declare function Repeat<T>(value: T, times?: number): IndexedSeq<T>;
-
-//TODO: Once flow can extend normal Objects we can change this back to actually reflect Record behavior.
-// For now fallback to any to not break existing Code
-declare class Record<T: Object> {
-  static <T: Object>(spec: T, name?: string): /*T & Record<T>*/any;
-  get<A>(key: $Keys<T>): A;
-  set<A>(key: $Keys<T>, value: A): /*T & Record<T>*/this;
-  remove(key: $Keys<T>): /*T & Record<T>*/this;
-}
-
-declare function fromJS(json: any, reviver?: (k: any, v: Iterable<any,any>) => any): any;
-declare function is(first: any, second: any): boolean;
-
-export {
-  Iterable,
-  Collection,
-  Seq,
-
-  // These classes do not actually exist under these names. But it is useful to
-  // have the types available.
-  KeyedIterable,
-  IndexedIterable,
-  SetIterable,
-  KeyedCollection,
-  IndexedCollection,
-  SetCollection,
-  KeyedSeq,
-  IndexedSeq,
-  SetSeq,
-
-  List,
-  Map,
-  OrderedMap,
-  OrderedSet,
-  Range,
-  Repeat,
-  Record,
-  Set,
-  Stack,
-
-  fromJS,
-  is,
+declare module 'immutable' {
+
+  declare class _Iterable<K, V, KI, II, SI> {
+    static Keyed:   KI;
+    static Indexed: II;
+    static Set:     SI;
+
+    static isIterable(maybeIterable: any): boolean;
+    static isKeyed(maybeKeyed: any): boolean;
+    static isIndexed(maybeIndexed: any): boolean;
+    static isAssociative(maybeAssociative: any): boolean;
+    static isOrdered(maybeOrdered: any): boolean;
+
+    equals(other: Iterable<K,V>): boolean;
+    hashCode(): number;
+    get(key: K): V;
+    get<V_>(key: K, notSetValue: V_): V|V_;
+    has(key: K): boolean;
+    includes(value: V): boolean;
+    contains(value: V): boolean;
+    first(): V;
+    last(): V;
+
+    getIn<T>(searchKeyPath: ESIterable<any>, notSetValue: T): T;
+    getIn<T>(searchKeyPath: ESIterable<any>): T;
+    hasIn(searchKeyPath: ESIterable<any>): boolean;
+
+    toJS(): any;
+    toArray(): V[];
+    toObject(): { [key: string]: V };
+    toMap(): Map<K,V>;
+    toOrderedMap(): Map<K,V>;
+    toSet(): Set<V>;
+    toOrderedSet(): Set<V>;
+    toList(): List<V>;
+    toStack(): Stack<V>;
+    toSeq(): Seq<K,V>;
+    toKeyedSeq(): KeyedSeq<K,V>;
+    toIndexedSeq(): IndexedSeq<V>;
+    toSetSeq(): SetSeq<V>;
+
+    keys(): Iterator<K>;
+    values(): Iterator<V>;
+    entries(): Iterator<[K,V]>;
+
+    keySeq(): IndexedSeq<K>;
+    valueSeq(): IndexedSeq<V>;
+    entrySeq(): IndexedSeq<[K,V]>;
+
+    reverse(): this;
+    sort(comparator?: (valueA: V, valueB: V) => number): this;
+
+    sortBy<C>(
+      comparatorValueMapper: (value: V, key: K, iter: this) => C,
+      comparator?: (valueA: C, valueB: C) => number
+    ): this;
+
+    groupBy<G>(
+      grouper: (value: V, key: K, iter: this) => G,
+      context?: any
+    ): KeyedSeq<G, this>;
+
+    forEach(
+      sideEffect: (value: V, key: K, iter: this) => any,
+      context?: any
+    ): number;
+
+    slice(begin?: number, end?: number): this;
+    rest(): this;
+    butLast(): this;
+    skip(amount: number): this;
+    skipLast(amount: number): this;
+    skipWhile(predicate: (value: V, key: K, iter: this) => mixed, context?: any): this;
+    skipUntil(predicate: (value: V, key: K, iter: this) => mixed, context?: any): this;
+    take(amount: number): this;
+    takeLast(amount: number): this;
+    takeWhile(predicate: (value: V, key: K, iter: this) => mixed, context?: any): this;
+    takeUntil(predicate: (value: V, key: K, iter: this) => mixed, context?: any): this;
+    flatten(depth?: number): /*this*/Iterable<any,any>;
+    flatten(shallow?: boolean): /*this*/Iterable<any,any>;
+
+    filter(
+      predicate: (value: V, key: K, iter: this) => mixed,
+      context?: any
+    ): this;
+
+    filterNot(
+      predicate: (value: V, key: K, iter: this) => mixed,
+      context?: any
+    ): this;
+
+    reduce<R>(
+      reducer: (reduction: R, value: V, key: K, iter: this) => R,
+      initialReduction?: R,
+      context?: any,
+    ): R;
+
+    reduceRight<R>(
+      reducer: (reduction: R, value: V, key: K, iter: this) => R,
+      initialReduction?: R,
+      context?: any,
+    ): R;
+
+    every(predicate: (value: V, key: K, iter: this) => mixed, context?: any): boolean;
+    some(predicate: (value: V, key: K, iter: this) => mixed, context?: any): boolean;
+    join(separator?: string): string;
+    isEmpty(): boolean;
+    count(predicate?: (value: V, key: K, iter: this) => mixed, context?: any): number;
+    countBy<G>(grouper: (value: V, key: K, iter: this) => G, context?: any): Map<G,number>;
+
+    find(
+      predicate: (value: V, key: K, iter: this) => mixed,
+      context?: any,
+    ): ?V;
+    find<V_>(
+      predicate: (value: V, key: K, iter: this) => mixed,
+      context: any,
+      notSetValue: V_
+    ): V|V_;
+
+    findLast(
+      predicate: (value: V, key: K, iter: this) => mixed,
+      context?: any,
+    ): ?V;
+    findLast<V_>(
+      predicate: (value: V, key: K, iter: this) => mixed,
+      context: any,
+      notSetValue: V_
+    ): V|V_;
+
+
+    findEntry(predicate: (value: V, key: K, iter: this) => mixed): ?[K,V];
+    findLastEntry(predicate: (value: V, key: K, iter: this) => mixed): ?[K,V];
+
+    findKey(predicate: (value: V, key: K, iter: this) => mixed, context?: any): ?K;
+    findLastKey(predicate: (value: V, key: K, iter: this) => mixed, context?: any): ?K;
+
+    keyOf(searchValue: V): ?K;
+    lastKeyOf(searchValue: V): ?K;
+
+    max(comparator?: (valueA: V, valueB: V) => number): V;
+    maxBy<C>(
+      comparatorValueMapper: (value: V, key: K, iter: this) => C,
+      comparator?: (valueA: C, valueB: C) => number
+    ): V;
+    min(comparator?: (valueA: V, valueB: V) => number): V;
+    minBy<C>(
+      comparatorValueMapper: (value: V, key: K, iter: this) => C,
+      comparator?: (valueA: C, valueB: C) => number
+    ): V;
+
+    isSubset(iter: Iterable<any, V>): boolean;
+    isSubset(iter: ESIterable<V>): boolean;
+    isSuperset(iter: Iterable<any, V>): boolean;
+    isSuperset(iter: ESIterable<V>): boolean;
+  }
+
+  declare class Iterable<K, V> extends _Iterable<K, V, typeof KeyedIterable, typeof IndexedIterable, typeof SetIterable> {}
+
+  declare class KeyedIterable<K,V> extends Iterable<K,V> {
+    static <K,V>(iter?: ESIterable<[K,V]>): KeyedIterable<K,V>;
+    static <K,V>(obj?: { [key: K]: V }): KeyedIterable<K,V>;
+
+    @@iterator(): Iterator<[K,V]>;
+    toSeq(): KeyedSeq<K,V>;
+    flip(): /*this*/KeyedIterable<V,K>;
+
+    mapKeys<K_>(
+      mapper: (key: K, value: V, iter: this) => K_,
+      context?: any
+    ): /*this*/KeyedIterable<K_,V>;
+
+    mapEntries<K_,V_>(
+      mapper: (entry: [K,V], index: number, iter: this) => [K_,V_],
+      context?: any
+    ): /*this*/KeyedIterable<K_,V_>;
+
+    concat(...iters: ESIterable<[K,V]>[]): this;
+
+    map<V_>(
+      mapper: (value: V, key: K, iter: this) => V_,
+      context?: any
+    ): /*this*/KeyedIterable<K,V_>;
+
+    flatMap<K_, V_>(
+      mapper: (value: V, key: K, iter: this) => ESIterable<[K_,V_]>,
+      context?: any
+    ): /*this*/KeyedIterable<K_,V_>;
+
+    flatten(depth?: number): /*this*/KeyedIterable<any,any>;
+    flatten(shallow?: boolean): /*this*/KeyedIterable<any,any>;
+  }
+
+  declare class IndexedIterable<T> extends Iterable<number,T> {
+    static <T>(iter?: ESIterable<T>): IndexedIterable<T>;
+
+    @@iterator(): Iterator<T>;
+    toSeq(): IndexedSeq<T>;
+    fromEntrySeq<K,V>(): KeyedSeq<K,V>;
+    interpose(separator: T): this;
+    interleave(...iterables: ESIterable<T>[]): this;
+    splice(
+      index: number,
+      removeNum: number,
+      ...values: T[]
+    ): this;
+
+    zip<A>(
+      a: ESIterable<A>,
+      $?: null
+    ): IndexedIterable<[T,A]>;
+    zip<A,B>(
+      a: ESIterable<A>,
+      b: ESIterable<B>,
+      $?: null
+    ): IndexedIterable<[T,A,B]>;
+    zip<A,B,C>(
+      a: ESIterable<A>,
+      b: ESIterable<B>,
+      c: ESIterable<C>,
+      $?: null
+    ): IndexedIterable<[T,A,B,C]>;
+    zip<A,B,C,D>(
+      a: ESIterable<A>,
+      b: ESIterable<B>,
+      c: ESIterable<C>,
+      d: ESIterable<D>,
+      $?: null
+    ): IndexedIterable<[T,A,B,C,D]>;
+    zip<A,B,C,D,E>(
+      a: ESIterable<A>,
+      b: ESIterable<B>,
+      c: ESIterable<C>,
+      d: ESIterable<D>,
+      e: ESIterable<E>,
+      $?: null
+    ): IndexedIterable<[T,A,B,C,D,E]>;
+
+    zipWith<A,R>(
+      zipper: (value: T, a: A) => R,
+      a: ESIterable<A>,
+      $?: null
+    ): IndexedIterable<R>;
+    zipWith<A,B,R>(
+      zipper: (value: T, a: A, b: B) => R,
+      a: ESIterable<A>,
+      b: ESIterable<B>,
+      $?: null
+    ): IndexedIterable<R>;
+    zipWith<A,B,C,R>(
+      zipper: (value: T, a: A, b: B, c: C) => R,
+      a: ESIterable<A>,
+      b: ESIterable<B>,
+      c: ESIterable<C>,
+      $?: null
+    ): IndexedIterable<R>;
+    zipWith<A,B,C,D,R>(
+      zipper: (value: T, a: A, b: B, c: C, d: D) => R,
+      a: ESIterable<A>,
+      b: ESIterable<B>,
+      c: ESIterable<C>,
+      d: ESIterable<D>,
+      $?: null
+    ): IndexedIterable<R>;
+    zipWith<A,B,C,D,E,R>(
+      zipper: (value: T, a: A, b: B, c: C, d: D, e: E) => R,
+      a: ESIterable<A>,
+      b: ESIterable<B>,
+      c: ESIterable<C>,
+      d: ESIterable<D>,
+      e: ESIterable<E>,
+      $?: null
+    ): IndexedIterable<R>;
+
+    indexOf(searchValue: T): number;
+    lastIndexOf(searchValue: T): number;
+    findIndex(
+      predicate: (value: T, index: number, iter: this) => mixed,
+      context?: any
+    ): number;
+    findLastIndex(
+      predicate: (value: T, index: number, iter: this) => mixed,
+      context?: any
+    ): number;
+
+    concat(...iters: ESIterable<T>[]): this;
+
+    map<U>(
+      mapper: (value: T, index: number, iter: this) => U,
+      context?: any
+    ): /*this*/IndexedIterable<U>;
+
+    flatMap<U>(
+      mapper: (value: T, index: number, iter: this) => ESIterable<U>,
+      context?: any
+    ): /*this*/IndexedIterable<U>;
+
+    flatten(depth?: number): /*this*/IndexedIterable<any>;
+    flatten(shallow?: boolean): /*this*/IndexedIterable<any>;
+  }
+
+  declare class SetIterable<T> extends Iterable<T,T> {
+    static <T>(iter?: ESIterable<T>): SetIterable<T>;
+
+    @@iterator(): Iterator<T>;
+    toSeq(): SetSeq<T>;
+
+    concat(...iters: ESIterable<T>[]): this;
+
+    // `map` and `flatMap` cannot be defined further up the hiearchy, because the
+    // implementation for `KeyedIterable` allows the value type to change without
+    // constraining the key type. That does not work for `SetIterable` - the value
+    // and key types *must* match.
+    map<U>(
+      mapper: (value: T, value: T, iter: this) => U,
+      context?: any
+    ): /*this*/SetIterable<U>;
+
+    flatMap<U>(
+      mapper: (value: T, value: T, iter: this) => ESIterable<U>,
+      context?: any
+    ): /*this*/SetIterable<U>;
+
+    flatten(depth?: number): /*this*/SetIterable<any>;
+    flatten(shallow?: boolean): /*this*/SetIterable<any>;
+  }
+
+  declare class Collection<K,V> extends _Iterable<K,V, typeof KeyedCollection, typeof IndexedCollection, typeof SetCollection> {
+    size: number;
+  }
+
+  declare class KeyedCollection<K,V> extends Collection<K,V> mixins KeyedIterable<K,V> {
+    toSeq(): KeyedSeq<K,V>;
+  }
+
+  declare class IndexedCollection<T> extends Collection<number,T> mixins IndexedIterable<T> {
+    toSeq(): IndexedSeq<T>;
+  }
+
+  declare class SetCollection<T> extends Collection<T,T> mixins SetIterable<T> {
+    toSeq(): SetSeq<T>;
+  }
+
+  declare class Seq<K,V> extends _Iterable<K,V, typeof KeyedSeq, typeof IndexedSeq, typeof SetSeq> {
+    static <K,V>(iter: KeyedSeq<K,V>):   KeyedSeq<K,V>;
+    static <T>  (iter: SetSeq<T>):       SetSeq<K,V>;
+    static <T>  (iter?: ESIterable<T>):  IndexedSeq<T>;
+    static <K,V>(iter: { [key: K]: V }): KeyedSeq<K,V>;
+
+    static isSeq(maybeSeq: any): boolean;
+    static of<T>(...values: T[]): IndexedSeq<T>;
+
+    size: ?number;
+    cacheResult(): this;
+    toSeq(): this;
+  }
+
+  declare class KeyedSeq<K,V> extends Seq<K,V> mixins KeyedIterable<K,V> {
+    static <K,V>(iter?: ESIterable<[K,V]>): KeyedSeq<K,V>;
+    static <K,V>(iter?: { [key: K]: V }): KeyedSeq<K,V>;
+  }
+
+  declare class IndexedSeq<T> extends Seq<number,T> mixins IndexedIterable<T> {
+    static <T>(iter?: ESIterable<T>): IndexedSeq<T>;
+    static of<T>(...values: T[]): IndexedSeq<T>;
+  }
+
+  declare class SetSeq<T> extends Seq<T,T> mixins SetIterable<T> {
+    static <T>(iter?: ESIterable<T>): IndexedSeq<T>;
+    static of<T>(...values: T[]): SetSeq<T>;
+  }
+
+  declare class List<T> extends IndexedCollection<T> {
+    static (iterable?: ESIterable<T>): List<T>;
+
+    static isList(maybeList: any): boolean;
+    static of<T>(...values: T[]): List<T>;
+
+    set<U>(index: number, value: U): List<T|U>;
+    delete(index: number): this;
+    remove(index: number): this;
+    insert<U>(index: number, value: U): List<T|U>;
+    clear(): this;
+    push<U>(...values: U[]): List<T|U>;
+    pop(): this;
+    unshift<U>(...values: U[]): List<T|U>;
+    shift(): this;
+
+    update<U>(updater: (value: this) => List<U>): List<U>;
+    update<U>(index: number, updater: (value: T) => U): List<T|U>;
+    update<U>(index: number, notSetValue: U, updater: (value: T) => U): List<T|U>;
+
+    merge<U>(...iterables: ESIterable<U>[]): List<T|U>;
+
+    mergeWith<U,V>(
+      merger: (previous: T, next: U, key: number) => V,
+      ...iterables: ESIterable<U>[]
+    ): List<T|U|V>;
+
+    mergeDeep<U>(...iterables: ESIterable<U>[]): List<T|U>;
+
+    mergeDeepWith<U,V>(
+      merger: (previous: T, next: U, key: number) => V,
+      ...iterables: ESIterable<U>[]
+    ): List<T|U|V>;
+
+    setSize(size: number): List<?T>;
+    setIn(keyPath: ESIterable<any>, value: any): List<T>;
+    deleteIn(keyPath: ESIterable<any>, value: any): this;
+    removeIn(keyPath: ESIterable<any>, value: any): this;
+
+    updateIn(keyPath: ESIterable<any>, notSetValue: any, value: any): List<T>;
+    updateIn(keyPath: ESIterable<any>, value: any): List<T>;
+
+    mergeIn(keyPath: ESIterable<any>, ...iterables: ESIterable<any>[]): List<T>;
+    mergeDeepIn(keyPath: ESIterable<any>, ...iterables: ESIterable<any>[]): List<T>;
+
+    withMutations(mutator: (mutable: this) => any): this;
+    asMutable(): this;
+    asImmutable(): this;
+
+    // Overrides that specialize return types
+    map<M>(
+      mapper: (value: T, index: number, iter: this) => M,
+      context?: any
+    ): List<M>;
+
+    flatMap<M>(
+      mapper: (value: T, index: number, iter: this) => ESIterable<M>,
+      context?: any
+    ): List<M>;
+
+    flatten(depth?: number): /*this*/List<any>;
+    flatten(shallow?: boolean): /*this*/List<any>;
+  }
+
+  declare class Map<K,V> extends KeyedCollection<K,V> {
+    static <K, V>(obj?: {[key: K]: V}): Map<K, V>;
+    static <K, V>(iterable: ESIterable<[K,V]>): Map<K, V>;
+
+    static isMap(maybeMap: any): boolean;
+
+    set<K_, V_>(key: K_, value: V_): Map<K|K_, V|V_>;
+    delete(key: K): this;
+    remove(key: K): this;
+    clear(): this;
+
+    update<K_,V_>(updater: (value: this) => Map<K_,V_>): Map<K_,V_>;
+    update<V_>(key: K, updater: (value: V) => V_): Map<K,V|V_>;
+    update<V_>(key: K, notSetValue: V_, updater: (value: V) => V_): Map<K,V|V_>;
+
+    merge<K_,V_>(
+      ...iterables: (ESIterable<[K_,V_]> | { [key: K_]: V_ })[]
+    ): Map<K|K_,V|V_>;
+
+    mergeWith<K_,W,X>(
+      merger: (previous: V, next: W, key: number) => X,
+      ...iterables: ESIterable<W>[]
+    ): Map<K,V|W|X>;
+
+    mergeDeep<K_,V_>(
+      ...iterables: (ESIterable<[K_,V_]> | { [key: K_]: V_ })[]
+    ): Map<K|K_,V|V_>;
+
+    mergeDeepWith<K_,W,X>(
+      merger: (previous: V, next: W, key: number) => X,
+      ...iterables: ESIterable<W>[]
+    ): Map<K,V|W|X>;
+
+    setIn(keyPath: ESIterable<any>, value: any): Map<K,V>;
+    deleteIn(keyPath: ESIterable<any>, value: any): this;
+    removeIn(keyPath: ESIterable<any>, value: any): this;
+
+    updateIn(keyPath: ESIterable<any>, notSetValue: any, value: any): Map<K,V>;
+    updateIn(keyPath: ESIterable<any>, value: any): Map<K,V>;
+
+    mergeIn(keyPath: ESIterable<any>, ...iterables: ESIterable<any>[]): Map<K,V>;
+    mergeDeepIn(keyPath: ESIterable<any>, ...iterables: ESIterable<any>[]): Map<K,V>;
+
+    withMutations(mutator: (mutable: this) => any): this;
+    asMutable(): this;
+    asImmutable(): this;
+
+    // Overrides that specialize return types
+    map<V_>(
+      mapper: (value: V, key: K, iter: this) => V_,
+      context?: any
+    ): Map<K,V_>;
+
+    flatMap<K_,V_>(
+      mapper: (value: V, key: K, iter: this) => ESIterable<[K_,V_]>,
+      context?: any
+    ): Map<K_,V_>;
+
+    flip(): Map<V,K>;
+
+    mapKeys<K_>(
+      mapper: (key: K, value: V, iter: this) => K_,
+      context?: any
+    ): Map<K_,V>;
+
+    flatten(depth?: number): /*this*/Map<any,any>;
+    flatten(shallow?: boolean): /*this*/Map<any,any>;
+  }
+
+  // OrderedMaps have nothing that Maps do not have. We do not need to override constructor & other statics
+  declare class OrderedMap<K,V> extends Map<K,V> {
+    static isOrderedMap(maybeOrderedMap: any): bool;
+  }
+
+  declare class Set<T> extends SetCollection<T> {
+    static <T>(iterable: ESIterable<T>): Set<T>;
+    static isSet(maybeSet: any): boolean;
+    static of<T>(...values: T[]): Set<T>;
+    static fromKeys<T>(iter: ESIterable<[T,any]>): Set<T>;
+    static fromKeys<K, V>(object: { [key: K]: V }): Set<K>;
+    static (_: void): Set<any>;
+
+    add<U>(value: U): Set<T|U>;
+    delete(value: T): this;
+    remove(value: T): this;
+    clear(): this;
+    union<U>(...iterables: ESIterable<U>[]): Set<T|U>;
+    merge<U>(...iterables: ESIterable<U>[]): Set<T|U>;
+    intersect<U>(...iterables: ESIterable<U>[]): Set<T&U>;
+    subtract<U>(...iterables: ESIterable<U>[]): Set<T>;
+
+    withMutations(mutator: (mutable: this) => any): this;
+    asMutable(): this;
+    asImmutable(): this;
+
+    // Overrides that specialize return types
+    map<M>(
+      mapper: (value: T, value: T, iter: this) => M,
+      context?: any
+    ): Set<M>;
+
+    flatMap<M>(
+      mapper: (value: T, value: T, iter: this) => ESIterable<M>,
+      context?: any
+    ): Set<M>;
+
+    flatten(depth?: number): /*this*/Set<any>;
+    flatten(shallow?: boolean): /*this*/Set<any>;
+  }
+
+  // OrderedSets have nothing that Sets do not have. We do not need to override constructor & other statics
+  declare class OrderedSet<T> extends Set<T> {
+    static isOrderedSet(maybeOrderedSet: any): bool;
+  }
+
+  declare class Stack<T> extends IndexedCollection<T> {
+    static <T>(iterable?: ESIterable<T>): Stack<T>;
+
+    static isStack(maybeStack: any): boolean;
+    static of<T>(...values: T[]): Stack<T>;
+
+    peek(): T;
+    clear(): this;
+    unshift<U>(...values: U[]): Stack<T|U>;
+    unshiftAll<U>(iter: ESIterable<U>): Stack<T|U>;
+    shift(): this;
+    push<U>(...values: U[]): Stack<T|U>;
+    pushAll<U>(iter: ESIterable<U>): Stack<T|U>;
+    pop(): this;
+
+    withMutations(mutator: (mutable: this) => any): this;
+    asMutable(): this;
+    asImmutable(): this;
+
+    // Overrides that specialize return types
+
+    map<U>(
+      mapper: (value: T, index: number, iter: this) => U,
+      context?: any
+    ): Stack<U>;
+
+    flatMap<U>(
+      mapper: (value: T, index: number, iter: this) => ESIterable<U>,
+      context?: any
+    ): Stack<U>;
+
+    flatten(depth?: number): /*this*/Stack<any>;
+    flatten(shallow?: boolean): /*this*/Stack<any>;
+  }
+
+  declare function Range(start?: number, end?: number, step?: number): IndexedSeq<number>;
+  declare function Repeat<T>(value: T, times?: number): IndexedSeq<T>;
+
+  //TODO: Once flow can extend normal Objects we can change this back to actually reflect Record behavior.
+  // For now fallback to any to not break existing Code
+  declare class Record<T: Object> {
+    static <T: Object>(spec: T, name?: string): /*T & Record<T>*/any;
+    get<A>(key: $Keys<T>): A;
+    set<A>(key: $Keys<T>, value: A): /*T & Record<T>*/this;
+    remove(key: $Keys<T>): /*T & Record<T>*/this;
+  }
+
+  declare function fromJS(json: any, reviver?: (k: any, v: Iterable<any,any>) => any): any;
+  declare function is(first: any, second: any): boolean;
+
 }

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -485,7 +485,7 @@ declare class List<T> extends IndexedCollection<T> {
 }
 
 declare class Map<K,V> extends KeyedCollection<K,V> {
-  static <K, V>(): Map<K, V>;
+  static <K,V>(_: void): Map<K,V>;
   static <V>(obj?: {[key: string]: V}): Map<string, V>;
   static <K, V>(iterable?: ESIterable<[K,V]>): Map<K, V>;
 

--- a/type-definitions/tests/.flowconfig
+++ b/type-definitions/tests/.flowconfig
@@ -2,9 +2,12 @@
 ../immutable.js.flow
 
 [ignore]
+; Unless node_modules are ignored, 'immutable' resolves to the module not the flow definition.
 .*/node_modules/.*
 
 [options]
+; Prevents Flow from reporting an error on a line which follows `// $ExpectError` comment.
+; Used for testing expected errors
 suppress_comment=^\\( \\|\n\\)*\\$ExpectError\\(([^)]*)\\)?$
 
 [version]

--- a/type-definitions/tests/.flowconfig
+++ b/type-definitions/tests/.flowconfig
@@ -1,0 +1,5 @@
+[libs]
+../
+[options]
+suppress_comment=^\\( \\|\n\\)*\\$ExpectError\\(([^)]*)\\)?$
+

--- a/type-definitions/tests/.flowconfig
+++ b/type-definitions/tests/.flowconfig
@@ -1,5 +1,5 @@
 [libs]
-../
+../immutable.js.flow
 [options]
 suppress_comment=^\\( \\|\n\\)*\\$ExpectError\\(([^)]*)\\)?$
 

--- a/type-definitions/tests/.flowconfig
+++ b/type-definitions/tests/.flowconfig
@@ -3,3 +3,6 @@
 [options]
 suppress_comment=^\\( \\|\n\\)*\\$ExpectError\\(([^)]*)\\)?$
 
+[version]
+^0.36.0
+

--- a/type-definitions/tests/.flowconfig
+++ b/type-definitions/tests/.flowconfig
@@ -1,5 +1,9 @@
 [libs]
 ../immutable.js.flow
+
+[ignore]
+.*/node_modules/.*
+
 [options]
 suppress_comment=^\\( \\|\n\\)*\\$ExpectError\\(([^)]*)\\)?$
 

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -1,0 +1,395 @@
+/*
+ * @flow
+ */
+
+// Some tests look like they are repeated but it's not actually the case; It is very likely to have a false positivie because Flow might not complain about an instance of (what it thinks is) T to be assigned to T<K, V>
+
+var numberList: List<number> = List()
+var numberOrStringList: List<string | number> = List()
+var nullableNumberList: List<?number> = List()
+var stringToNumber: Map<string, number> = Map()
+var stringToNumberOrString: Map<string, string | number> = Map()
+var numberToString: Map<number, string> = Map()
+var stringOrNumberToNumberOrString: Map<string | number, string | number> = Map()
+var anyMap: Map = Map()
+var numberSet: Set<number> = Set()
+var numberOrStringSet: Set<number | string> = Set()
+var stringSet: Set<string> = Set()
+var numberStack: Stack<number> = Stack()
+var numberOrStringStack: Stack<string | number> = Stack()
+var number: number = 0
+var numberSequence: IndexedSeq<number>
+var stringSequence: IndexedSeq<string>
+var stringToNumberIterable: KeyedIterable<string, number> = stringToNumber
+var numberToStringIterable: KeyedIterable<number, string> = numberToString
+
+numberList = List([1, 2])
+numberOrStringList = List(['a', 1])
+// $ExpectError
+numberList = List(['a', 'b'])
+
+numberList = List.of(1, 2)
+numberOrStringList = List.of('a', 1)
+// $ExpectError
+numberList = List.of('a', 1)
+
+numberList = List().set(0, 0)
+numberOrStringList = List.of(0).set(1, 'a')
+// $ExpectError
+numberList = List().set(0, 'a')
+
+numberList = List().insert(0, 0)
+numberOrStringList = List.of(0).insert(1, 'a')
+// $ExpectError
+numberList = List().insert(0, 'a')
+
+numberList = List().push(1, 1)
+numberOrStringList = List().push(1, 'a')
+// $ExpectError
+numberList = List().push(0, 'a')
+
+numberList = List().unshift(1, 1)
+numberOrStringList = List().unshift(1, 'a')
+// $ExpectError
+numberList = List().unshift(0, 'a')
+
+numberList = List.of(1).delete(0)
+// $ExpectError
+numberList = List.of('a').delete(0)
+
+numberList = List.of(1).remove(0)
+// $ExpectError
+numberList = List.of('a').remove(0)
+
+numberList = List.of(1).clear()
+// $ExpectError
+numberList = List.of('a').clear()
+
+numberList = List.of(1).pop()
+// $ExpectError
+numberList = List.of('a').pop()
+
+numberList = List.of(1).shift()
+// $ExpectError
+numberList = List.of('a').shift()
+
+numberList = List.of('a').update((value) => List.of(1))
+// $ExpectError
+numberList = List.of(1).update((value) => List.of('a'))
+
+numberOrStringList = List.of('a').update(0, (value) => 1) 
+// $ExpectError
+numberList = List.of(1).update(0, (value) => 'a')
+
+numberOrStringList = List.of(1).update(1, 0, (value) => 'a')
+// $ExpectError
+numberList = List.of(1).update(1, 0, (value) => 'a')
+
+numberList = List.of(1).merge(List.of(2))
+numberOrStringList = List.of('a').merge(List.of(1))
+// $ExpectError
+numberList = List.of('a').merge(List.of(1))
+
+numberList = List.of(1).mergeWith((previous, next, key) => 1, [1])
+// $ExpectError
+numberList = List.of(1).mergeWith((previous, next, key) => previous + next, ['a'])
+
+numberOrStringList = List.of(1).mergeDeep(['a'])
+// $ExpectError
+numberList = List.of(1).mergeDeep(['a'])
+
+numberList = List.of(1).mergeDeepWith((previous, next, key) => 1, [1])
+// $ExpectError
+numberList = List.of(1).mergeDeepWith((previous, next, key) => previous + next, ['a'])
+
+nullableNumberList = List.of(1).setSize(2)
+
+numberList = List.of(1).setIn([], 0)
+
+numberList = List.of(1).deleteIn([], 0)
+numberList = List.of(1).removeIn([], 0)
+
+numberList = List.of(1).mergeIn([], [])
+numberList = List.of(1).mergeDeepIn([], [])
+
+numberList = List.of(1).withMutations(mutable => mutable)
+
+numberList = List.of(1).asMutable()
+numberList = List.of(1).asImmutable()
+
+numberList = List.of(1).map((value, index, iter) => 1)
+// $ExpectError
+numberList = List.of(1).map((value, index, iter) => 'a')
+
+numberList = List.of(1).flatMap((value, index, iter) => [1])
+// $ExpectError
+numberList = List.of(1).flatMap((value, index, iter) => ['a'])
+
+numberList = List.of(1).flatten()
+
+/* Map */
+
+stringToNumber = Map()
+stringToNumberOrString = Map()
+numberToString = Map()
+
+stringToNumber = Map({'a': 1})
+// $ExpectError
+stringToNumber = Map({'a': 'a'})
+
+stringToNumber = Map([['a', 1]])
+// $ExpectError
+stringToNumber = Map([['a', 'b']])
+
+stringOrNumberToNumberOrString = Map({'a': 'a'}).set('b', 1).set(2, 'c')
+// $ExpectError
+stringToNumber = Map({'a': 0}).set('b', '')
+// $ExpectError
+stringToNumber = Map().set(1, '')
+
+stringToNumber = Map({'a': 0}).delete('a')
+stringToNumber = Map({'a': 0}).remove('a')
+
+stringToNumber = Map({'a': 0}).clear()
+
+stringToNumber = Map({'a': 1}).update((value) => Map({'a': 1}))
+// $ExpectError
+stringToNumber = Map({'a': 1}).update((value) => Map({1: 'a'}))
+
+stringToNumberOrString = Map({'a': 1}).update('a', (value) => 'a') 
+// $ExpectError
+stringToNumber = Map({'a': 1}).update('a', (value) => 'a')
+
+stringToNumberOrString = Map({'a': 1}).update('a', 'b', (value) => 'a')
+// $ExpectError
+stringToNumber = Map({'a': 1}).update('a', 'b', (value) => 'a')
+
+stringToNumber = Map({'a': 1}).merge(Map({'a': 1}))
+stringToNumberOrString = Map({'a': 1}).merge({'a': 'b'})
+// $ExpectError
+stringToNumber = Map({'a': 1}).merge({'a': 'b'})
+// $ExpectError
+stringToNumber = Map({'a': 1}).merge([['a', 'b']])
+// $ExpectError
+stringToNumber = Map({'a': 1}).merge(Map({'a': 'b'}))
+
+stringToNumber = Map({'a': 1}).mergeWith((previous, next, key) => 1, [1])
+// $ExpectError
+stringToNumber = Map({'a': 1}).mergeWith((previous, next, key) => previous + next, ['a'])
+
+stringToNumberOrString = Map({'a': 1}).mergeDeep({'a': 'b'})
+// $ExpectError
+stringToNumber = Map({'a': 1}).mergeDeep({'a': 'b'})
+
+stringToNumber = Map({'a': 1}).mergeDeepWith((previous, next, key) => 1, [1])
+// $ExpectError
+stringToNumber = Map({'a': 1}).mergeDeepWith((previous, next, key) => previous + next, ['a'])
+
+stringToNumber = Map({'a': 1}).setIn([], 0)
+
+stringToNumber = Map({'a': 1}).deleteIn([], 0)
+stringToNumber = Map({'a': 1}).removeIn([], 0)
+
+stringToNumber = Map({'a': 1}).mergeIn([], [])
+stringToNumber = Map({'a': 1}).mergeDeepIn([], [])
+
+stringToNumber = Map({'a': 1}).withMutations(mutable => mutable)
+
+stringToNumber = Map({'a': 1}).asMutable()
+stringToNumber = Map({'a': 1}).asImmutable()
+
+stringToNumber = Map({'a': 1}).map((value, index, iter) => 1)
+// $ExpectError
+stringToNumber = Map({'a': 1}).map((value, index, iter) => 'a')
+
+stringToNumber = Map({'a': 1}).flatMap((value, index, iter) => [['b', 1]])
+// $ExpectError
+stringToNumber = Map({'a': 1}).flatMap((value, index, iter) => [['a', 'a']])
+// $ExpectError
+stringToNumber = Map({'a': 1}).flatMap((value, index, iter) => Map({'a': 'a'}))
+
+numberToString= Map({'a': 1}).flip()
+// $ExpectError
+stringToNumber = Map({'a': 1}).flip()
+
+numberToString = Map({'a': 'a'}).mapKeys((key, value, iter) => 1)
+// $ExpectError
+stringToNumber = Map({'a': 1}).mapKeys((key, value, iter) => 1)
+
+anyMap = Map({'a': 1}).flatten()
+
+/* Set */
+
+numberSet = Set()
+numberOrStringSet = Set()
+stringSet = Set()
+
+numberSet = Set([1, 2, 3])
+// $ExpectError
+numberSet = Set(['a', 'b'])
+
+numberSet = Set.of(1, 2)
+// $ExpectError
+numberSet = Set.of('a', 'b')
+
+numberSet = Set.fromKeys(Map().set(1, ''))
+stringSet = Set.fromKeys({'a': ''})
+// $ExpectError
+numberSet = Set.fromKeys(Map({'a': 1}))
+// $ExpectError
+numberSet = Set.fromKeys({'a': 1})
+
+numberOrStringSet = Set([1]).add('a')
+// $ExpectError
+numberSet = Set([1]).add('s')
+
+numberSet = Set([1]).delete(1)
+// $ExpectError
+numberSet = Set([1]).delete('a')
+// $ExpectError
+numberSet = Set(['a']).delete('a')
+
+numberSet = Set([1]).remove(1)
+// $ExpectError
+numberSet = Set([1]).remove('a')
+// $ExpectError
+numberSet = Set(['a']).remove('a')
+
+numberSet = Set([1]).clear()
+// $ExpectError
+numberSet = Set(['a']).clear()
+
+numberOrStringSet = Set(['a']).union([1])
+numberOrStringSet = Set(['a']).union(Set([1]))
+numberSet = Set([1]).union([1])
+numberSet = Set([1]).union(Set([1]))
+// $ExpectError
+numberSet = Set([1]).union(['a'])
+// $ExpectError
+numberSet = Set([1]).union(Set(['a']))
+
+numberOrStringSet = Set(['a']).merge([1])
+numberOrStringSet = Set(['a']).merge(Set([1]))
+numberSet = Set([1]).merge([1])
+numberSet = Set([1]).merge(Set([1]))
+// $ExpectError
+numberSet = Set([1]).merge(['a'])
+// $ExpectError
+numberSet = Set([1]).merge(Set(['a']))
+
+numberSet = Set([1]).intersect(Set([1]))
+numberSet = Set([1]).intersect([1])
+// $ExpectError
+numberSet = Set([1]).intersect(Set(['a']))
+// $ExpectError
+numberSet = Set([1]).intersect(['a'])
+
+numberSet = Set([1]).subtract(Set([1]))
+numberSet = Set([1]).subtract([1])
+numberSet = Set([1]).subtract(Set(['a']))
+numberSet = Set([1]).subtract(['a'])
+
+numberSet = Set([1]).withMutations(mutable => mutable)
+// $ExpectError
+stringSet = Set([1]).withMutations(mutable => mutable)
+
+numberSet = Set([1]).asMutable()
+// $ExpectError
+stringSet = Set([1]).asMutable()
+
+numberSet = Set([1]).asImmutable()
+// $ExpectError
+stringSet = Set([1]).asImmutable()
+
+stringSet = Set([1]).map((value, index, iter) => 'a')
+// $ExpectError
+numberSet = Set([1]).map((value, index, iter) => 'a')
+
+stringSet = Set([1]).flatMap((value, index, iter) => ['a'])
+// $ExpectError
+numberSet = Set([1]).flatMap((value, index, iter) => ['a'])
+
+numberSet = Set([1]).flatten()
+
+/* Stack */
+
+numberStack = Stack([1, 2])
+numberOrStringStack = Stack(['a', 1])
+// $ExpectError
+numberStack = Stack(['a', 'b'])
+
+numberStack = Stack.of(1, 2)
+numberOrStringStack = Stack.of('a', 1)
+// $ExpectError
+numberStack = Stack.of('a', 1)
+
+number = Stack([1]).peek()
+// $ExpectError
+number = Stack(['a']).peek()
+
+numberStack = Stack([1]).unshift(1)
+numberOrStringStack = Stack([1]).unshift('a')
+// $ExpectError
+numberStack = Stack([1]).unshift('a')
+
+numberStack = Stack([1]).unshiftAll([1])
+numberOrStringStack = Stack([1]).unshiftAll(['a'])
+// $ExpectError
+numberStack = Stack([1]).unshiftAll(['a'])
+
+numberStack = Stack.of(1).shift()
+// $ExpectError
+numberStack = Stack.of('a').shift()
+
+numberStack = Stack().push(1)
+numberOrStringStack = Stack([1]).push('a')
+// $ExpectError
+numberStack = Stack().push('a')
+
+numberStack = Stack().pushAll([1])
+numberOrStringStack = Stack([1]).pushAll(['a'])
+// $ExpectError
+numberStack = Stack().push(['a'])
+
+numberStack = Stack.of(1).pop()
+// $ExpectError
+numberStack = Stack.of('a').pop()
+
+numberStack = Stack([1]).withMutations(mutable => mutable)
+// $ExpectError
+numberStack = Stack(['a']).withMutations(mutable => mutable)
+
+numberStack = Stack([1]).asMutable()
+// $ExpectError
+numberStack = Stack(['a']).asMutable()
+
+numberStack = Stack([1]).asImmutable()
+// $ExpectError
+numberStack = Stack(['a']).asImmutable()
+
+numberStack = Stack([1]).map((value, index, iter) => 1)
+// $ExpectError
+numberStack = Stack([1]).map((value, index, iter) => 'a')
+
+numberStack = Stack([1]).flatMap((value, index, iter) => [1])
+// $ExpectError
+numberStack = Stack([1]).flatMap((value, index, iter) => ['a'])
+
+numberStack = Stack([1]).flatten()
+numberStack = Stack(['a']).flatten()
+
+/* Range & Repeat */
+
+numberSequence = Range(0, 0, 0)
+// $ExpectError
+stringSequence = Range(0, 0, 0)
+
+numberSequence = Repeat(0, 1)
+// $ExpectError
+numberSequence = Repeat('a', 1)
+
+/* Record */
+// TODO
+
+
+

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -2,7 +2,8 @@
  * @flow
  */
 
-// Some tests look like they are repeated but it's not actually the case; It is very likely to have a false positivie because Flow might not complain about an instance of (what it thinks is) T to be assigned to T<K, V>
+// Some tests look like they are repeated in order to avoid false positives.
+// Flow might not complain about an instance of (what it thinks is) T to be assigned to T<K, V>
 
 import Immutable, {
   List,

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -4,6 +4,36 @@
 
 // Some tests look like they are repeated but it's not actually the case; It is very likely to have a false positivie because Flow might not complain about an instance of (what it thinks is) T to be assigned to T<K, V>
 
+import Immutable, {
+  List,
+  Map,
+  Stack,
+  Set,
+  KeyedIterable,
+  Range,
+  Repeat,
+  IndexedSeq
+} from 'immutable'
+import * as Immutable2 from 'immutable'
+
+const ImmutableList = Immutable.List
+const ImmutableMap = Immutable.Map
+const ImmutableStack = Immutable.Stack
+const ImmutableSet = Immutable.Set
+const ImmutableKeyedIterable = Immutable.KeyedIterable
+const ImmutableRange = Immutable.Range
+const ImmutableRepeat = Immutable.Repeat
+const ImmutableIndexedSeq = Immutable.IndexedSeq
+
+const Immutable2List = Immutable2.List
+const Immutable2Map = Immutable2.Map
+const Immutable2Stack = Immutable2.Stack
+const Immutable2Set = Immutable2.Set
+const Immutable2KeyedIterable = Immutable2.KeyedIterable
+const Immutable2Range = Immutable2.Range
+const Immutable2Repeat = Immutable2.Repeat
+const Immutable2IndexedSeq = Immutable2.IndexedSeq
+
 var numberList: List<number> = List()
 var numberOrStringList: List<string | number> = List()
 var nullableNumberList: List<?number> = List()
@@ -75,7 +105,7 @@ numberList = List.of('a').update((value) => List.of(1))
 // $ExpectError
 numberList = List.of(1).update((value) => List.of('a'))
 
-numberOrStringList = List.of('a').update(0, (value) => 1) 
+numberOrStringList = List.of('a').update(0, (value) => 1)
 // $ExpectError
 numberList = List.of(1).update(0, (value) => 'a')
 
@@ -154,7 +184,7 @@ stringToNumber = Map({'a': 1}).update((value) => Map({'a': 1}))
 // $ExpectError
 stringToNumber = Map({'a': 1}).update((value) => Map({1: 'a'}))
 
-stringToNumberOrString = Map({'a': 1}).update('a', (value) => 'a') 
+stringToNumberOrString = Map({'a': 1}).update('a', (value) => 'a')
 // $ExpectError
 stringToNumber = Map({'a': 1}).update('a', (value) => 'a')
 
@@ -397,6 +427,5 @@ numberStack = Stack(['a']).flatten()
 
 /* Record */
 // TODO
-
 
 

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -11,15 +11,13 @@ var stringToNumber: Map<string, number> = Map()
 var stringToNumberOrString: Map<string, string | number> = Map()
 var numberToString: Map<number, string> = Map()
 var stringOrNumberToNumberOrString: Map<string | number, string | number> = Map()
-var anyMap: Map = Map()
+var anyMap: Map<any, any> = Map()
 var numberSet: Set<number> = Set()
 var numberOrStringSet: Set<number | string> = Set()
 var stringSet: Set<string> = Set()
 var numberStack: Stack<number> = Stack()
 var numberOrStringStack: Stack<string | number> = Stack()
 var number: number = 0
-var numberSequence: IndexedSeq<number>
-var stringSequence: IndexedSeq<string>
 var stringToNumberIterable: KeyedIterable<string, number> = stringToNumber
 var numberToStringIterable: KeyedIterable<number, string> = numberToString
 
@@ -163,15 +161,21 @@ stringToNumber = Map({'a': 1}).update('a', (value) => 'a')
 stringToNumberOrString = Map({'a': 1}).update('a', 'b', (value) => 'a')
 // $ExpectError
 stringToNumber = Map({'a': 1}).update('a', 'b', (value) => 'a')
+// $ExpectError
+stringToNumberOrString = Map({'a': 1}).merge({'a': {a: '1'}})
+// $ExpectError
+stringToNumberOrString = Map({'a': 1}).update('a', 'b', (value) => {a: '1'})
 
 stringToNumber = Map({'a': 1}).merge(Map({'a': 1}))
 stringToNumberOrString = Map({'a': 1}).merge({'a': 'b'})
 // $ExpectError
-stringToNumber = Map({'a': 1}).merge({'a': 'b'})
+stringToNumber = Map({a: 1}).merge({'a': 'b'})
 // $ExpectError
-stringToNumber = Map({'a': 1}).merge([['a', 'b']])
+stringToNumber = Map({a: 1}).merge([[1, 'a']])
+
+// FIXME: Simple `stringToNumber = ...` assignment shows an error at the declaration of stringToNumber and numberToString
 // $ExpectError
-stringToNumber = Map({'a': 1}).merge(Map({'a': 'b'}))
+const stringToNumber: Map<string, number> = Map({a: 1}).merge(numberToString)
 
 stringToNumber = Map({'a': 1}).mergeWith((previous, next, key) => 1, [1])
 // $ExpectError
@@ -233,7 +237,7 @@ numberSet = Set.of(1, 2)
 numberSet = Set.of('a', 'b')
 
 numberSet = Set.fromKeys(Map().set(1, ''))
-stringSet = Set.fromKeys({'a': ''})
+stringSet = Set.fromKeys({a: ''})
 // $ExpectError
 numberSet = Set.fromKeys(Map({'a': 1}))
 // $ExpectError
@@ -380,13 +384,16 @@ numberStack = Stack(['a']).flatten()
 
 /* Range & Repeat */
 
-numberSequence = Range(0, 0, 0)
-// $ExpectError
-stringSequence = Range(0, 0, 0)
+// `{}` provide namespaces
+{ const numberSequence: IndexedSeq<number> = Range(0, 0, 0) }
+{ const numberSequence: IndexedSeq<number> = Repeat(1, 5) }
 
-numberSequence = Repeat(0, 1)
+{ const stringSequence: IndexedSeq<string> = Repeat('a', 5) }
 // $ExpectError
-numberSequence = Repeat('a', 1)
+{ const stringSequence: IndexedSeq<string> = Repeat(0, 1) }
+// $ExpectError
+{ const stringSequence: IndexedSeq<string> = Range(0, 0, 0) }
+
 
 /* Record */
 // TODO


### PR DESCRIPTION
I'm using `Flow` with `Immutable` but I found numerous false positives when I was working with it. 
By _false positives_ I mean cases where types were ignored. Most of the time it resulted in types dropping their generic definition (from `T<K,V> -> T`).

This is `WIP` because:
- tests for `Iterable` and `Seq` are not implemented yet
- `merge` on maps ignores types when given a `ESIterable`. It only infers types from plain objects.
- after initialization without type (for instance by calling `Map()`) and setting a value on empty object it doesn't correctly infer types

```
var map: Map<number, string> = Map().set(1, '')
```

This might be a flaw of Flow so feel free to point it here.

---

In f31e5c2 I copied the definition of `$Iterable` to `immutable-js`. I did it for two reasons:
1. It didn't work
2. `$Iterable` is private

---

Tests for `Iterable` and `Seq` are not implemented yet. I had some problems implementing tests for `Iterable`. Ideally I would like to cast some concrete type to it, but I'm not sure how to do it.

Is the type of `Map<K,V>` `Iterable<K,V,void,void,void>`?

---

**Next steps:**
- If tests receive a 👍🏻 I'm going to implement tests for other types.
- ~~I believe I found a bug in Flow. Namely argument of union type is not correctly resolved. I am not sure how to phrase it in order to file a bug in flow. An instance of this problem can be seen [here](https://github.com/facebook/immutable-js/blob/ea507393e1ff306025938341d07d8153b2bf95ce/type-definitions/immutable.js.flow#L503). `ESIterable` is casted to `{ [key: string]: T }`. How do I name this, _`casting`_?~~
