### PR TITLE
fix #852 footer is behind sidebar and sidebar is cutoff on short pages

### DIFF
--- a/pages/src/docs/src/SideBar.js
+++ b/pages/src/docs/src/SideBar.js
@@ -10,6 +10,18 @@ var SideBar = React.createClass({
 
     return (
       <div className="sideBar">
+        <div className="toolBar">
+          <div onClick={this.props.toggleShowInGroups}>
+            <span className={this.props.showInGroups && 'selected'}>Grouped</span>
+            {' • '}
+            <span className={this.props.showInGroups || 'selected'}>Alphabetized</span>
+          </div>
+          <div onClick={this.props.toggleShowInherited}>
+            <span className={this.props.showInherited && 'selected'}>Inherited</span>
+            {' • '}
+            <span className={this.props.showInherited || 'selected'}>Defined</span>
+          </div>
+        </div>
         <div className="scrollContent">
           <h4 className="groupTitle">API</h4>
           {Seq(type.module).map((t, name) =>

--- a/pages/src/docs/src/TypeDocumentation.js
+++ b/pages/src/docs/src/TypeDocumentation.js
@@ -11,6 +11,17 @@ var collectMemberGroups = require('../../../lib/collectMemberGroups');
 var TypeKind = require('../../../lib/TypeKind');
 var defs = require('../../../lib/getTypeDefs');
 
+var typeDefURL = "https://github.com/facebook/immutable-js/blob/master/type-definitions/Immutable.d.ts";
+var issuesURL = "https://github.com/facebook/immutable-js/issues";
+
+var Disclaimer = function() {
+  return (
+    <section className="disclaimer">
+      This documentation is generated from <a href={typeDefURL}>Immutable.d.ts</a>.
+      Pull requests and <a href={issuesURL}>Issues</a> welcome.
+    </section>
+  );
+}
 
 var TypeDocumentation = React.createClass({
   getInitialState() {
@@ -40,19 +51,14 @@ var TypeDocumentation = React.createClass({
 
     return (
       <div>
-        {isMobile || <SideBar focus={name} memberGroups={memberGroups} />}
-        {isMobile || <div className="toolBar">
-          <div onClick={this.toggleShowInGroups}>
-            <span className={this.state.showInGroups && 'selected'}>Grouped</span>
-            {' • '}
-            <span className={this.state.showInGroups || 'selected'}>Alphabetized</span>
-          </div>
-          <div onClick={this.toggleShowInherited}>
-            <span className={this.state.showInherited && 'selected'}>Inherited</span>
-            {' • '}
-            <span className={this.state.showInherited || 'selected'}>Defined</span>
-          </div>
-        </div>}
+        {isMobile || <SideBar
+          focus={name}
+          memberGroups={memberGroups}
+          toggleShowInherited={this.toggleShowInherited}
+          toggleShowInGroups={this.toggleShowInGroups}
+          showInGroups={this.state.showInGroups}
+          showInherited={this.state.showInherited}
+        />}
         <div key={name} className="docContents">
 
           {!def ?
@@ -123,6 +129,7 @@ var FunctionDoc = React.createClass({
             <MarkDown className="discussion" contents={doc.description} />
           </section>
         }
+        <Disclaimer />
       </div>
     );
   }
@@ -240,6 +247,8 @@ var TypeDoc = React.createClass({
             ])
           ).flatten().toArray()}
         </section>
+
+        <Disclaimer />
       </div>
     );
   }

--- a/pages/src/docs/src/index.js
+++ b/pages/src/docs/src/index.js
@@ -9,18 +9,12 @@ var defs = require('../../../lib/getTypeDefs');
 
 var Documentation = React.createClass({
   render() {
-    var typeDefURL = "https://github.com/facebook/immutable-js/blob/master/type-definitions/Immutable.d.ts";
-    var issuesURL = "https://github.com/facebook/immutable-js/issues";
     return (
       <div>
         <DocHeader />
         <div className="pageBody" id="body">
           <div className="contents">
             <RouteHandler />
-            <section className="disclaimer">
-            This documentation is generated from <a href={typeDefURL}>Immutable.d.ts</a>.
-            Pull requests and <a href={issuesURL}>Issues</a> welcome.
-            </section>
           </div>
         </div>
       </div>

--- a/pages/src/docs/src/style.less
+++ b/pages/src/docs/src/style.less
@@ -86,7 +86,7 @@
   .select-none();
   position: absolute;
   right: 0;
-  top: 66px
+  top: 66px;
   width: 220px;
   color: #888;
   cursor: pointer;

--- a/pages/src/docs/src/style.less
+++ b/pages/src/docs/src/style.less
@@ -13,7 +13,7 @@
 }
 
 .disclaimer {
-  margin: 60px 20px 0 260px;
+  margin: 60px 0 0 0;
   border: solid 1px #eecccc;
   background: #fefafa;
   padding: 1em;
@@ -84,10 +84,9 @@
 
 .toolBar {
   .select-none();
-  font-size: 0.825em;
   position: absolute;
   right: 0;
-  top: 66px;
+  top: 66px
   width: 220px;
   color: #888;
   cursor: pointer;
@@ -108,9 +107,7 @@
   font-size: 0.825em;
   height: 100%;
   overflow: hidden;
-  position: absolute;
-  right: 0;
-  top: 50px;
+  float: right;
   width: 220px;
   z-index: 0;
 }
@@ -125,7 +122,7 @@
   box-sizing: border-box;
   height: 100%;
   overflow: auto;
-  padding: 66px 0 100px;
+  padding: 28px 0 100px;
   width: 240px;
 }
 


### PR DESCRIPTION
#### Summary

Fixes the short page issues mentioned in #852. Didn't mean to push aside #873 but the ability to click on the links in the disclaimer was only part of the problem. An example of this issue on the production documentation site can be seen [here](http://facebook.github.io/immutable-js/docs/#/Record.Class).
#### Features
- [x] Disclaimer is fully visible with clickable links.
- [x] Sidebar is visible and not cut off.

![Example of Short Page Fix](http://i.imgur.com/JM7dEcG.png)
#### Manual Tests

Firefox 47
Chrome 50
Safari 9.1.1
on El Capitan 10.11.5 
