### PR TITLE
Nit: Fix License and Patent links for gh-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,4 +471,4 @@ name. If you're looking for his unsupported package, see [this repository](https
 License
 -------
 
-`Immutable` is [BSD-licensed](./LICENSE). We also provide an additional [patent grant](./PATENTS).
+`Immutable` is [BSD-licensed](https://github.com/facebook/immutable-js/blob/master/LICENSE). We also provide an additional [patent grant](https://github.com/facebook/immutable-js/blob/master/PATENTS).


### PR DESCRIPTION
These links at the bottom of https://facebook.github.io/immutable-js/ were broken since they're relative and https://facebook.github.io/immutable-js/LICENSE and https://facebook.github.io/immutable-js/PATENTS don't exist.

This fixes the issue by using the full link instead of the relative link. I poked around regenerating the hg-pages for you guys, but couldn't find an obvious way to do it so heads up someone will have to regenerate them. =]
