### PR TITLE
ignore JetBrains WebStorm IDE config folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ readme.json
 /pages/out
 /pages/resources/immutable.d.json
 /pages/resources/readme.json
+.idea


### PR DESCRIPTION
Ignore the `.idea` folder to avoid tracking changes as a result of using the JetBrains WebStorm IDE.