### PR TITLE
Use polymorphic 'this' return types for Map methods

### DIFF
--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -471,7 +471,7 @@
      * Returns a new Map also containing the new key, value pair. If an equivalent
      * key already exists in this Map, it will be replaced.
      */
-    set(key: K, value: V): Map<K, V>;
+    set(key: K, value: V): this;
 
     /**
      * Returns a new Map which excludes this `key`.
@@ -480,13 +480,13 @@
      * the ES6 collection API.
      * @alias remove
      */
-    delete(key: K): Map<K, V>;
-    remove(key: K): Map<K, V>;
+    delete(key: K): this;
+    remove(key: K): this;
 
     /**
      * Returns a new Map containing no keys or values.
      */
-    clear(): Map<K, V>;
+    clear(): this;
 
     /**
      * Returns a new Map having updated the value at this `key` with the return
@@ -496,9 +496,9 @@
      *
      * Equivalent to: `map.set(key, updater(map.get(key, notSetValue)))`.
      */
-    update(updater: (value: Map<K, V>) => Map<K, V>): Map<K, V>;
-    update(key: K, updater: (value: V) => V): Map<K, V>;
-    update(key: K, notSetValue: V, updater: (value: V) => V): Map<K, V>;
+    update(updater: (value: this) => this): this;
+    update(key: K, updater: (value: V) => V): this;
+    update(key: K, notSetValue: V, updater: (value: V) => V): this;
 
     /**
      * Returns a new Map resulting from merging the provided Iterables
@@ -517,7 +517,7 @@
      *     y.merge(x) // { b: 20, a: 10, d: 60, c: 30 }
      *
      */
-    merge(...iterables: Iterable<K, V>[]): Map<K, V>;
+    merge(...iterables: Iterable<K, V>[]): this;
     merge(...iterables: {[key: string]: V}[]): Map<string, V>;
 
     /**
@@ -534,7 +534,7 @@
     mergeWith(
       merger: (previous?: V, next?: V, key?: K) => V,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeWith(
       merger: (previous?: V, next?: V, key?: K) => V,
       ...iterables: {[key: string]: V}[]
@@ -549,7 +549,7 @@
      *     x.mergeDeep(y) // {a: { x: 2, y: 10 }, b: { x: 20, y: 5 }, c: { z: 3 } }
      *
      */
-    mergeDeep(...iterables: Iterable<K, V>[]): Map<K, V>;
+    mergeDeep(...iterables: Iterable<K, V>[]): this;
     mergeDeep(...iterables: {[key: string]: V}[]): Map<string, V>;
 
     /**
@@ -565,7 +565,7 @@
     mergeDeepWith(
       merger: (previous?: V, next?: V, key?: K) => V,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeDeepWith(
       merger: (previous?: V, next?: V, key?: K) => V,
       ...iterables: {[key: string]: V}[]
@@ -578,8 +578,8 @@
      * Returns a new Map having set `value` at this `keyPath`. If any keys in
      * `keyPath` do not exist, a new immutable Map will be created at that key.
      */
-    setIn(keyPath: Array<any>, value: any): Map<K, V>;
-    setIn(KeyPath: Iterable<any, any>, value: any): Map<K, V>;
+    setIn(keyPath: Array<any>, value: any): this;
+    setIn(KeyPath: Iterable<any, any>, value: any): this;
 
     /**
      * Returns a new Map having removed the value at this `keyPath`. If any keys
@@ -587,10 +587,10 @@
      *
      * @alias removeIn
      */
-    deleteIn(keyPath: Array<any>): Map<K, V>;
-    deleteIn(keyPath: Iterable<any, any>): Map<K, V>;
-    removeIn(keyPath: Array<any>): Map<K, V>;
-    removeIn(keyPath: Iterable<any, any>): Map<K, V>;
+    deleteIn(keyPath: Array<any>): this;
+    deleteIn(keyPath: Iterable<any, any>): this;
+    removeIn(keyPath: Array<any>): this;
+    removeIn(keyPath: Iterable<any, any>): this;
 
     /**
      * Returns a new Map having applied the `updater` to the entry found at the
@@ -616,21 +616,21 @@
     updateIn(
       keyPath: Array<any>,
       updater: (value: any) => any
-    ): Map<K, V>;
+    ): this;
     updateIn(
       keyPath: Array<any>,
       notSetValue: any,
       updater: (value: any) => any
-    ): Map<K, V>;
+    ): this;
     updateIn(
       keyPath: Iterable<any, any>,
       updater: (value: any) => any
-    ): Map<K, V>;
+    ): this;
     updateIn(
       keyPath: Iterable<any, any>,
       notSetValue: any,
       updater: (value: any) => any
-    ): Map<K, V>;
+    ): this;
 
     /**
      * A combination of `updateIn` and `merge`, returning a new Map, but
@@ -644,11 +644,11 @@
     mergeIn(
       keyPath: Iterable<any, any>,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeIn(
       keyPath: Array<any>,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeIn(
       keyPath: Array<any>,
       ...iterables: {[key: string]: V}[]
@@ -666,11 +666,11 @@
     mergeDeepIn(
       keyPath: Iterable<any, any>,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeDeepIn(
       keyPath: Array<any>,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeDeepIn(
       keyPath: Array<any>,
       ...iterables: {[key: string]: V}[]
@@ -703,7 +703,7 @@
      * `withMutations`! Only `set` and `merge` may be used mutatively.
      *
      */
-    withMutations(mutator: (mutable: Map<K, V>) => any): Map<K, V>;
+    withMutations(mutator: (mutable: this) => any): this;
 
     /**
      * Another way to avoid creation of intermediate Immutable maps is to create
@@ -718,14 +718,14 @@
      * Note: Not all methods can be used on a mutable collection or within
      * `withMutations`! Only `set` and `merge` may be used mutatively.
      */
-    asMutable(): Map<K, V>;
+    asMutable(): this;
 
     /**
      * The yin to `asMutable`'s yang. Because it applies to mutable collections,
      * this operation is *mutable* and returns itself. Once performed, the mutable
      * copy has become immutable and can be safely returned from a function.
      */
-    asImmutable(): Map<K, V>;
+    asImmutable(): this;
   }
 
 

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -471,7 +471,7 @@ declare module Immutable {
      * Returns a new Map also containing the new key, value pair. If an equivalent
      * key already exists in this Map, it will be replaced.
      */
-    set(key: K, value: V): Map<K, V>;
+    set(key: K, value: V): this;
 
     /**
      * Returns a new Map which excludes this `key`.
@@ -480,13 +480,13 @@ declare module Immutable {
      * the ES6 collection API.
      * @alias remove
      */
-    delete(key: K): Map<K, V>;
-    remove(key: K): Map<K, V>;
+    delete(key: K): this;
+    remove(key: K): this;
 
     /**
      * Returns a new Map containing no keys or values.
      */
-    clear(): Map<K, V>;
+    clear(): this;
 
     /**
      * Returns a new Map having updated the value at this `key` with the return
@@ -496,9 +496,9 @@ declare module Immutable {
      *
      * Equivalent to: `map.set(key, updater(map.get(key, notSetValue)))`.
      */
-    update(updater: (value: Map<K, V>) => Map<K, V>): Map<K, V>;
-    update(key: K, updater: (value: V) => V): Map<K, V>;
-    update(key: K, notSetValue: V, updater: (value: V) => V): Map<K, V>;
+    update(updater: (value: this) => this): this;
+    update(key: K, updater: (value: V) => V): this;
+    update(key: K, notSetValue: V, updater: (value: V) => V): this;
 
     /**
      * Returns a new Map resulting from merging the provided Iterables
@@ -517,7 +517,7 @@ declare module Immutable {
      *     y.merge(x) // { b: 20, a: 10, d: 60, c: 30 }
      *
      */
-    merge(...iterables: Iterable<K, V>[]): Map<K, V>;
+    merge(...iterables: Iterable<K, V>[]): this;
     merge(...iterables: {[key: string]: V}[]): Map<string, V>;
 
     /**
@@ -534,7 +534,7 @@ declare module Immutable {
     mergeWith(
       merger: (previous?: V, next?: V, key?: K) => V,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeWith(
       merger: (previous?: V, next?: V, key?: K) => V,
       ...iterables: {[key: string]: V}[]
@@ -549,7 +549,7 @@ declare module Immutable {
      *     x.mergeDeep(y) // {a: { x: 2, y: 10 }, b: { x: 20, y: 5 }, c: { z: 3 } }
      *
      */
-    mergeDeep(...iterables: Iterable<K, V>[]): Map<K, V>;
+    mergeDeep(...iterables: Iterable<K, V>[]): this;
     mergeDeep(...iterables: {[key: string]: V}[]): Map<string, V>;
 
     /**
@@ -565,7 +565,7 @@ declare module Immutable {
     mergeDeepWith(
       merger: (previous?: V, next?: V, key?: K) => V,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeDeepWith(
       merger: (previous?: V, next?: V, key?: K) => V,
       ...iterables: {[key: string]: V}[]
@@ -578,8 +578,8 @@ declare module Immutable {
      * Returns a new Map having set `value` at this `keyPath`. If any keys in
      * `keyPath` do not exist, a new immutable Map will be created at that key.
      */
-    setIn(keyPath: Array<any>, value: any): Map<K, V>;
-    setIn(KeyPath: Iterable<any, any>, value: any): Map<K, V>;
+    setIn(keyPath: Array<any>, value: any): this;
+    setIn(KeyPath: Iterable<any, any>, value: any): this;
 
     /**
      * Returns a new Map having removed the value at this `keyPath`. If any keys
@@ -587,10 +587,10 @@ declare module Immutable {
      *
      * @alias removeIn
      */
-    deleteIn(keyPath: Array<any>): Map<K, V>;
-    deleteIn(keyPath: Iterable<any, any>): Map<K, V>;
-    removeIn(keyPath: Array<any>): Map<K, V>;
-    removeIn(keyPath: Iterable<any, any>): Map<K, V>;
+    deleteIn(keyPath: Array<any>): this;
+    deleteIn(keyPath: Iterable<any, any>): this;
+    removeIn(keyPath: Array<any>): this;
+    removeIn(keyPath: Iterable<any, any>): this;
 
     /**
      * Returns a new Map having applied the `updater` to the entry found at the
@@ -616,21 +616,21 @@ declare module Immutable {
     updateIn(
       keyPath: Array<any>,
       updater: (value: any) => any
-    ): Map<K, V>;
+    ): this;
     updateIn(
       keyPath: Array<any>,
       notSetValue: any,
       updater: (value: any) => any
-    ): Map<K, V>;
+    ): this;
     updateIn(
       keyPath: Iterable<any, any>,
       updater: (value: any) => any
-    ): Map<K, V>;
+    ): this;
     updateIn(
       keyPath: Iterable<any, any>,
       notSetValue: any,
       updater: (value: any) => any
-    ): Map<K, V>;
+    ): this;
 
     /**
      * A combination of `updateIn` and `merge`, returning a new Map, but
@@ -644,11 +644,11 @@ declare module Immutable {
     mergeIn(
       keyPath: Iterable<any, any>,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeIn(
       keyPath: Array<any>,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeIn(
       keyPath: Array<any>,
       ...iterables: {[key: string]: V}[]
@@ -666,11 +666,11 @@ declare module Immutable {
     mergeDeepIn(
       keyPath: Iterable<any, any>,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeDeepIn(
       keyPath: Array<any>,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeDeepIn(
       keyPath: Array<any>,
       ...iterables: {[key: string]: V}[]
@@ -703,7 +703,7 @@ declare module Immutable {
      * `withMutations`! Only `set` and `merge` may be used mutatively.
      *
      */
-    withMutations(mutator: (mutable: Map<K, V>) => any): Map<K, V>;
+    withMutations(mutator: (mutable: this) => any): this;
 
     /**
      * Another way to avoid creation of intermediate Immutable maps is to create
@@ -718,14 +718,14 @@ declare module Immutable {
      * Note: Not all methods can be used on a mutable collection or within
      * `withMutations`! Only `set` and `merge` may be used mutatively.
      */
-    asMutable(): Map<K, V>;
+    asMutable(): this;
 
     /**
      * The yin to `asMutable`'s yang. Because it applies to mutable collections,
      * this operation is *mutable* and returns itself. Once performed, the mutable
      * copy has become immutable and can be safely returned from a function.
      */
-    asImmutable(): Map<K, V>;
+    asImmutable(): this;
   }
 
 

--- a/pages/lib/DocVisitor.js
+++ b/pages/lib/DocVisitor.js
@@ -42,7 +42,7 @@ class DocVisitor extends TypeScript.SyntaxWalker {
   }
 
   isAliased(name) {
-    return !!Seq(this.aliases).last()[name];
+    return this.aliases.length && !!Seq(this.aliases).last()[name];
   }
 
   addAliases(comment, name) {

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -471,7 +471,7 @@ declare module Immutable {
      * Returns a new Map also containing the new key, value pair. If an equivalent
      * key already exists in this Map, it will be replaced.
      */
-    set(key: K, value: V): Map<K, V>;
+    set(key: K, value: V): this;
 
     /**
      * Returns a new Map which excludes this `key`.
@@ -480,13 +480,13 @@ declare module Immutable {
      * the ES6 collection API.
      * @alias remove
      */
-    delete(key: K): Map<K, V>;
-    remove(key: K): Map<K, V>;
+    delete(key: K): this;
+    remove(key: K): this;
 
     /**
      * Returns a new Map containing no keys or values.
      */
-    clear(): Map<K, V>;
+    clear(): this;
 
     /**
      * Returns a new Map having updated the value at this `key` with the return
@@ -496,9 +496,9 @@ declare module Immutable {
      *
      * Equivalent to: `map.set(key, updater(map.get(key, notSetValue)))`.
      */
-    update(updater: (value: Map<K, V>) => Map<K, V>): Map<K, V>;
-    update(key: K, updater: (value: V) => V): Map<K, V>;
-    update(key: K, notSetValue: V, updater: (value: V) => V): Map<K, V>;
+    update(updater: (value: this) => this): this;
+    update(key: K, updater: (value: V) => V): this;
+    update(key: K, notSetValue: V, updater: (value: V) => V): this;
 
     /**
      * Returns a new Map resulting from merging the provided Iterables
@@ -517,7 +517,7 @@ declare module Immutable {
      *     y.merge(x) // { b: 20, a: 10, d: 60, c: 30 }
      *
      */
-    merge(...iterables: Iterable<K, V>[]): Map<K, V>;
+    merge(...iterables: Iterable<K, V>[]): this;
     merge(...iterables: {[key: string]: V}[]): Map<string, V>;
 
     /**
@@ -534,7 +534,7 @@ declare module Immutable {
     mergeWith(
       merger: (previous?: V, next?: V, key?: K) => V,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeWith(
       merger: (previous?: V, next?: V, key?: K) => V,
       ...iterables: {[key: string]: V}[]
@@ -549,7 +549,7 @@ declare module Immutable {
      *     x.mergeDeep(y) // {a: { x: 2, y: 10 }, b: { x: 20, y: 5 }, c: { z: 3 } }
      *
      */
-    mergeDeep(...iterables: Iterable<K, V>[]): Map<K, V>;
+    mergeDeep(...iterables: Iterable<K, V>[]): this;
     mergeDeep(...iterables: {[key: string]: V}[]): Map<string, V>;
 
     /**
@@ -565,7 +565,7 @@ declare module Immutable {
     mergeDeepWith(
       merger: (previous?: V, next?: V, key?: K) => V,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeDeepWith(
       merger: (previous?: V, next?: V, key?: K) => V,
       ...iterables: {[key: string]: V}[]
@@ -578,8 +578,8 @@ declare module Immutable {
      * Returns a new Map having set `value` at this `keyPath`. If any keys in
      * `keyPath` do not exist, a new immutable Map will be created at that key.
      */
-    setIn(keyPath: Array<any>, value: any): Map<K, V>;
-    setIn(KeyPath: Iterable<any, any>, value: any): Map<K, V>;
+    setIn(keyPath: Array<any>, value: any): this;
+    setIn(KeyPath: Iterable<any, any>, value: any): this;
 
     /**
      * Returns a new Map having removed the value at this `keyPath`. If any keys
@@ -587,10 +587,10 @@ declare module Immutable {
      *
      * @alias removeIn
      */
-    deleteIn(keyPath: Array<any>): Map<K, V>;
-    deleteIn(keyPath: Iterable<any, any>): Map<K, V>;
-    removeIn(keyPath: Array<any>): Map<K, V>;
-    removeIn(keyPath: Iterable<any, any>): Map<K, V>;
+    deleteIn(keyPath: Array<any>): this;
+    deleteIn(keyPath: Iterable<any, any>): this;
+    removeIn(keyPath: Array<any>): this;
+    removeIn(keyPath: Iterable<any, any>): this;
 
     /**
      * Returns a new Map having applied the `updater` to the entry found at the
@@ -616,21 +616,21 @@ declare module Immutable {
     updateIn(
       keyPath: Array<any>,
       updater: (value: any) => any
-    ): Map<K, V>;
+    ): this;
     updateIn(
       keyPath: Array<any>,
       notSetValue: any,
       updater: (value: any) => any
-    ): Map<K, V>;
+    ): this;
     updateIn(
       keyPath: Iterable<any, any>,
       updater: (value: any) => any
-    ): Map<K, V>;
+    ): this;
     updateIn(
       keyPath: Iterable<any, any>,
       notSetValue: any,
       updater: (value: any) => any
-    ): Map<K, V>;
+    ): this;
 
     /**
      * A combination of `updateIn` and `merge`, returning a new Map, but
@@ -644,11 +644,11 @@ declare module Immutable {
     mergeIn(
       keyPath: Iterable<any, any>,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeIn(
       keyPath: Array<any>,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeIn(
       keyPath: Array<any>,
       ...iterables: {[key: string]: V}[]
@@ -666,11 +666,11 @@ declare module Immutable {
     mergeDeepIn(
       keyPath: Iterable<any, any>,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeDeepIn(
       keyPath: Array<any>,
       ...iterables: Iterable<K, V>[]
-    ): Map<K, V>;
+    ): this;
     mergeDeepIn(
       keyPath: Array<any>,
       ...iterables: {[key: string]: V}[]
@@ -703,7 +703,7 @@ declare module Immutable {
      * `withMutations`! Only `set` and `merge` may be used mutatively.
      *
      */
-    withMutations(mutator: (mutable: Map<K, V>) => any): Map<K, V>;
+    withMutations(mutator: (mutable: this) => any): this;
 
     /**
      * Another way to avoid creation of intermediate Immutable maps is to create
@@ -718,14 +718,14 @@ declare module Immutable {
      * Note: Not all methods can be used on a mutable collection or within
      * `withMutations`! Only `set` and `merge` may be used mutatively.
      */
-    asMutable(): Map<K, V>;
+    asMutable(): this;
 
     /**
      * The yin to `asMutable`'s yang. Because it applies to mutable collections,
      * this operation is *mutable* and returns itself. Once performed, the mutable
      * copy has become immutable and can be safely returned from a function.
      */
-    asImmutable(): Map<K, V>;
+    asImmutable(): this;
   }
 
 


### PR DESCRIPTION
## The Problem

As a simplified example, consider the following `ABClass`, which extends from `ABRecord` (itself instantiated with `Record({ a: 1, b: 2 })`):

``` ts
const ABRecord = Record({ a: 1, b: 2 });

class ABClass extends ABRecord {
  a: number;
  b: number;

  setA(a: number) {
    return this.set('a', a);
  }

  setB(b: number) {
    return this.set('b', b);
  }
}
```

Because the return type of `Map.set` is specified explicitly as `Map<K, V>`, the following attempt at chaining the method calls will alert the TS compiler:

``` ts
const ab = new ABClass({ b: 3 });
const ab2 = ab.setA(5).setB(6);
console.log(ab2.a, ab2.b);
```

As a result, we must cast the return types of `ABClass.setA` and `ABClass.setB` methods explicitly to `ABClass` in order to satisfy the TS compiler.

---

The situation is more complicated when calling `withMutations`:

``` ts
const ab3 = ab.withMutations(
  mutable => mutable.set('a', mutable.a + 1).set('b', mutable.b + 1));
```

The above example fails to compile because `mutable` is typed to `Map<string, any>`, which does not have the properties `a` and `b`, so we have to either access them with `get`, or cast mutable to `ABClass`, as well as having to cast the return type that will be assigned to `ab3`.
## The Solution

This PR addresses those problems, by using polymorphic `this` return types for `Map.*` methods that result in a new `Map` of the same type.
