### PR TITLE
Make the documentation sidebar position fixed.

### DIFF
--- a/pages/src/docs/src/style.less
+++ b/pages/src/docs/src/style.less
@@ -126,6 +126,7 @@
   height: 100%;
   overflow: auto;
   padding: 66px 0 100px;
+  position: fixed;
   width: 240px;
 }
 


### PR DESCRIPTION
The sidebar in the documentation is always positioned at the top of the document, making navigating the docs extremely difficult.  

I recently used Stylish (a chrome plugin that lets you change styles on pages) to make this change myself, and thought that other people might enjoy it as well. 
