### PR TITLE
Ensure 'Example' header shows for method documentation that end with examples

### DIFF
--- a/pages/lib/DocVisitor.js
+++ b/pages/lib/DocVisitor.js
@@ -388,6 +388,7 @@ function setIn(obj, path, value) {
 }
 
 var COMMENT_NOTE_RX = /@(\w+)(?:\s+(.*))?/;
+var COMMENT_EXAMPLE_RX = /^\s{4}\S.+/;
 
 var NOTE_BLACKLIST = {
   override: true
@@ -412,6 +413,13 @@ function parseComment(node) {
   var paragraphs =
     lines.filter(l => !COMMENT_NOTE_RX.test(l)).join('\n').split('\n\n');
   var synopsis = paragraphs.shift();
+  
+  var lastParagraph = paragraphs[paragraphs.length - 1];
+  var example;
+  if (lastParagraph && lastParagraph.match(COMMENT_EXAMPLE_RX)) {
+    example = paragraphs.pop();
+  }
+  
   var description = paragraphs.join('\n\n');
 
   var comment = { synopsis };
@@ -420,6 +428,9 @@ function parseComment(node) {
   }
   if (description) {
     comment.description = description;
+  }
+  if (example) {
+    comment.example = example;
   }
 
   return comment;

--- a/pages/lib/markdownDocs.js
+++ b/pages/lib/markdownDocs.js
@@ -45,6 +45,7 @@ function markdownDoc(doc, context) {
       note.body = markdown(note.body, context);
     }
   });
+  doc.example && (doc.example = markdown(doc.example, context));
 }
 
 module.exports = markdownDocs;

--- a/pages/src/docs/src/MemberDoc.js
+++ b/pages/src/docs/src/MemberDoc.js
@@ -142,12 +142,14 @@ var MemberDoc = React.createClass({
               )}
               {doc.description &&
                 <section>
-                  <h4 className="infoHeader">
-                    {doc.description.substr(0, 5) === '<code' ?
-                      'Example' :
-                      'Discussion'}
-                  </h4>
+                  <h4 className="infoHeader">Discussion</h4>
                   <MarkDown className="discussion" contents={doc.description} />
+                </section>
+              }
+              {doc.example &&
+                <section>
+                  <h4 className="infoHeader">Example</h4>
+                  <MarkDown className="example" contents={doc.example} />
                 </section>
               }
             </div>

--- a/pages/src/docs/src/TypeDocumentation.js
+++ b/pages/src/docs/src/TypeDocumentation.js
@@ -115,12 +115,14 @@ var FunctionDoc = React.createClass({
         )}
         {doc.description &&
           <section>
-            <h4 className="infoHeader">
-              {doc.description.substr(0, 5) === '<code' ?
-                'Example' :
-                'Discussion'}
-            </h4>
+            <h4 className="infoHeader">Discussion</h4>
             <MarkDown className="discussion" contents={doc.description} />
+          </section>
+        }
+        {doc.example &&
+          <section>
+            <h4 className="infoHeader">Example</h4>
+            <MarkDown className="example" contents={doc.example} />
           </section>
         }
       </div>
@@ -167,12 +169,14 @@ var TypeDoc = React.createClass({
 
         {doc.description &&
           <section>
-            <h4 className="infoHeader">
-              {doc.description.substr(0, 5) === '<code' ?
-                'Example' :
-                'Discussion'}
-            </h4>
+            <h4 className="infoHeader">Discussion</h4>
             <MarkDown className="discussion" contents={doc.description} />
+          </section>
+        }
+        {doc.example &&
+          <section>
+            <h4 className="infoHeader">Example</h4>
+            <MarkDown className="example" contents={doc.example} />
           </section>
         }
 

--- a/pages/src/docs/src/style.less
+++ b/pages/src/docs/src/style.less
@@ -198,7 +198,7 @@
   margin: -0.5em 0 1em;
 }
 
-.discussion p:first-child {
+.discussion p:first-child, .example code {
   margin-top: 0.5em;
 }
 

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -1887,8 +1887,6 @@ declare module Immutable {
      * The returned Seq will have identical iteration order as
      * this Iterable.
      *
-     * Example:
-     *
      *     var indexedSeq = Immutable.Seq.of('A', 'B', 'C');
      *     indexedSeq.filter(v => v === 'B').toString() // Seq [ 'B' ]
      *     var keyedSeq = indexedSeq.toKeyedSeq();


### PR DESCRIPTION
Documentation for methods that have both a "Discussion" paragraph and an "Example" are missing the "Example" header.

For instance, compare the documentation for `merge`...
<img width="400" alt="screen shot 2016-07-16 at 12 30 29 am" src="https://cloud.githubusercontent.com/assets/7499938/16892411/6ff21ffa-4aec-11e6-8cac-c3468cc4b38a.png">
...with the documention for `mergeWith`...
<img width="400" alt="screen shot 2016-07-16 at 12 30 44 am" src="https://cloud.githubusercontent.com/assets/7499938/16892416/9fb0b0f8-4aec-11e6-9d5e-7a74d8bc659c.png">

**This PR corrects this by putting examples in a distinct `example` property of the doc definition when parsing the comment in `DocVistor`. This property is then used explicitly in `MemberDoc` and `TypeDocumentation` instead of rendering the example as a part of the description.**

It then also removes an explicitly added "Example:" header that is now redundant.
