### PR TITLE
Overloads for concat

### DIFF
--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -403,6 +403,20 @@
       mapper: (value: T, key: number, iter: /*this*/List<T>) => M,
       context?: any
     ): List<M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, T>>): List<T>;
+    concat<I1>(iterable1: Iterable<any, I1>): List<T | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): List<T | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): List<T | I1 | I2 | I3>;
   }
 
 
@@ -756,6 +770,20 @@
       mapper: (value: V, key: K, iter: /*this*/Map<K, V>) => M,
       context?: any
     ): Map<K, M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, V>>): Map<K, V>;
+    concat<I1>(iterable1: Iterable<any, I1>): Map<K, V | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Map<K, V | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Map<K, V | I1 | I2 | I3>;
   }
 
 
@@ -817,6 +845,19 @@
       context?: any
     ): OrderedMap<K, M>;
 
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, V>>): OrderedMap<K, V>;
+    concat<I1>(iterable1: Iterable<any, I1>): OrderedMap<K, V | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): OrderedMap<K, V | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): OrderedMap<K, V | I1 | I2 | I3>;
   }
 
 
@@ -945,6 +986,20 @@
       mapper: (value: T, key: T, iter: /*this*/Set<T>) => M,
       context?: any
     ): Set<M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, T>>): Set<T>;
+    concat<I1>(iterable1: Iterable<any, I1>): Set<T | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Set<T | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Set<T | I1 | I2 | I3>;
   }
 
 
@@ -1006,6 +1061,20 @@
       mapper: (value: T, key: T, iter: /*this*/OrderedSet<T>) => M,
       context?: any
     ): OrderedSet<M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, T>>): OrderedSet<T>;
+    concat<I1>(iterable1: Iterable<any, I1>): OrderedSet<T | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): OrderedSet<T | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): OrderedSet<T | I1 | I2 | I3>;
   }
 
 
@@ -1142,6 +1211,20 @@
       mapper: (value: T, key: number, iter: /*this*/Stack<T>) => M,
       context?: any
     ): Stack<M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, T>>): Stack<T>;
+    concat<I1>(iterable1: Iterable<any, I1>): Stack<T | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Stack<T | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Stack<T | I1 | I2 | I3>;
   }
 
 
@@ -1337,6 +1420,20 @@
         mapper: (value: V, key: K, iter: /*this*/Seq.Keyed<K, V>) => M,
         context?: any
       ): Seq.Keyed<K, M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Keyed<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Keyed<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Keyed<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Keyed<T | I1 | I2 | I3>;
     }
 
 
@@ -1382,6 +1479,20 @@
         mapper: (value: T, key: number, iter: /*this*/Seq.Indexed<T>) => M,
         context?: any
       ): Seq.Indexed<M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq.Indexed<K, V>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Indexed<K, V | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Indexed<K, V | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Indexed<K, V | I1 | I2 | I3>;
     }
 
 
@@ -1429,6 +1540,20 @@
         mapper: (value: T, key: T, iter: /*this*/Seq.Set<T>) => M,
         context?: any
       ): Seq.Set<M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Set<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Set<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Set<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Set<T | I1 | I2 | I3>;
     }
 
   }
@@ -1507,6 +1632,20 @@
       mapper: (value: V, key: K, iter: /*this*/Seq<K, V>) => M,
       context?: any
     ): Seq<K, M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq<K, V>;
+    concat<I1>(iterable1: Iterable<any, I1>): Seq<K, V | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq<K, V | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq<K, V | I1 | I2 | I3>;
   }
 
   /**
@@ -1633,6 +1772,20 @@
         mapper: (value: V, key: K, iter: /*this*/Iterable.Keyed<K, V>) => M,
         context?: any
       ): Iterable.Keyed<K, M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, V>>): Iterable.Keyed<K, V>;
+      concat<I1>(iterable1: Iterable<any, I1>): Iterable.Keyed<K, V | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Iterable.Keyed<K, V | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Iterable.Keyed<K, V | I1 | I2 | I3>;
     }
 
 
@@ -1821,6 +1974,20 @@
         mapper: (value: T, key: number, iter: /*this*/Iterable.Indexed<T>) => M,
         context?: any
       ): Iterable.Indexed<T>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Iterable.Indexed<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Iterable.Indexed<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Iterable.Indexed<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Iterable.Indexed<T | I1 | I2 | I3>;
     }
 
 
@@ -1870,6 +2037,20 @@
         mapper: (value: T, key: T, iter: /*this*/Iterable.Set<T>) => M,
         context?: any
       ): Iterable.Set<T>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Iterable.Set<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Iterable.Set<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Iterable.Set<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Iterable.Set<T | I1 | I2 | I3>;
     }
 
   }
@@ -2682,6 +2863,20 @@
         mapper: (value: V, key: K, iter: /*this*/Collection.Keyed<K, V>) => M,
         context?: any
       ): Collection.Keyed<K, M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, V>>): Collection.Keyed<K, V>;
+      concat<I1>(iterable1: Iterable<any, I1>): Collection.Keyed<K, V | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Collection.Keyed<K, V | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Collection.Keyed<K, V | I1 | I2 | I3>;
     }
 
 
@@ -2712,6 +2907,20 @@
         mapper: (value: T, key: number, iter: /*this*/Collection.Indexed<T>) => M,
         context?: any
       ): Collection.Indexed<T>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Collection.Indexed<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Collection.Indexed<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Collection.Indexed<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Collection.Indexed<T | I1 | I2 | I3>;
     }
 
 
@@ -2744,6 +2953,20 @@
         mapper: (value: T, key: T, iter: /*this*/Collection.Set<T>) => M,
         context?: any
       ): Collection.Set<T>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Collection.Set<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Collection.Set<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Collection.Set<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Collection.Set<T | I1 | I2 | I3>;
     }
 
   }

--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -1430,10 +1430,10 @@
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Keyed<T>;
-      concat<I1>(iterable1: Iterable<any, I1>): Seq.Keyed<T | I1>;
-      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Keyed<T | I1 | I2>;
-      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Keyed<T | I1 | I2 | I3>;
+      concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq.Keyed<K, V>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Keyed<K, V | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Keyed<K, V | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Keyed<K, V | I1 | I2 | I3>;
     }
 
 
@@ -1489,10 +1489,10 @@
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq.Indexed<K, V>;
-      concat<I1>(iterable1: Iterable<any, I1>): Seq.Indexed<K, V | I1>;
-      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Indexed<K, V | I1 | I2>;
-      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Indexed<K, V | I1 | I2 | I3>;
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Indexed<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Indexed<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Indexed<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Indexed<T | I1 | I2 | I3>;
     }
 
 

--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -813,7 +813,7 @@
      *
      */
     map<M>(
-      mapper: (value: V, key: K, iter: /*this*/OrderedMap<k, V>) => M,
+      mapper: (value: V, key: K, iter: /*this*/OrderedMap<K, V>) => M,
       context?: any
     ): OrderedMap<K, M>;
 
@@ -1867,7 +1867,7 @@
        *
        */
       map<M>(
-        mapper: (value: T, key: number, iter: /*this*/Iterable.Set<T>) => M,
+        mapper: (value: T, key: T, iter: /*this*/Iterable.Set<T>) => M,
         context?: any
       ): Iterable.Set<T>;
     }
@@ -2741,7 +2741,7 @@
        *
        */
       map<M>(
-        mapper: (value: T, key: number, iter: /*this*/Collection.Set<T>) => M,
+        mapper: (value: T, key: T, iter: /*this*/Collection.Set<T>) => M,
         context?: any
       ): Collection.Set<T>;
     }

--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -388,6 +388,21 @@
      * @see `Map#asImmutable`
      */
     asImmutable(): List<T>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new List with values passed through a
+     * `mapper` function.
+     *
+     *     List([1,2]).map(x => 10 * x)
+     *     // List [ 10, 20 ]
+     *
+     */
+    map<M>(
+      mapper: (value: T, key: number, iter: /*this*/List<T>) => M,
+      context?: any
+    ): List<M>;
   }
 
 
@@ -726,6 +741,21 @@
      * copy has become immutable and can be safely returned from a function.
      */
     asImmutable(): Map<K, V>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Map with values passed through a
+     * `mapper` function.
+     *
+     *     Map({ a: 1, b: 2 }).map(x => 10 * x)
+     *     // Map { a: 10, b: 20 }
+     *
+     */
+    map<M>(
+      mapper: (value: V, key: K, iter: /*this*/Map<K, V>) => M,
+      context?: any
+    ): Map<K, M>;
   }
 
 
@@ -770,7 +800,24 @@
   export function OrderedMap<K, V>(iterator: Iterator</*[K,V]*/Array<any>>): OrderedMap<K, V>;
   export function OrderedMap<K, V>(iterable: /*Iterable<[K,V]>*/Object): OrderedMap<K, V>;
 
-  export interface OrderedMap<K, V> extends Map<K, V> {}
+  export interface OrderedMap<K, V> extends Map<K, V> {
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new OrderedMap with values passed through a
+     * `mapper` function.
+     *
+     *     OrderedMap({ a: 1, b: 2 }).map(x => 10 * x)
+     *     // OrderedMap { a: 10, b: 20 }
+     *
+     */
+    map<M>(
+      mapper: (value: V, key: K, iter: /*this*/OrderedMap<k, V>) => M,
+      context?: any
+    ): OrderedMap<K, M>;
+
+  }
 
 
   /**
@@ -883,6 +930,21 @@
      * @see `Map#asImmutable`
      */
     asImmutable(): Set<T>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Set with values passed through a
+     * `mapper` function.
+     *
+     *     Set([1,2]).map(x => 10 * x)
+     *     // Set [10,20]
+     *
+     */
+    map<M>(
+      mapper: (value: T, key: T, iter: /*this*/Set<T>) => M,
+      context?: any
+    ): Set<M>;
   }
 
 
@@ -928,7 +990,23 @@
   export function OrderedSet<T>(iterator: Iterator<T>): OrderedSet<T>;
   export function OrderedSet<T>(iterable: /*Iterable<T>*/Object): OrderedSet<T>;
 
-  export interface OrderedSet<T> extends Set<T> {}
+  export interface OrderedSet<T> extends Set<T> {
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Set with values passed through a
+     * `mapper` function.
+     *
+     *     OrderedSet([1,2]).map(x => 10 * x)
+     *     // Set [10,20]
+     *
+     */
+    map<M>(
+      mapper: (value: T, key: T, iter: /*this*/OrderedSet<T>) => M,
+      context?: any
+    ): OrderedSet<M>;
+  }
 
 
   /**
@@ -1049,6 +1127,21 @@
      * @see `Map#asImmutable`
      */
     asImmutable(): Stack<T>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Stack with values passed through a
+     * `mapper` function.
+     *
+     *     Stack([1,2]).map(x => 10 * x)
+     *     // Stack [10,20]
+     *
+     */
+    map<M>(
+      mapper: (value: T, key: number, iter: /*this*/Stack<T>) => M,
+      context?: any
+    ): Stack<M>;
   }
 
 
@@ -1231,6 +1324,19 @@
        * Returns itself
        */
       toSeq(): /*this*/Seq.Keyed<K, V>
+
+      /**
+       * Returns a new Seq.Keyed with values passed through a
+       * `mapper` function.
+       *
+       *     Indexed([1, 2]).map(x => 10 * x)
+       *     // Indexed [10, 20]
+       *
+       */
+      map<M>(
+        mapper: (value: V, key: K, iter: /*this*/Seq.Keyed<K, V>) => M,
+        context?: any
+      ): Seq.Keyed<K, M>;
     }
 
 
@@ -1263,6 +1369,19 @@
        * Returns itself
        */
       toSeq(): /*this*/Seq.Indexed<T>
+
+      /**
+       * Returns a new Seq.Indexed with values passed through a
+       * `mapper` function.
+       *
+       *     Seq.Indexed({a: 1, b: 2}).map(x => 10 * x)
+       *     // Seq.Indexed {a: 10, b: 20}
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Seq.Indexed<T>) => M,
+        context?: any
+      ): Seq.Indexed<M>;
     }
 
 
@@ -1297,6 +1416,19 @@
        * Returns itself
        */
       toSeq(): /*this*/Seq.Set<T>
+
+      /**
+       * Returns a new Seq.Set with values passed through a
+       * `mapper` function.
+       *
+       *     Seq.Set([1, 2]).map(x => 10 * x)
+       *     // Seq.Set [10, 20]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: T, iter: /*this*/Seq.Set<T>) => M,
+        context?: any
+      ): Seq.Set<M>;
     }
 
   }
@@ -1360,6 +1492,21 @@
      * Note: after calling `cacheResult`, a Seq will always have a `size`.
      */
     cacheResult(): /*this*/Seq<K, V>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Seq with values passed through a
+     * `mapper` function.
+     *
+     *     Seq({a: 1, b: 2}).map(x => 10 * x)
+     *     // Set {a: 10, b: 20}
+     *
+     */
+    map<M>(
+      mapper: (value: V, key: K, iter: /*this*/Seq<K, V>) => M,
+      context?: any
+    ): Seq<K, M>;
   }
 
   /**
@@ -1471,6 +1618,21 @@
         ) => /*[KM, VM]*/Array<any>,
         context?: any
       ): /*this*/Iterable.Keyed<KM, VM>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Iterable.Keyed with values passed through a
+       * `mapper` function.
+       *
+       *     Iterable.Keyed({a: 1, b: 2}).map(x => 10 * x)
+       *     // Iterable.Keyed {a: 10, b: 20}
+       *
+       */
+      map<M>(
+        mapper: (value: V, key: K, iter: /*this*/Iterable.Keyed<K, V>) => M,
+        context?: any
+      ): Iterable.Keyed<K, M>;
     }
 
 
@@ -1644,6 +1806,21 @@
         predicate: (value?: T, index?: number, iter?: /*this*/Iterable.Indexed<T>) => boolean,
         context?: any
       ): number;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Iterable.Indexed with values passed through a
+       * `mapper` function.
+       *
+       *     Iterable.Indexed([1,2]).map(x => 10 * x)
+       *     // Iterable.Indexed [1,2]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Iterable.Indexed<T>) => M,
+        context?: any
+      ): Iterable.Indexed<T>;
     }
 
 
@@ -1678,6 +1855,21 @@
        * @override
        */
       toSeq(): Seq.Set<T>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Iterable.Set with values passed through a
+       * `mapper` function.
+       *
+       *     Iterable.Set([1,2]).map(x => 10 * x)
+       *     // Iterable.Set [1,2]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Iterable.Set<T>) => M,
+        context?: any
+      ): Iterable.Set<T>;
     }
 
   }
@@ -2475,6 +2667,21 @@
        * @override
        */
       toSeq(): Seq.Keyed<K, V>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Collection.Keyed with values passed through a
+       * `mapper` function.
+       *
+       *     Collection.Keyed({a: 1, b: 2}).map(x => 10 * x)
+       *     // Collection.Keyed {a: 10, b: 20}
+       *
+       */
+      map<M>(
+        mapper: (value: V, key: K, iter: /*this*/Collection.Keyed<K, V>) => M,
+        context?: any
+      ): Collection.Keyed<K, M>;
     }
 
 
@@ -2490,6 +2697,21 @@
        * @override
        */
       toSeq(): Seq.Indexed<T>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Collection.Indexed with values passed through a
+       * `mapper` function.
+       *
+       *     Collection.Indexed([1,2]).map(x => 10 * x)
+       *     // Collection.Indexed [1,2]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Collection.Indexed<T>) => M,
+        context?: any
+      ): Collection.Indexed<T>;
     }
 
 
@@ -2507,6 +2729,21 @@
        * @override
        */
       toSeq(): Seq.Set<T>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Collection.Set with values passed through a
+       * `mapper` function.
+       *
+       *     Collection.Set([1,2]).map(x => 10 * x)
+       *     // Collection.Set [1,2]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Collection.Set<T>) => M,
+        context?: any
+      ): Collection.Set<T>;
     }
 
   }

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -1430,10 +1430,10 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Keyed<T>;
-      concat<I1>(iterable1: Iterable<any, I1>): Seq.Keyed<T | I1>;
-      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Keyed<T | I1 | I2>;
-      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Keyed<T | I1 | I2 | I3>;
+      concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq.Keyed<K, V>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Keyed<K, V | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Keyed<K, V | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Keyed<K, V | I1 | I2 | I3>;
     }
 
 
@@ -1489,10 +1489,10 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq.Indexed<K, V>;
-      concat<I1>(iterable1: Iterable<any, I1>): Seq.Indexed<K, V | I1>;
-      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Indexed<K, V | I1 | I2>;
-      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Indexed<K, V | I1 | I2 | I3>;
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Indexed<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Indexed<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Indexed<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Indexed<T | I1 | I2 | I3>;
     }
 
 

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -403,6 +403,20 @@ declare module Immutable {
       mapper: (value: T, key: number, iter: /*this*/List<T>) => M,
       context?: any
     ): List<M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, T>>): List<T>;
+    concat<I1>(iterable1: Iterable<any, I1>): List<T | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): List<T | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): List<T | I1 | I2 | I3>;
   }
 
 
@@ -756,6 +770,20 @@ declare module Immutable {
       mapper: (value: V, key: K, iter: /*this*/Map<K, V>) => M,
       context?: any
     ): Map<K, M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, V>>): Map<K, V>;
+    concat<I1>(iterable1: Iterable<any, I1>): Map<K, V | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Map<K, V | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Map<K, V | I1 | I2 | I3>;
   }
 
 
@@ -817,6 +845,19 @@ declare module Immutable {
       context?: any
     ): OrderedMap<K, M>;
 
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, V>>): OrderedMap<K, V>;
+    concat<I1>(iterable1: Iterable<any, I1>): OrderedMap<K, V | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): OrderedMap<K, V | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): OrderedMap<K, V | I1 | I2 | I3>;
   }
 
 
@@ -945,6 +986,20 @@ declare module Immutable {
       mapper: (value: T, key: T, iter: /*this*/Set<T>) => M,
       context?: any
     ): Set<M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, T>>): Set<T>;
+    concat<I1>(iterable1: Iterable<any, I1>): Set<T | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Set<T | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Set<T | I1 | I2 | I3>;
   }
 
 
@@ -1006,6 +1061,20 @@ declare module Immutable {
       mapper: (value: T, key: T, iter: /*this*/OrderedSet<T>) => M,
       context?: any
     ): OrderedSet<M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, T>>): OrderedSet<T>;
+    concat<I1>(iterable1: Iterable<any, I1>): OrderedSet<T | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): OrderedSet<T | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): OrderedSet<T | I1 | I2 | I3>;
   }
 
 
@@ -1142,6 +1211,20 @@ declare module Immutable {
       mapper: (value: T, key: number, iter: /*this*/Stack<T>) => M,
       context?: any
     ): Stack<M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, T>>): Stack<T>;
+    concat<I1>(iterable1: Iterable<any, I1>): Stack<T | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Stack<T | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Stack<T | I1 | I2 | I3>;
   }
 
 
@@ -1337,6 +1420,20 @@ declare module Immutable {
         mapper: (value: V, key: K, iter: /*this*/Seq.Keyed<K, V>) => M,
         context?: any
       ): Seq.Keyed<K, M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Keyed<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Keyed<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Keyed<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Keyed<T | I1 | I2 | I3>;
     }
 
 
@@ -1382,6 +1479,20 @@ declare module Immutable {
         mapper: (value: T, key: number, iter: /*this*/Seq.Indexed<T>) => M,
         context?: any
       ): Seq.Indexed<M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq.Indexed<K, V>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Indexed<K, V | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Indexed<K, V | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Indexed<K, V | I1 | I2 | I3>;
     }
 
 
@@ -1429,6 +1540,20 @@ declare module Immutable {
         mapper: (value: T, key: T, iter: /*this*/Seq.Set<T>) => M,
         context?: any
       ): Seq.Set<M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Set<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Set<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Set<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Set<T | I1 | I2 | I3>;
     }
 
   }
@@ -1507,6 +1632,20 @@ declare module Immutable {
       mapper: (value: V, key: K, iter: /*this*/Seq<K, V>) => M,
       context?: any
     ): Seq<K, M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq<K, V>;
+    concat<I1>(iterable1: Iterable<any, I1>): Seq<K, V | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq<K, V | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq<K, V | I1 | I2 | I3>;
   }
 
   /**
@@ -1633,6 +1772,20 @@ declare module Immutable {
         mapper: (value: V, key: K, iter: /*this*/Iterable.Keyed<K, V>) => M,
         context?: any
       ): Iterable.Keyed<K, M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, V>>): Iterable.Keyed<K, V>;
+      concat<I1>(iterable1: Iterable<any, I1>): Iterable.Keyed<K, V | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Iterable.Keyed<K, V | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Iterable.Keyed<K, V | I1 | I2 | I3>;
     }
 
 
@@ -1821,6 +1974,20 @@ declare module Immutable {
         mapper: (value: T, key: number, iter: /*this*/Iterable.Indexed<T>) => M,
         context?: any
       ): Iterable.Indexed<T>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Iterable.Indexed<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Iterable.Indexed<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Iterable.Indexed<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Iterable.Indexed<T | I1 | I2 | I3>;
     }
 
 
@@ -1870,6 +2037,20 @@ declare module Immutable {
         mapper: (value: T, key: T, iter: /*this*/Iterable.Set<T>) => M,
         context?: any
       ): Iterable.Set<T>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Iterable.Set<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Iterable.Set<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Iterable.Set<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Iterable.Set<T | I1 | I2 | I3>;
     }
 
   }
@@ -2682,6 +2863,20 @@ declare module Immutable {
         mapper: (value: V, key: K, iter: /*this*/Collection.Keyed<K, V>) => M,
         context?: any
       ): Collection.Keyed<K, M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, V>>): Collection.Keyed<K, V>;
+      concat<I1>(iterable1: Iterable<any, I1>): Collection.Keyed<K, V | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Collection.Keyed<K, V | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Collection.Keyed<K, V | I1 | I2 | I3>;
     }
 
 
@@ -2712,6 +2907,20 @@ declare module Immutable {
         mapper: (value: T, key: number, iter: /*this*/Collection.Indexed<T>) => M,
         context?: any
       ): Collection.Indexed<T>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Collection.Indexed<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Collection.Indexed<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Collection.Indexed<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Collection.Indexed<T | I1 | I2 | I3>;
     }
 
 
@@ -2744,6 +2953,20 @@ declare module Immutable {
         mapper: (value: T, key: T, iter: /*this*/Collection.Set<T>) => M,
         context?: any
       ): Collection.Set<T>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Collection.Set<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Collection.Set<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Collection.Set<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Collection.Set<T | I1 | I2 | I3>;
     }
 
   }

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -813,7 +813,7 @@ declare module Immutable {
      *
      */
     map<M>(
-      mapper: (value: V, key: K, iter: /*this*/OrderedMap<k, V>) => M,
+      mapper: (value: V, key: K, iter: /*this*/OrderedMap<K, V>) => M,
       context?: any
     ): OrderedMap<K, M>;
 
@@ -1867,7 +1867,7 @@ declare module Immutable {
        *
        */
       map<M>(
-        mapper: (value: T, key: number, iter: /*this*/Iterable.Set<T>) => M,
+        mapper: (value: T, key: T, iter: /*this*/Iterable.Set<T>) => M,
         context?: any
       ): Iterable.Set<T>;
     }
@@ -2741,7 +2741,7 @@ declare module Immutable {
        *
        */
       map<M>(
-        mapper: (value: T, key: number, iter: /*this*/Collection.Set<T>) => M,
+        mapper: (value: T, key: T, iter: /*this*/Collection.Set<T>) => M,
         context?: any
       ): Collection.Set<T>;
     }

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -388,6 +388,21 @@ declare module Immutable {
      * @see `Map#asImmutable`
      */
     asImmutable(): List<T>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new List with values passed through a
+     * `mapper` function.
+     *
+     *     List([1,2]).map(x => 10 * x)
+     *     // List [ 10, 20 ]
+     *
+     */
+    map<M>(
+      mapper: (value: T, key: number, iter: /*this*/List<T>) => M,
+      context?: any
+    ): List<M>;
   }
 
 
@@ -726,6 +741,21 @@ declare module Immutable {
      * copy has become immutable and can be safely returned from a function.
      */
     asImmutable(): Map<K, V>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Map with values passed through a
+     * `mapper` function.
+     *
+     *     Map({ a: 1, b: 2 }).map(x => 10 * x)
+     *     // Map { a: 10, b: 20 }
+     *
+     */
+    map<M>(
+      mapper: (value: V, key: K, iter: /*this*/Map<K, V>) => M,
+      context?: any
+    ): Map<K, M>;
   }
 
 
@@ -770,7 +800,24 @@ declare module Immutable {
   export function OrderedMap<K, V>(iterator: Iterator</*[K,V]*/Array<any>>): OrderedMap<K, V>;
   export function OrderedMap<K, V>(iterable: /*Iterable<[K,V]>*/Object): OrderedMap<K, V>;
 
-  export interface OrderedMap<K, V> extends Map<K, V> {}
+  export interface OrderedMap<K, V> extends Map<K, V> {
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new OrderedMap with values passed through a
+     * `mapper` function.
+     *
+     *     OrderedMap({ a: 1, b: 2 }).map(x => 10 * x)
+     *     // OrderedMap { a: 10, b: 20 }
+     *
+     */
+    map<M>(
+      mapper: (value: V, key: K, iter: /*this*/OrderedMap<k, V>) => M,
+      context?: any
+    ): OrderedMap<K, M>;
+
+  }
 
 
   /**
@@ -883,6 +930,21 @@ declare module Immutable {
      * @see `Map#asImmutable`
      */
     asImmutable(): Set<T>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Set with values passed through a
+     * `mapper` function.
+     *
+     *     Set([1,2]).map(x => 10 * x)
+     *     // Set [10,20]
+     *
+     */
+    map<M>(
+      mapper: (value: T, key: T, iter: /*this*/Set<T>) => M,
+      context?: any
+    ): Set<M>;
   }
 
 
@@ -928,7 +990,23 @@ declare module Immutable {
   export function OrderedSet<T>(iterator: Iterator<T>): OrderedSet<T>;
   export function OrderedSet<T>(iterable: /*Iterable<T>*/Object): OrderedSet<T>;
 
-  export interface OrderedSet<T> extends Set<T> {}
+  export interface OrderedSet<T> extends Set<T> {
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Set with values passed through a
+     * `mapper` function.
+     *
+     *     OrderedSet([1,2]).map(x => 10 * x)
+     *     // Set [10,20]
+     *
+     */
+    map<M>(
+      mapper: (value: T, key: T, iter: /*this*/OrderedSet<T>) => M,
+      context?: any
+    ): OrderedSet<M>;
+  }
 
 
   /**
@@ -1049,6 +1127,21 @@ declare module Immutable {
      * @see `Map#asImmutable`
      */
     asImmutable(): Stack<T>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Stack with values passed through a
+     * `mapper` function.
+     *
+     *     Stack([1,2]).map(x => 10 * x)
+     *     // Stack [10,20]
+     *
+     */
+    map<M>(
+      mapper: (value: T, key: number, iter: /*this*/Stack<T>) => M,
+      context?: any
+    ): Stack<M>;
   }
 
 
@@ -1231,6 +1324,19 @@ declare module Immutable {
        * Returns itself
        */
       toSeq(): /*this*/Seq.Keyed<K, V>
+
+      /**
+       * Returns a new Seq.Keyed with values passed through a
+       * `mapper` function.
+       *
+       *     Indexed([1, 2]).map(x => 10 * x)
+       *     // Indexed [10, 20]
+       *
+       */
+      map<M>(
+        mapper: (value: V, key: K, iter: /*this*/Seq.Keyed<K, V>) => M,
+        context?: any
+      ): Seq.Keyed<K, M>;
     }
 
 
@@ -1263,6 +1369,19 @@ declare module Immutable {
        * Returns itself
        */
       toSeq(): /*this*/Seq.Indexed<T>
+
+      /**
+       * Returns a new Seq.Indexed with values passed through a
+       * `mapper` function.
+       *
+       *     Seq.Indexed({a: 1, b: 2}).map(x => 10 * x)
+       *     // Seq.Indexed {a: 10, b: 20}
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Seq.Indexed<T>) => M,
+        context?: any
+      ): Seq.Indexed<M>;
     }
 
 
@@ -1297,6 +1416,19 @@ declare module Immutable {
        * Returns itself
        */
       toSeq(): /*this*/Seq.Set<T>
+
+      /**
+       * Returns a new Seq.Set with values passed through a
+       * `mapper` function.
+       *
+       *     Seq.Set([1, 2]).map(x => 10 * x)
+       *     // Seq.Set [10, 20]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: T, iter: /*this*/Seq.Set<T>) => M,
+        context?: any
+      ): Seq.Set<M>;
     }
 
   }
@@ -1360,6 +1492,21 @@ declare module Immutable {
      * Note: after calling `cacheResult`, a Seq will always have a `size`.
      */
     cacheResult(): /*this*/Seq<K, V>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Seq with values passed through a
+     * `mapper` function.
+     *
+     *     Seq({a: 1, b: 2}).map(x => 10 * x)
+     *     // Set {a: 10, b: 20}
+     *
+     */
+    map<M>(
+      mapper: (value: V, key: K, iter: /*this*/Seq<K, V>) => M,
+      context?: any
+    ): Seq<K, M>;
   }
 
   /**
@@ -1471,6 +1618,21 @@ declare module Immutable {
         ) => /*[KM, VM]*/Array<any>,
         context?: any
       ): /*this*/Iterable.Keyed<KM, VM>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Iterable.Keyed with values passed through a
+       * `mapper` function.
+       *
+       *     Iterable.Keyed({a: 1, b: 2}).map(x => 10 * x)
+       *     // Iterable.Keyed {a: 10, b: 20}
+       *
+       */
+      map<M>(
+        mapper: (value: V, key: K, iter: /*this*/Iterable.Keyed<K, V>) => M,
+        context?: any
+      ): Iterable.Keyed<K, M>;
     }
 
 
@@ -1644,6 +1806,21 @@ declare module Immutable {
         predicate: (value?: T, index?: number, iter?: /*this*/Iterable.Indexed<T>) => boolean,
         context?: any
       ): number;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Iterable.Indexed with values passed through a
+       * `mapper` function.
+       *
+       *     Iterable.Indexed([1,2]).map(x => 10 * x)
+       *     // Iterable.Indexed [1,2]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Iterable.Indexed<T>) => M,
+        context?: any
+      ): Iterable.Indexed<T>;
     }
 
 
@@ -1678,6 +1855,21 @@ declare module Immutable {
        * @override
        */
       toSeq(): Seq.Set<T>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Iterable.Set with values passed through a
+       * `mapper` function.
+       *
+       *     Iterable.Set([1,2]).map(x => 10 * x)
+       *     // Iterable.Set [1,2]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Iterable.Set<T>) => M,
+        context?: any
+      ): Iterable.Set<T>;
     }
 
   }
@@ -2475,6 +2667,21 @@ declare module Immutable {
        * @override
        */
       toSeq(): Seq.Keyed<K, V>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Collection.Keyed with values passed through a
+       * `mapper` function.
+       *
+       *     Collection.Keyed({a: 1, b: 2}).map(x => 10 * x)
+       *     // Collection.Keyed {a: 10, b: 20}
+       *
+       */
+      map<M>(
+        mapper: (value: V, key: K, iter: /*this*/Collection.Keyed<K, V>) => M,
+        context?: any
+      ): Collection.Keyed<K, M>;
     }
 
 
@@ -2490,6 +2697,21 @@ declare module Immutable {
        * @override
        */
       toSeq(): Seq.Indexed<T>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Collection.Indexed with values passed through a
+       * `mapper` function.
+       *
+       *     Collection.Indexed([1,2]).map(x => 10 * x)
+       *     // Collection.Indexed [1,2]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Collection.Indexed<T>) => M,
+        context?: any
+      ): Collection.Indexed<T>;
     }
 
 
@@ -2507,6 +2729,21 @@ declare module Immutable {
        * @override
        */
       toSeq(): Seq.Set<T>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Collection.Set with values passed through a
+       * `mapper` function.
+       *
+       *     Collection.Set([1,2]).map(x => 10 * x)
+       *     // Collection.Set [1,2]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Collection.Set<T>) => M,
+        context?: any
+      ): Collection.Set<T>;
     }
 
   }

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -1430,10 +1430,10 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Keyed<T>;
-      concat<I1>(iterable1: Iterable<any, I1>): Seq.Keyed<T | I1>;
-      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Keyed<T | I1 | I2>;
-      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Keyed<T | I1 | I2 | I3>;
+      concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq.Keyed<K, V>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Keyed<K, V | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Keyed<K, V | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Keyed<K, V | I1 | I2 | I3>;
     }
 
 
@@ -1489,10 +1489,10 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq.Indexed<K, V>;
-      concat<I1>(iterable1: Iterable<any, I1>): Seq.Indexed<K, V | I1>;
-      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Indexed<K, V | I1 | I2>;
-      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Indexed<K, V | I1 | I2 | I3>;
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Indexed<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Indexed<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Indexed<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Indexed<T | I1 | I2 | I3>;
     }
 
 

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -403,6 +403,20 @@ declare module Immutable {
       mapper: (value: T, key: number, iter: /*this*/List<T>) => M,
       context?: any
     ): List<M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, T>>): List<T>;
+    concat<I1>(iterable1: Iterable<any, I1>): List<T | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): List<T | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): List<T | I1 | I2 | I3>;
   }
 
 
@@ -756,6 +770,20 @@ declare module Immutable {
       mapper: (value: V, key: K, iter: /*this*/Map<K, V>) => M,
       context?: any
     ): Map<K, M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, V>>): Map<K, V>;
+    concat<I1>(iterable1: Iterable<any, I1>): Map<K, V | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Map<K, V | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Map<K, V | I1 | I2 | I3>;
   }
 
 
@@ -817,6 +845,19 @@ declare module Immutable {
       context?: any
     ): OrderedMap<K, M>;
 
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, V>>): OrderedMap<K, V>;
+    concat<I1>(iterable1: Iterable<any, I1>): OrderedMap<K, V | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): OrderedMap<K, V | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): OrderedMap<K, V | I1 | I2 | I3>;
   }
 
 
@@ -945,6 +986,20 @@ declare module Immutable {
       mapper: (value: T, key: T, iter: /*this*/Set<T>) => M,
       context?: any
     ): Set<M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, T>>): Set<T>;
+    concat<I1>(iterable1: Iterable<any, I1>): Set<T | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Set<T | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Set<T | I1 | I2 | I3>;
   }
 
 
@@ -1006,6 +1061,20 @@ declare module Immutable {
       mapper: (value: T, key: T, iter: /*this*/OrderedSet<T>) => M,
       context?: any
     ): OrderedSet<M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, T>>): OrderedSet<T>;
+    concat<I1>(iterable1: Iterable<any, I1>): OrderedSet<T | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): OrderedSet<T | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): OrderedSet<T | I1 | I2 | I3>;
   }
 
 
@@ -1142,6 +1211,20 @@ declare module Immutable {
       mapper: (value: T, key: number, iter: /*this*/Stack<T>) => M,
       context?: any
     ): Stack<M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, T>>): Stack<T>;
+    concat<I1>(iterable1: Iterable<any, I1>): Stack<T | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Stack<T | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Stack<T | I1 | I2 | I3>;
   }
 
 
@@ -1337,6 +1420,20 @@ declare module Immutable {
         mapper: (value: V, key: K, iter: /*this*/Seq.Keyed<K, V>) => M,
         context?: any
       ): Seq.Keyed<K, M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Keyed<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Keyed<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Keyed<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Keyed<T | I1 | I2 | I3>;
     }
 
 
@@ -1382,6 +1479,20 @@ declare module Immutable {
         mapper: (value: T, key: number, iter: /*this*/Seq.Indexed<T>) => M,
         context?: any
       ): Seq.Indexed<M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq.Indexed<K, V>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Indexed<K, V | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Indexed<K, V | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Indexed<K, V | I1 | I2 | I3>;
     }
 
 
@@ -1429,6 +1540,20 @@ declare module Immutable {
         mapper: (value: T, key: T, iter: /*this*/Seq.Set<T>) => M,
         context?: any
       ): Seq.Set<M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Set<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Seq.Set<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Set<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Set<T | I1 | I2 | I3>;
     }
 
   }
@@ -1507,6 +1632,20 @@ declare module Immutable {
       mapper: (value: V, key: K, iter: /*this*/Seq<K, V>) => M,
       context?: any
     ): Seq<K, M>;
+
+    // Combination
+
+    /**
+     * Returns a new Iterable of the same type with other values and
+     * iterable-like concatenated to this one.
+     *
+     * For Seqs, all entries will be present in
+     * the resulting iterable, even if they have the same key.
+     */
+    concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq<K, V>;
+    concat<I1>(iterable1: Iterable<any, I1>): Seq<K, V | I1>;
+    concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq<K, V | I1 | I2>;
+    concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq<K, V | I1 | I2 | I3>;
   }
 
   /**
@@ -1633,6 +1772,20 @@ declare module Immutable {
         mapper: (value: V, key: K, iter: /*this*/Iterable.Keyed<K, V>) => M,
         context?: any
       ): Iterable.Keyed<K, M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, V>>): Iterable.Keyed<K, V>;
+      concat<I1>(iterable1: Iterable<any, I1>): Iterable.Keyed<K, V | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Iterable.Keyed<K, V | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Iterable.Keyed<K, V | I1 | I2 | I3>;
     }
 
 
@@ -1821,6 +1974,20 @@ declare module Immutable {
         mapper: (value: T, key: number, iter: /*this*/Iterable.Indexed<T>) => M,
         context?: any
       ): Iterable.Indexed<T>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Iterable.Indexed<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Iterable.Indexed<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Iterable.Indexed<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Iterable.Indexed<T | I1 | I2 | I3>;
     }
 
 
@@ -1870,6 +2037,20 @@ declare module Immutable {
         mapper: (value: T, key: T, iter: /*this*/Iterable.Set<T>) => M,
         context?: any
       ): Iterable.Set<T>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Iterable.Set<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Iterable.Set<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Iterable.Set<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Iterable.Set<T | I1 | I2 | I3>;
     }
 
   }
@@ -2682,6 +2863,20 @@ declare module Immutable {
         mapper: (value: V, key: K, iter: /*this*/Collection.Keyed<K, V>) => M,
         context?: any
       ): Collection.Keyed<K, M>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, V>>): Collection.Keyed<K, V>;
+      concat<I1>(iterable1: Iterable<any, I1>): Collection.Keyed<K, V | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Collection.Keyed<K, V | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Collection.Keyed<K, V | I1 | I2 | I3>;
     }
 
 
@@ -2712,6 +2907,20 @@ declare module Immutable {
         mapper: (value: T, key: number, iter: /*this*/Collection.Indexed<T>) => M,
         context?: any
       ): Collection.Indexed<T>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Collection.Indexed<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Collection.Indexed<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Collection.Indexed<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Collection.Indexed<T | I1 | I2 | I3>;
     }
 
 
@@ -2744,6 +2953,20 @@ declare module Immutable {
         mapper: (value: T, key: T, iter: /*this*/Collection.Set<T>) => M,
         context?: any
       ): Collection.Set<T>;
+
+      // Combination
+
+      /**
+       * Returns a new Iterable of the same type with other values and
+       * iterable-like concatenated to this one.
+       *
+       * For Seqs, all entries will be present in
+       * the resulting iterable, even if they have the same key.
+       */
+      concat(...valuesOrIterables: Array<Iterable<any, T>>): Collection.Set<T>;
+      concat<I1>(iterable1: Iterable<any, I1>): Collection.Set<T | I1>;
+      concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Collection.Set<T | I1 | I2>;
+      concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Collection.Set<T | I1 | I2 | I3>;
     }
 
   }

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -413,7 +413,7 @@ declare module Immutable {
      * For Seqs, all entries will be present in
      * the resulting iterable, even if they have the same key.
      */
-    concat(...valuesOrIterables: Array<Iterable<any, T>>): List<T>;
+    concat(...valuesOrIterables: Array<Iterable<any, T> | Array<T> | T>): List<T>;
     concat<I1>(iterable1: Iterable<any, I1>): List<T | I1>;
     concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): List<T | I1 | I2>;
     concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): List<T | I1 | I2 | I3>;
@@ -780,7 +780,7 @@ declare module Immutable {
      * For Seqs, all entries will be present in
      * the resulting iterable, even if they have the same key.
      */
-    concat(...valuesOrIterables: Array<Iterable<any, V>>): Map<K, V>;
+    concat(...valuesOrIterables: Array<Iterable<any, V> | Array<V> | V>): Map<K, V>;
     concat<I1>(iterable1: Iterable<any, I1>): Map<K, V | I1>;
     concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Map<K, V | I1 | I2>;
     concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Map<K, V | I1 | I2 | I3>;
@@ -854,7 +854,7 @@ declare module Immutable {
      * For Seqs, all entries will be present in
      * the resulting iterable, even if they have the same key.
      */
-    concat(...valuesOrIterables: Array<Iterable<any, V>>): OrderedMap<K, V>;
+    concat(...valuesOrIterables: Array<Iterable<any, V> | Array<V> | V>): OrderedMap<K, V>;
     concat<I1>(iterable1: Iterable<any, I1>): OrderedMap<K, V | I1>;
     concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): OrderedMap<K, V | I1 | I2>;
     concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): OrderedMap<K, V | I1 | I2 | I3>;
@@ -996,7 +996,7 @@ declare module Immutable {
      * For Seqs, all entries will be present in
      * the resulting iterable, even if they have the same key.
      */
-    concat(...valuesOrIterables: Array<Iterable<any, T>>): Set<T>;
+    concat(...valuesOrIterables: Array<Iterable<any, T> | Array<T> | T>): Set<T>;
     concat<I1>(iterable1: Iterable<any, I1>): Set<T | I1>;
     concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Set<T | I1 | I2>;
     concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Set<T | I1 | I2 | I3>;
@@ -1071,7 +1071,7 @@ declare module Immutable {
      * For Seqs, all entries will be present in
      * the resulting iterable, even if they have the same key.
      */
-    concat(...valuesOrIterables: Array<Iterable<any, T>>): OrderedSet<T>;
+    concat(...valuesOrIterables: Array<Iterable<any, T> | Array<T> | T>): OrderedSet<T>;
     concat<I1>(iterable1: Iterable<any, I1>): OrderedSet<T | I1>;
     concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): OrderedSet<T | I1 | I2>;
     concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): OrderedSet<T | I1 | I2 | I3>;
@@ -1221,7 +1221,7 @@ declare module Immutable {
      * For Seqs, all entries will be present in
      * the resulting iterable, even if they have the same key.
      */
-    concat(...valuesOrIterables: Array<Iterable<any, T>>): Stack<T>;
+    concat(...valuesOrIterables: Array<Iterable<any, T> | Array<T> | T>): Stack<T>;
     concat<I1>(iterable1: Iterable<any, I1>): Stack<T | I1>;
     concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Stack<T | I1 | I2>;
     concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Stack<T | I1 | I2 | I3>;
@@ -1430,7 +1430,7 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq.Keyed<K, V>;
+      concat(...valuesOrIterables: Array<Iterable<any, V> | Array<V> | V>): Seq.Keyed<K, V>;
       concat<I1>(iterable1: Iterable<any, I1>): Seq.Keyed<K, V | I1>;
       concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Keyed<K, V | I1 | I2>;
       concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Keyed<K, V | I1 | I2 | I3>;
@@ -1489,7 +1489,7 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Indexed<T>;
+      concat(...valuesOrIterables: Array<Iterable<any, T> | Array<T> | T>): Seq.Indexed<T>;
       concat<I1>(iterable1: Iterable<any, I1>): Seq.Indexed<T | I1>;
       concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Indexed<T | I1 | I2>;
       concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Indexed<T | I1 | I2 | I3>;
@@ -1550,7 +1550,7 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, T>>): Seq.Set<T>;
+      concat(...valuesOrIterables: Array<Iterable<any, T> | Array<T> | T>): Seq.Set<T>;
       concat<I1>(iterable1: Iterable<any, I1>): Seq.Set<T | I1>;
       concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq.Set<T | I1 | I2>;
       concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq.Set<T | I1 | I2 | I3>;
@@ -1642,7 +1642,7 @@ declare module Immutable {
      * For Seqs, all entries will be present in
      * the resulting iterable, even if they have the same key.
      */
-    concat(...valuesOrIterables: Array<Iterable<any, V>>): Seq<K, V>;
+    concat(...valuesOrIterables: Array<Iterable<any, V> | Array<V> | V>): Seq<K, V>;
     concat<I1>(iterable1: Iterable<any, I1>): Seq<K, V | I1>;
     concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Seq<K, V | I1 | I2>;
     concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Seq<K, V | I1 | I2 | I3>;
@@ -1782,7 +1782,7 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, V>>): Iterable.Keyed<K, V>;
+      concat(...valuesOrIterables: Array<Iterable<any, V> | Array<V> | V>): Iterable.Keyed<K, V>;
       concat<I1>(iterable1: Iterable<any, I1>): Iterable.Keyed<K, V | I1>;
       concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Iterable.Keyed<K, V | I1 | I2>;
       concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Iterable.Keyed<K, V | I1 | I2 | I3>;
@@ -1984,7 +1984,7 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, T>>): Iterable.Indexed<T>;
+      concat(...valuesOrIterables: Array<Iterable<any, T> | Array<T> | T>): Iterable.Indexed<T>;
       concat<I1>(iterable1: Iterable<any, I1>): Iterable.Indexed<T | I1>;
       concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Iterable.Indexed<T | I1 | I2>;
       concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Iterable.Indexed<T | I1 | I2 | I3>;
@@ -2047,7 +2047,7 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, T>>): Iterable.Set<T>;
+      concat(...valuesOrIterables: Array<Iterable<any, T> | Array<T> | T>): Iterable.Set<T>;
       concat<I1>(iterable1: Iterable<any, I1>): Iterable.Set<T | I1>;
       concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Iterable.Set<T | I1 | I2>;
       concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Iterable.Set<T | I1 | I2 | I3>;
@@ -2873,7 +2873,7 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, V>>): Collection.Keyed<K, V>;
+      concat(...valuesOrIterables: Array<Iterable<any, V> | Array<V> | V>): Collection.Keyed<K, V>;
       concat<I1>(iterable1: Iterable<any, I1>): Collection.Keyed<K, V | I1>;
       concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Collection.Keyed<K, V | I1 | I2>;
       concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Collection.Keyed<K, V | I1 | I2 | I3>;
@@ -2917,7 +2917,7 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, T>>): Collection.Indexed<T>;
+      concat(...valuesOrIterables: Array<Iterable<any, T> | Array<T> | T>): Collection.Indexed<T>;
       concat<I1>(iterable1: Iterable<any, I1>): Collection.Indexed<T | I1>;
       concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Collection.Indexed<T | I1 | I2>;
       concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Collection.Indexed<T | I1 | I2 | I3>;
@@ -2963,7 +2963,7 @@ declare module Immutable {
        * For Seqs, all entries will be present in
        * the resulting iterable, even if they have the same key.
        */
-      concat(...valuesOrIterables: Array<Iterable<any, T>>): Collection.Set<T>;
+      concat(...valuesOrIterables: Array<Iterable<any, T> | Array<T> | T>): Collection.Set<T>;
       concat<I1>(iterable1: Iterable<any, I1>): Collection.Set<T | I1>;
       concat<I1, I2>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>): Collection.Set<T | I1 | I2>;
       concat<I1, I2, I3>(iterable1: Iterable<any, I1>, iterable2: Iterable<any, I2>, iterable3: Iterable<any, I3>): Collection.Set<T | I1 | I2 | I3>;

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -813,7 +813,7 @@ declare module Immutable {
      *
      */
     map<M>(
-      mapper: (value: V, key: K, iter: /*this*/OrderedMap<k, V>) => M,
+      mapper: (value: V, key: K, iter: /*this*/OrderedMap<K, V>) => M,
       context?: any
     ): OrderedMap<K, M>;
 
@@ -1867,7 +1867,7 @@ declare module Immutable {
        *
        */
       map<M>(
-        mapper: (value: T, key: number, iter: /*this*/Iterable.Set<T>) => M,
+        mapper: (value: T, key: T, iter: /*this*/Iterable.Set<T>) => M,
         context?: any
       ): Iterable.Set<T>;
     }
@@ -2741,7 +2741,7 @@ declare module Immutable {
        *
        */
       map<M>(
-        mapper: (value: T, key: number, iter: /*this*/Collection.Set<T>) => M,
+        mapper: (value: T, key: T, iter: /*this*/Collection.Set<T>) => M,
         context?: any
       ): Collection.Set<T>;
     }

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -388,6 +388,21 @@ declare module Immutable {
      * @see `Map#asImmutable`
      */
     asImmutable(): List<T>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new List with values passed through a
+     * `mapper` function.
+     *
+     *     List([1,2]).map(x => 10 * x)
+     *     // List [ 10, 20 ]
+     *
+     */
+    map<M>(
+      mapper: (value: T, key: number, iter: /*this*/List<T>) => M,
+      context?: any
+    ): List<M>;
   }
 
 
@@ -726,6 +741,21 @@ declare module Immutable {
      * copy has become immutable and can be safely returned from a function.
      */
     asImmutable(): Map<K, V>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Map with values passed through a
+     * `mapper` function.
+     *
+     *     Map({ a: 1, b: 2 }).map(x => 10 * x)
+     *     // Map { a: 10, b: 20 }
+     *
+     */
+    map<M>(
+      mapper: (value: V, key: K, iter: /*this*/Map<K, V>) => M,
+      context?: any
+    ): Map<K, M>;
   }
 
 
@@ -770,7 +800,24 @@ declare module Immutable {
   export function OrderedMap<K, V>(iterator: Iterator</*[K,V]*/Array<any>>): OrderedMap<K, V>;
   export function OrderedMap<K, V>(iterable: /*Iterable<[K,V]>*/Object): OrderedMap<K, V>;
 
-  export interface OrderedMap<K, V> extends Map<K, V> {}
+  export interface OrderedMap<K, V> extends Map<K, V> {
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new OrderedMap with values passed through a
+     * `mapper` function.
+     *
+     *     OrderedMap({ a: 1, b: 2 }).map(x => 10 * x)
+     *     // OrderedMap { a: 10, b: 20 }
+     *
+     */
+    map<M>(
+      mapper: (value: V, key: K, iter: /*this*/OrderedMap<k, V>) => M,
+      context?: any
+    ): OrderedMap<K, M>;
+
+  }
 
 
   /**
@@ -883,6 +930,21 @@ declare module Immutable {
      * @see `Map#asImmutable`
      */
     asImmutable(): Set<T>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Set with values passed through a
+     * `mapper` function.
+     *
+     *     Set([1,2]).map(x => 10 * x)
+     *     // Set [10,20]
+     *
+     */
+    map<M>(
+      mapper: (value: T, key: T, iter: /*this*/Set<T>) => M,
+      context?: any
+    ): Set<M>;
   }
 
 
@@ -928,7 +990,23 @@ declare module Immutable {
   export function OrderedSet<T>(iterator: Iterator<T>): OrderedSet<T>;
   export function OrderedSet<T>(iterable: /*Iterable<T>*/Object): OrderedSet<T>;
 
-  export interface OrderedSet<T> extends Set<T> {}
+  export interface OrderedSet<T> extends Set<T> {
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Set with values passed through a
+     * `mapper` function.
+     *
+     *     OrderedSet([1,2]).map(x => 10 * x)
+     *     // Set [10,20]
+     *
+     */
+    map<M>(
+      mapper: (value: T, key: T, iter: /*this*/OrderedSet<T>) => M,
+      context?: any
+    ): OrderedSet<M>;
+  }
 
 
   /**
@@ -1049,6 +1127,21 @@ declare module Immutable {
      * @see `Map#asImmutable`
      */
     asImmutable(): Stack<T>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Stack with values passed through a
+     * `mapper` function.
+     *
+     *     Stack([1,2]).map(x => 10 * x)
+     *     // Stack [10,20]
+     *
+     */
+    map<M>(
+      mapper: (value: T, key: number, iter: /*this*/Stack<T>) => M,
+      context?: any
+    ): Stack<M>;
   }
 
 
@@ -1231,6 +1324,19 @@ declare module Immutable {
        * Returns itself
        */
       toSeq(): /*this*/Seq.Keyed<K, V>
+
+      /**
+       * Returns a new Seq.Keyed with values passed through a
+       * `mapper` function.
+       *
+       *     Indexed([1, 2]).map(x => 10 * x)
+       *     // Indexed [10, 20]
+       *
+       */
+      map<M>(
+        mapper: (value: V, key: K, iter: /*this*/Seq.Keyed<K, V>) => M,
+        context?: any
+      ): Seq.Keyed<K, M>;
     }
 
 
@@ -1263,6 +1369,19 @@ declare module Immutable {
        * Returns itself
        */
       toSeq(): /*this*/Seq.Indexed<T>
+
+      /**
+       * Returns a new Seq.Indexed with values passed through a
+       * `mapper` function.
+       *
+       *     Seq.Indexed({a: 1, b: 2}).map(x => 10 * x)
+       *     // Seq.Indexed {a: 10, b: 20}
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Seq.Indexed<T>) => M,
+        context?: any
+      ): Seq.Indexed<M>;
     }
 
 
@@ -1297,6 +1416,19 @@ declare module Immutable {
        * Returns itself
        */
       toSeq(): /*this*/Seq.Set<T>
+
+      /**
+       * Returns a new Seq.Set with values passed through a
+       * `mapper` function.
+       *
+       *     Seq.Set([1, 2]).map(x => 10 * x)
+       *     // Seq.Set [10, 20]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: T, iter: /*this*/Seq.Set<T>) => M,
+        context?: any
+      ): Seq.Set<M>;
     }
 
   }
@@ -1360,6 +1492,21 @@ declare module Immutable {
      * Note: after calling `cacheResult`, a Seq will always have a `size`.
      */
     cacheResult(): /*this*/Seq<K, V>;
+
+    // Sequence algorithms
+
+    /**
+     * Returns a new Seq with values passed through a
+     * `mapper` function.
+     *
+     *     Seq({a: 1, b: 2}).map(x => 10 * x)
+     *     // Set {a: 10, b: 20}
+     *
+     */
+    map<M>(
+      mapper: (value: V, key: K, iter: /*this*/Seq<K, V>) => M,
+      context?: any
+    ): Seq<K, M>;
   }
 
   /**
@@ -1471,6 +1618,21 @@ declare module Immutable {
         ) => /*[KM, VM]*/Array<any>,
         context?: any
       ): /*this*/Iterable.Keyed<KM, VM>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Iterable.Keyed with values passed through a
+       * `mapper` function.
+       *
+       *     Iterable.Keyed({a: 1, b: 2}).map(x => 10 * x)
+       *     // Iterable.Keyed {a: 10, b: 20}
+       *
+       */
+      map<M>(
+        mapper: (value: V, key: K, iter: /*this*/Iterable.Keyed<K, V>) => M,
+        context?: any
+      ): Iterable.Keyed<K, M>;
     }
 
 
@@ -1644,6 +1806,21 @@ declare module Immutable {
         predicate: (value?: T, index?: number, iter?: /*this*/Iterable.Indexed<T>) => boolean,
         context?: any
       ): number;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Iterable.Indexed with values passed through a
+       * `mapper` function.
+       *
+       *     Iterable.Indexed([1,2]).map(x => 10 * x)
+       *     // Iterable.Indexed [1,2]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Iterable.Indexed<T>) => M,
+        context?: any
+      ): Iterable.Indexed<T>;
     }
 
 
@@ -1678,6 +1855,21 @@ declare module Immutable {
        * @override
        */
       toSeq(): Seq.Set<T>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Iterable.Set with values passed through a
+       * `mapper` function.
+       *
+       *     Iterable.Set([1,2]).map(x => 10 * x)
+       *     // Iterable.Set [1,2]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Iterable.Set<T>) => M,
+        context?: any
+      ): Iterable.Set<T>;
     }
 
   }
@@ -2475,6 +2667,21 @@ declare module Immutable {
        * @override
        */
       toSeq(): Seq.Keyed<K, V>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Collection.Keyed with values passed through a
+       * `mapper` function.
+       *
+       *     Collection.Keyed({a: 1, b: 2}).map(x => 10 * x)
+       *     // Collection.Keyed {a: 10, b: 20}
+       *
+       */
+      map<M>(
+        mapper: (value: V, key: K, iter: /*this*/Collection.Keyed<K, V>) => M,
+        context?: any
+      ): Collection.Keyed<K, M>;
     }
 
 
@@ -2490,6 +2697,21 @@ declare module Immutable {
        * @override
        */
       toSeq(): Seq.Indexed<T>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Collection.Indexed with values passed through a
+       * `mapper` function.
+       *
+       *     Collection.Indexed([1,2]).map(x => 10 * x)
+       *     // Collection.Indexed [1,2]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Collection.Indexed<T>) => M,
+        context?: any
+      ): Collection.Indexed<T>;
     }
 
 
@@ -2507,6 +2729,21 @@ declare module Immutable {
        * @override
        */
       toSeq(): Seq.Set<T>;
+
+      // Sequence algorithms
+
+      /**
+       * Returns a new Collection.Set with values passed through a
+       * `mapper` function.
+       *
+       *     Collection.Set([1,2]).map(x => 10 * x)
+       *     // Collection.Set [1,2]
+       *
+       */
+      map<M>(
+        mapper: (value: T, key: number, iter: /*this*/Collection.Set<T>) => M,
+        context?: any
+      ): Collection.Set<T>;
     }
 
   }


### PR DESCRIPTION
This overloading for proper return type of `concat` method.
This PR build on top of #925, for reduce amount of conflicts.
