### PR TITLE
Efficient trie diff

### DIFF
--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -353,9 +353,9 @@ describe('Map', () => {
     expect(m2.diffFrom(m1).added.toObject()).toEqual({'b': 12})
   })
 
-  it('diffs against the older version of the map providing a map of deleted entries', () => {
+  it('diffs against the older version of the map providing a map of removed entries', () => {
     var m1 = Map({'a': 11, 'b': 12})
-    var m2 = m1.delete('a')
+    var m2 = m1.remove('a')
 
     expect(m2.diffFrom(m1).removed.toObject()).toEqual({'a': 11})
   })

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -346,4 +346,56 @@ describe('Map', () => {
     expect(is(m1, m2)).toBe(true);
   });
 
+  it('diffs against the older version of the map providing a map of added entries', () => {
+    var m1 = Map({'a' : 11})
+    var m2 = m1.set('b', 12)
+
+    expect(m2.diffFrom(m1).added.toObject()).toEqual({'b': 12})
+  })
+
+  it('diffs against the older version of the map providing a map of deleted entries', () => {
+    var m1 = Map({'a': 11, 'b': 12})
+    var m2 = m1.delete('a')
+
+    expect(m2.diffFrom(m1).removed.toObject()).toEqual({'a': 11})
+  })
+
+  it('diffs against the older version of the map providing a map of updated entries', () => {
+    var m1 = Map({'a': 11, 'b': 12})
+    var m2 = m1.set('a', 13)
+
+    expect(m2.diffFrom(m1).updated.toObject()).toEqual({'a': {prev: 11, next: 13}})
+  })
+
+  it('diffs against the older version of the large map', () => {
+    var largeObject = {}
+    for(let i=0; i<10000; ++i) largeObject[i] = i*2+11
+
+    var m1 = Map(largeObject)
+    var m2 = m1
+      .set('b', 12)
+      .delete('11')
+      .set('12', 17)
+
+    var diff = m2.diffFrom(m1)
+    expect(diff.updated.toObject()).toEqual({'12': {prev: 12*2+11, next: 17}})
+    expect(diff.removed.toObject()).toEqual({'11': 11*2+11})
+    expect(diff.added.toObject()).toEqual({'b': 12})
+  })
+
+  it('diffs against the branched out version of the map', () => {
+    var largeObject = {}
+    for(let i=0; i<10000; ++i) largeObject[i] = i*2+11
+
+    var m1 = Map(largeObject)
+      .set('somethingDifferent', 12323948)
+    var m2 = m1
+      .set('somethingDifferent', 23928492)
+
+    var diff = m2.diffFrom(m1)
+    expect(diff.updated.toObject()).toEqual({'somethingDifferent': {prev: 12323948, next: 23928492}})
+    expect(diff.removed.toObject()).toEqual({})
+    expect(diff.added.toObject()).toEqual({})
+  })
+
 });

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -263,6 +263,20 @@ describe('Set', () => {
 
   });
 
+  it('diffs against the older version of the set providing a set of added entries', () => {
+    var s1 = Set(['a'])
+    var s2 = s1.add('b')
+
+    expect(s2.diffFrom(s1).added.toArray()).toEqual(['b'])
+  })
+
+  it('diffs against the older version of the set providing a set of removed entries', () => {
+    var s1 = Set(['a', 'b'])
+    var s2 = s1.remove('b')
+
+    expect(s2.diffFrom(s1).removed.toArray()).toEqual(['b'])
+  })
+
   // TODO: more tests
 
 });

--- a/src/Map.js
+++ b/src/Map.js
@@ -380,8 +380,8 @@ class BitmapIndexedNode {
     const hashRanges = []
     let hash = 0
     let position = 0
-    while(bitmap !== 0) {
-      if(bitmap & 1 === 1) {
+    while (bitmap !== 0) {
+      if (bitmap & 1 === 1) {
         const subNode = this.nodes[position]
         hashRanges.push({ hash, node: subNode })
         position += 1
@@ -457,9 +457,9 @@ class HashArrayMapNode {
 
   getHashRanges() {
     return this.nodes
-      .map((node,i) => ([node,i]))
-      .filter(([node,i]) => !!node)
-      .map(([node,i]) => ({ hash: i, node }))
+      .map((node, i) => ([node, i]))
+      .filter(([node, i]) => !!node)
+      .map(([node, i]) => ({ hash: i, node }))
   }
 
   collectAllEntries(collectingArray) {
@@ -937,22 +937,22 @@ function processAllEntries(node1, node2, added, removed, updated) {
 
   allEntries2.forEach(([key, value]) => {
     const prev = keyToValue1[key]
-    if(prev === undefined) {
+    if (prev === undefined) {
       added.push([key, value])
-    } else if(prev !== value) {
+    } else if (prev !== value) {
       updated.push([key, { prev, next: value }])
     }
   })
 
   allEntries1.forEach(([key, value]) => {
-    if(keyToValue2[key] === undefined) {
+    if (keyToValue2[key] === undefined) {
       removed.push([key, value])
     }
   })
 }
 
 function processDiffForEquivalentNodes(node1, node2, added, removed, updated) {
-  if(node1 === node2) {
+  if (node1 === node2) {
     // The equivalent nodes in boths tries are the same node — no need to diff further
     return
   }
@@ -962,35 +962,34 @@ function processDiffForEquivalentNodes(node1, node2, added, removed, updated) {
   const hashRanges2 = (node2 && node2.getHashRanges) ?
     node2.getHashRanges() : undefined;
 
-  if(!hashRanges1 || !hashRanges2) {
+  if (!hashRanges1 || !hashRanges2) {
     return processAllEntries(node1, node2, added, removed, updated)
   }
 
   // Double pointer walk
   let hashIndex1 = 0
   let hashIndex2 = 0
-  while(hashIndex1 < hashRanges1.length && hashIndex2 < hashRanges2.length) {
+  while (hashIndex1 < hashRanges1.length && hashIndex2 < hashRanges2.length) {
     const { node: subNode1, hash: hash1 } = hashRanges1[hashIndex1]
     const { node: subNode2, hash: hash2 } = hashRanges2[hashIndex2]
-    if(hash1 < hash2) {
+    if (hash1 < hash2) {
       processAllEntries(subNode1, undefined, added, removed, updated)
       hashIndex1 += 1
     } else if (hash2 < hash1) {
       processAllEntries(undefined, subNode2, added, removed, updated)
       hashIndex2 += 1
     } else {
-      // console.log('merging nodes of the same hash', hash1, hash2)
       processDiffForEquivalentNodes(subNode1, subNode2, added, removed, updated)
       hashIndex1 += 1
       hashIndex2 += 1
     }
   }
-  while(hashIndex1 < hashRanges1.length) {
+  while (hashIndex1 < hashRanges1.length) {
     const { node: subNode1 } = hashRanges1[hashIndex1]
     processAllEntries(subNode1, undefined, added, removed, updated)
     hashIndex1 += 1
   }
-  while(hashIndex2 < hashRanges2.length) {
+  while (hashIndex2 < hashRanges2.length) {
     const { node: subNode2 } = hashRanges2[hashIndex2]
     processAllEntries(undefined, subNode2, added, removed, updated)
     hashIndex2 += 1

--- a/src/Map.js
+++ b/src/Map.js
@@ -180,6 +180,20 @@ export class Map extends KeyedCollection {
     return this.__altered;
   }
 
+  diffFrom(otherMap) {
+    const added = []
+    const removed = []
+    const updated = []
+
+    processDiffForEquivalentNodes(otherMap._root, this._root, added, removed, updated)
+
+    return {
+      added: Map(added),
+      removed: Map(removed),
+      updated: Map(updated),
+    }
+  }
+
   __iterator(type, reverse) {
     return new MapIterator(this, type, reverse);
   }
@@ -286,6 +300,11 @@ class ArrayMapNode {
 
     return new ArrayMapNode(ownerID, newEntries);
   }
+
+  collectAllEntries(collectingArray) {
+    collectingArray.push(...this.entries);
+    return collectingArray;
+  }
 }
 
 class BitmapIndexedNode {
@@ -355,6 +374,28 @@ class BitmapIndexedNode {
 
     return new BitmapIndexedNode(ownerID, newBitmap, newNodes);
   }
+
+  getHashRanges() {
+    let bitmap = this.bitmap
+    const hashRanges = []
+    let hash = 0
+    let position = 0
+    while(bitmap !== 0) {
+      if(bitmap & 1 === 1) {
+        const subNode = this.nodes[position]
+        hashRanges.push({ hash, node: subNode })
+        position += 1
+      }
+      bitmap = bitmap >>> 1
+      hash++
+    }
+    return hashRanges
+  }
+
+  collectAllEntries(collectingArray) {
+    this.nodes.forEach(node => (!!node) && node.collectAllEntries(collectingArray));
+    return collectingArray;
+  }
 }
 
 class HashArrayMapNode {
@@ -412,6 +453,18 @@ class HashArrayMapNode {
     }
 
     return new HashArrayMapNode(ownerID, newCount, newNodes);
+  }
+
+  getHashRanges() {
+    return this.nodes
+      .map((node,i) => ([node,i]))
+      .filter(([node,i]) => !!node)
+      .map(([node,i]) => ({ hash: i, node }))
+  }
+
+  collectAllEntries(collectingArray) {
+    this.nodes.forEach(node => (!!node) && node.collectAllEntries(collectingArray));
+    return collectingArray;
   }
 }
 
@@ -489,6 +542,11 @@ class HashCollisionNode {
 
     return new HashCollisionNode(ownerID, this.keyHash, newEntries);
   }
+
+  collectAllEntries(collectingArray) {
+    collectingArray.push(...this.entries);
+    return collectingArray;
+  }
 }
 
 class ValueNode {
@@ -527,6 +585,11 @@ class ValueNode {
 
     SetRef(didChangeSize);
     return mergeIntoNode(this, ownerID, shift, hash(key), [key, value]);
+  }
+
+  collectAllEntries(collectingArray) {
+    collectingArray.push(this.entry);
+    return collectingArray;
   }
 }
 
@@ -856,3 +919,80 @@ function spliceOut(array, idx, canEdit) {
 var MAX_ARRAY_MAP_SIZE = SIZE / 4;
 var MAX_BITMAP_INDEXED_SIZE = SIZE / 2;
 var MIN_HASH_ARRAY_MAP_SIZE = SIZE / 4;
+
+function processAllEntries(node1, node2, added, removed, updated) {
+  const allEntries1 = node1 ? node1.collectAllEntries([]) : []
+  const allEntries2 = node2 ? node2.collectAllEntries([]) : []
+
+  const keyToValue1 = {}
+  const keyToValue2 = {}
+
+  allEntries1.forEach(([key, value]) => {
+    keyToValue1[key] = value
+  })
+
+  allEntries2.forEach(([key, value]) => {
+    keyToValue2[key] = value
+  })
+
+  allEntries2.forEach(([key, value]) => {
+    const prev = keyToValue1[key]
+    if(prev === undefined) {
+      added.push([key, value])
+    } else if(prev !== value) {
+      updated.push([key, { prev, next: value }])
+    }
+  })
+
+  allEntries1.forEach(([key, value]) => {
+    if(keyToValue2[key] === undefined) {
+      removed.push([key, value])
+    }
+  })
+}
+
+function processDiffForEquivalentNodes(node1, node2, added, removed, updated) {
+  if(node1 === node2) {
+    // The equivalent nodes in boths tries are the same node — no need to diff further
+    return
+  }
+
+  const hashRanges1 = (node1 && node1.getHashRanges) ?
+    node1.getHashRanges() : undefined;
+  const hashRanges2 = (node2 && node2.getHashRanges) ?
+    node2.getHashRanges() : undefined;
+
+  if(!hashRanges1 || !hashRanges2) {
+    return processAllEntries(node1, node2, added, removed, updated)
+  }
+
+  // Double pointer walk
+  let hashIndex1 = 0
+  let hashIndex2 = 0
+  while(hashIndex1 < hashRanges1.length && hashIndex2 < hashRanges2.length) {
+    const { node: subNode1, hash: hash1 } = hashRanges1[hashIndex1]
+    const { node: subNode2, hash: hash2 } = hashRanges2[hashIndex2]
+    if(hash1 < hash2) {
+      processAllEntries(subNode1, undefined, added, removed, updated)
+      hashIndex1 += 1
+    } else if (hash2 < hash1) {
+      processAllEntries(undefined, subNode2, added, removed, updated)
+      hashIndex2 += 1
+    } else {
+      // console.log('merging nodes of the same hash', hash1, hash2)
+      processDiffForEquivalentNodes(subNode1, subNode2, added, removed, updated)
+      hashIndex1 += 1
+      hashIndex2 += 1
+    }
+  }
+  while(hashIndex1 < hashRanges1.length) {
+    const { node: subNode1 } = hashRanges1[hashIndex1]
+    processAllEntries(subNode1, undefined, added, removed, updated)
+    hashIndex1 += 1
+  }
+  while(hashIndex2 < hashRanges2.length) {
+    const { node: subNode2 } = hashRanges2[hashIndex2]
+    processAllEntries(undefined, subNode2, added, removed, updated)
+    hashIndex2 += 1
+  }
+}

--- a/src/Set.js
+++ b/src/Set.js
@@ -132,6 +132,16 @@ export class Set extends SetCollection {
     return this._map.wasAltered();
   }
 
+  diffFrom(otherSet) {
+    const { added, removed } = this._map.diffFrom(otherSet._map)
+
+    return {
+      added: added.keySeq().toSet(),
+      removed: removed.keySeq().toSet(),
+    }
+  }
+
+
   __iterate(fn, reverse) {
     return this._map.__iterate((_, k) => fn(k, k, this), reverse);
   }

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -727,10 +727,10 @@ declare module Immutable {
      */
     asImmutable(): Map<K, V>;
 
-    diffFrom(otherMap : Map<K,V>): DiffResult<K,V>;
+    diffFrom(otherMap : Map<K,V>): MapDiffResult<K,V>;
   }
 
-  interface DiffResult<K,V> {
+  interface MapDiffResult<K,V> {
     added: Map<K,V>;
     removed: Map<K,V>;
     updated: Map<K, {prev: V, next: V} >;
@@ -890,8 +890,14 @@ declare module Immutable {
      * @see `Map#asImmutable`
      */
     asImmutable(): Set<T>;
+
+    diffFrom(otherSet : Set<T>): SetDiffResult<T>;
   }
 
+  interface SetDiffResult<T> {
+    added: Set<T>;
+    removed: Set<T>;
+  }
 
   /**
    * A type of Set that has the additional guarantee that the iteration order of

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -727,9 +727,14 @@ declare module Immutable {
      */
     asImmutable(): Map<K, V>;
 
-    diffFrom(otherMap : Map<K,V>): { added: Map<K,V>, removed: Map<K,V>, updated: Map<K,{prev: V, next: V}> }; 
+    diffFrom(otherMap : Map<K,V>): DiffResult<K,V>;
   }
 
+  interface DiffResult<K,V> {
+    added: Map<K,V>;
+    removed: Map<K,V>;
+    updated: Map<K, {prev: V, next: V} >;
+  }
 
   /**
    * A type of Map that has the additional guarantee that the iteration order of

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -726,6 +726,8 @@ declare module Immutable {
      * copy has become immutable and can be safely returned from a function.
      */
     asImmutable(): Map<K, V>;
+
+    diffFrom(otherMap : Map<K,V>): { added: Map<K,V>, removed: Map<K,V>, updated: Map<K,{prev: V, next: V}> }; 
   }
 
 


### PR DESCRIPTION
If there are two `Map` objects deriving from a common `Map` object ancestor, their underlying hash trie can be expected to be very similar. For example `const m1 = Map({...largeObject}); const m2 = m1.set('b', 11); const m3 = m1.set('a',12)` will produce maps `m1`, `m2` and `m3` that share most of the trie.

Entries with the same hashes can be expected to be on the "same" paths in both tries. In Immutable.js each parent-child node relation in a trie is associated with some 5-bit hash fragment. If two nodes in two different tries can be reached from the root of their respective tries by the same 5-bit hash fragments (in the same order), then any entry present in both tries will either be a child of both of those nodes or neither of them. (Property *)

The above two notions can be leveraged to efficiently produce shallow diffs between any trie based datastructures. Such a diff is a collection of added, removed and updated entries representing the changes needed to transform one provided datastructure into the other.

The diff is produced by synchronously traversing both tries. During such a traversal pairs of nodes (one from each trie) are marked as equivalent. The first pair of equivalent nodes are the roots of both tries (since they satisfy Property *). Then for each remaining equivalent pair, the child nodes are extracted together with the hash fragments associated with their parent-child connection. Any two child nodes (from different tries) with the same hash fragments are then marked as equivalent. For each child node with a hash fragment that doesn't exist for any relation in the other trie, all the entries "below" that node are known to be missing in the other trie.

I am aware that the concept of diffing has already bee brought up: https://github.com/facebook/immutable-js/issues/52. As far as I am aware the focus of https://github.com/intelie/immutable-js-diff is not on the efficient shallow diffs. The implementation of this diff algorithm is only possible with an insight into the internal structure of the tries that immutable.js uses. This is why I believe this code belongs here.

I believe this functionality is useful in declaratively built apps (approach encouraged by so many frameworks now). Recomputing data derived from an immutable.js object (for example through grouping objects from a `Map` by a specific attribute) can be computationally expensive. Thanks to the immutability memoization can be used to stop the computation if the result is already known. However if the input object is replaced with a new immutable.js object deriving from the previous one, the result must be recomputed in its entirety. Availability of an efficient diff can enable incremental updates of those derived objects. 

I hope you like my code. I added the `diffFrom` method to the `Map`. It can be easily adapted to the other datastructures. There is a optimization that can be made: The `added` and `removed` `Map`s don't have to be created from scratch. We could reuse the existing trie nodes to build those maps, thus reducing memory used.

Please tell me what you think
Thanks!
