### PR TITLE
Add Default Export to Flow Type definitions

### DIFF
--- a/dist/immutable.js.flow
+++ b/dist/immutable.js.flow
@@ -661,3 +661,22 @@ export {
   fromJS,
   is,
 }
+
+export default {
+  Iterable,
+  Collection,
+  Seq,
+
+  List,
+  Map,
+  OrderedMap,
+  OrderedSet,
+  Range,
+  Repeat,
+  Record,
+  Set,
+  Stack,
+
+  fromJS,
+  is,
+}

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -661,3 +661,22 @@ export {
   fromJS,
   is,
 }
+
+export default {
+  Iterable,
+  Collection,
+  Seq,
+
+  List,
+  Map,
+  OrderedMap,
+  OrderedSet,
+  Range,
+  Repeat,
+  Record,
+  Set,
+  Stack,
+
+  fromJS,
+  is,
+}


### PR DESCRIPTION
This PR solves this issue:

https://github.com/facebook/immutable-js/issues/854

In the [Flow documentation](https://flowtype.org/docs/third-party.html#example) the show an example where you define library definitions in the `libs` option. So you may be inclined to use these type declarations by having the following in your flowconfig:

```
[libs]
./node_modules/immutable-js/dist/immutable.js.flow
```

The problem with this approach is that those type definitions are now global. Anytime you define a Map type, its going to defer to the Immutable Map and ever the window.Map type definition.

In a [separate part of the documentation](https://flowtype.org/docs/declarations.html#declaration-files) the talk about delcaration files using the `.js.flow` approach. Now instead of adding the files as a global declaration in libs, you can simply `import immutable from 'immutable'` and everything just works :)
