### PR TITLE
Update Record Flow Type Definition

### DIFF
--- a/dist/immutable.js.flow
+++ b/dist/immutable.js.flow
@@ -661,3 +661,22 @@ export {
   fromJS,
   is,
 }
+
+export default {
+  Iterable,
+  Collection,
+  Seq,
+
+  List,
+  Map,
+  OrderedMap,
+  OrderedSet,
+  Range,
+  Repeat,
+  Record,
+  Set,
+  Stack,
+
+  fromJS,
+  is,
+}

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -661,3 +661,22 @@ export {
   fromJS,
   is,
 }
+
+export default {
+  Iterable,
+  Collection,
+  Seq,
+
+  List,
+  Map,
+  OrderedMap,
+  OrderedSet,
+  Range,
+  Repeat,
+  Record,
+  Set,
+  Stack,
+
+  fromJS,
+  is,
+}

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -626,6 +626,8 @@ declare class Record<T: Object> {
   get<A>(key: $Keys<T>): A;
   set<A>(key: $Keys<T>, value: A): /*T & Record<T>*/this;
   remove(key: $Keys<T>): /*T & Record<T>*/this;
+  update<A>(key: $Keys<T>, fn: (value: A) => A): this;
+  withMutations(mutator: (mutable: this) => any): this;
 }
 
 declare function fromJS(json: any, reviver?: (k: any, v: Iterable<any,any>) => any): any;


### PR DESCRIPTION
I added `update` and `withMutations`. The definitions for `setIn`, `getIn`, and `updateIn` are going to be a bit trickier.

Looking here for functions not included in the documentations: https://github.com/facebook/immutable-js/blob/master/src/Record.js#L131-L146

FYI this PR contains a commit from https://github.com/facebook/immutable-js/blob/master/dist/immutable.js.flow
