### PR TITLE
TypeScript typings: fix incorrect undefined

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -1962,7 +1962,7 @@ declare module Immutable {
      *
      */
     map<M>(
-      mapper: (value?: V, key?: K, iter?: /*this*/Iterable<K, V>) => M,
+      mapper: (value: V, key: K, iter?: /*this*/Iterable<K, V>) => M,
       context?: any
     ): /*this*/Iterable<K, M>;
 


### PR DESCRIPTION
```
const x = Map<string,string>();
x.set('y', 'bar').map((key, value) => 1)
```

In TypeScript 2 with strict null checking enabled and the current typings, the `value` parameter is inferred to be `string | undefined` because of these typings:

```
    map<M>(
      mapper: (value?: V, key?: K, iter?: /*this*/Iterable<K, V>) => M,
      context?: any
    ): /*this*/Iterable<K, M>;
```

I believe the `?` is intended to mean "this parameter is optional". However, in practice it is equivalent to `value: V | undefined`, which is of course saying something very different. Parameters are already optional in TypeScript:

```
type x = (y: number) => number
const p: x = () => 1 // fine
const p: x = (y) => 1 // fine
```

By changing the typings to the following, `value` is correctly inferred as `string`.
