### PR TITLE
Add named exports

### DIFF
--- a/src/Immutable.js
+++ b/src/Immutable.js
@@ -44,3 +44,21 @@ export default {
   fromJS: fromJS
 
 };
+
+export Iterable;
+
+export Seq;
+export Collection;
+export Map;
+export OrderedMap;
+export List;
+export Stack;
+export Set;
+export OrderedSet;
+
+export Record;
+export Range;
+export Repeat;
+
+export is;
+export fromJS;


### PR DESCRIPTION
Would love to do this:

``` javascript
import { Map, Record } from 'immutable';
```

but at the moment, that's not spec compliant, since immutable only exports a default object.

Thoughts? Pardon if this has been discussed before and I just missed it. Thanks!
