### PR TITLE
Use modern Jest for running tests.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,6 @@
  *   grunt lint      Lint all source javascript
  *   grunt clean     Clean dist folder
  *   grunt build     Build dist javascript
- *   grunt test      Test dist javascript
  *   grunt default   Lint, Build then Test
  *
  */
@@ -53,11 +52,6 @@ module.exports = function(grunt) {
         }]
       }
     },
-    jest: {
-      options: {
-        testPathPattern: /.*/
-      }
-    }
   });
 
 
@@ -211,10 +205,6 @@ module.exports = function(grunt) {
     });
   });
 
-  grunt.registerTask('jest', 'Run tests with Jest.', function () {
-    require('jest-cli').runCLI(this.options(), process.cwd(), this.async());
-  });
-
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-clean');
@@ -222,6 +212,5 @@ module.exports = function(grunt) {
 
   grunt.registerTask('lint', 'Lint all source javascript', ['jshint']);
   grunt.registerTask('build', 'Build distributed javascript', ['clean', 'bundle', 'copy']);
-  grunt.registerTask('test', 'Test built javascript', ['jest']);
-  grunt.registerTask('default', 'Lint, build and test.', ['lint', 'build', 'stats', 'test']);
+  grunt.registerTask('default', 'Lint, build.', ['lint', 'build', 'stats']);
 }

--- a/__tests__/ArraySeq.ts
+++ b/__tests__/ArraySeq.ts
@@ -1,7 +1,5 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
-jest.autoMockOff();
-
 import { Seq } from 'immutable';
 
 describe('ArraySequence', () => {
@@ -22,7 +20,7 @@ describe('ArraySequence', () => {
 
   it('maps', () => {
     var i = Seq([1,2,3]);
-    var m = i.map(x => x + x).toObject();
+    var m = i.map(x => x + x).toArray();
     expect(m).toEqual([2,4,6]);
   });
 

--- a/__tests__/Conversion.ts
+++ b/__tests__/Conversion.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
@@ -15,19 +13,24 @@ interface ExpectWithIs extends Expect {
   not: ExpectWithIs;
 }
 
+jasmine.addMatchers({
+  is: function() {
+    return {
+      compare: function(actual, expected) {
+        var passed = is(actual, expected);
+        return {
+          pass: passed,
+          message: 'Expected ' + actual + (passed ? '' : ' not') + ' to equal ' + expected
+        };
+      }
+    };
+  }
+});
+
 // Symbols
 declare function Symbol(name: string): Object;
 
 describe('Conversion', () => {
-
-  beforeEach(function () {
-    this.addMatchers({
-      is: function(expected) {
-        return is(this.actual, expected);
-      }
-    });
-  });
-
   // Note: order of keys based on Map's hashing order
   var js = {
     deepList: [

--- a/__tests__/Equality.ts
+++ b/__tests__/Equality.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/__tests__/IndexedSeq.ts
+++ b/__tests__/IndexedSeq.ts
@@ -1,7 +1,5 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/__tests__/IterableSeq.ts
+++ b/__tests__/IterableSeq.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 declare var Symbol: any;
-jest.autoMockOff();
-
 import { Seq } from 'immutable';
 
 describe('IterableSequence', () => {

--- a/__tests__/KeyedSeq.ts
+++ b/__tests__/KeyedSeq.ts
@@ -1,7 +1,5 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/__tests__/ListJS.js
+++ b/__tests__/ListJS.js
@@ -1,5 +1,3 @@
-jest.autoMockOff();
-
 var Immutable = require('immutable');
 var List = Immutable.List;
 

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/__tests__/MultiRequire.js
+++ b/__tests__/MultiRequire.js
@@ -1,5 +1,3 @@
-jest.autoMockOff();
-
 var Immutable1 = require('../');
 jest.resetModuleRegistry();
 var Immutable2 = require('../');

--- a/__tests__/ObjectSeq.ts
+++ b/__tests__/ObjectSeq.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { Seq } from 'immutable';
 
 describe('ObjectSequence', () => {

--- a/__tests__/OrderedMap.ts
+++ b/__tests__/OrderedMap.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { OrderedMap, Seq } from 'immutable';
 
 describe('OrderedMap', () => {

--- a/__tests__/OrderedSet.ts
+++ b/__tests__/OrderedSet.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { OrderedSet } from 'immutable';
 
 describe('OrderedSet', () => {

--- a/__tests__/Range.ts
+++ b/__tests__/Range.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { Record, Seq } from 'immutable';
 
 describe('Record', () => {

--- a/__tests__/RecordJS.js
+++ b/__tests__/RecordJS.js
@@ -1,5 +1,3 @@
-jest.autoMockOff();
-
 var Immutable = require('immutable');
 var Record = Immutable.Record;
 

--- a/__tests__/Repeat.ts
+++ b/__tests__/Repeat.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { Repeat } from 'immutable';
 
 describe('Repeat', () => {

--- a/__tests__/Seq.ts
+++ b/__tests__/Seq.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { Iterable, Seq } from 'immutable';
 
 describe('Seq', () => {

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 declare var Symbol: any;
-jest.autoMockOff();
-
 import { List, Map, OrderedSet, Seq, Set, is } from 'immutable';
 
 declare function expect(val: any): ExpectWithIs;
@@ -12,16 +10,21 @@ interface ExpectWithIs extends Expect {
   not: ExpectWithIs;
 }
 
-describe('Set', () => {
-
-  beforeEach(function () {
-    this.addMatchers({
-      is: function(expected) {
-        return is(this.actual, expected);
+jasmine.addMatchers({
+  is: function() {
+    return {
+      compare: function(actual, expected) {
+        var passed = is(actual, expected);
+        return {
+          pass: passed,
+          message: 'Expected ' + actual + (passed ? '' : ' not') + ' to equal ' + expected
+        };
       }
-    })
-  })
+    };
+  }
+});
 
+describe('Set', () => {
   it('accepts array of values', () => {
     var s = Set([1,2,3]);
     expect(s.has(1)).toBe(true);

--- a/__tests__/Stack.ts
+++ b/__tests__/Stack.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/__tests__/concat.ts
+++ b/__tests__/concat.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { Seq, Set, List, is } from 'immutable';
 
 declare function expect(val: any): ExpectWithIs;
@@ -12,15 +10,21 @@ interface ExpectWithIs extends Expect {
   not: ExpectWithIs;
 }
 
-describe('concat', () => {
-
-  beforeEach(function () {
-    this.addMatchers({
-      is: function(expected) {
-        return is(this.actual, expected);
+jasmine.addMatchers({
+  is: function() {
+    return {
+      compare: function(actual, expected) {
+        var passed = is(actual, expected);
+        return {
+          pass: passed,
+          message: 'Expected ' + actual + (passed ? '' : ' not') + ' to equal ' + expected
+        };
       }
-    })
-  })
+    };
+  }
+});
+
+describe('concat', () => {
 
   it('concats two sequences', () => {
     var a = Seq.of(1,2,3);
@@ -56,13 +60,13 @@ describe('concat', () => {
     var a = Seq.of(1,2,3);
     var b = [4,5,6];
     expect(a.concat(b).size).toBe(6);
-    expect(a.concat(b).toObject()).toEqual([1,2,3,4,5,6]);
+    expect(a.concat(b).toArray()).toEqual([1,2,3,4,5,6]);
   })
 
   it('concats values', () => {
     var a = Seq.of(1,2,3);
     expect(a.concat(4,5,6).size).toBe(6);
-    expect(a.concat(4,5,6).toObject()).toEqual([1,2,3,4,5,6]);
+    expect(a.concat(4,5,6).toArray()).toEqual([1,2,3,4,5,6]);
   })
 
   it('doesnt concat objects to indexed seq', () => {
@@ -79,13 +83,13 @@ describe('concat', () => {
     var b = [4,5,6];
     var c = [7,8,9];
     expect(a.concat(b, c).size).toBe(9);
-    expect(a.concat(b, c).toObject()).toEqual([1,2,3,4,5,6,7,8,9]);
+    expect(a.concat(b, c).toArray()).toEqual([1,2,3,4,5,6,7,8,9]);
   })
 
   it('can concat itself!', () => {
     var a = Seq.of(1,2,3);
     expect(a.concat(a, a).size).toBe(9);
-    expect(a.concat(a, a).toObject()).toEqual([1,2,3,1,2,3,1,2,3]);
+    expect(a.concat(a, a).toArray()).toEqual([1,2,3,1,2,3,1,2,3]);
   })
 
   it('returns itself when concat does nothing', () => {

--- a/__tests__/count.ts
+++ b/__tests__/count.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { Seq, Range } from 'immutable';
 
 describe('count', () => {

--- a/__tests__/find.ts
+++ b/__tests__/find.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/__tests__/flatten.ts
+++ b/__tests__/flatten.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/__tests__/get.ts
+++ b/__tests__/get.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { Range } from 'immutable';
 
 describe('get', () => {

--- a/__tests__/groupBy.ts
+++ b/__tests__/groupBy.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { Iterable, Seq, Map } from 'immutable';
 
 describe('groupBy', () => {
@@ -31,11 +29,16 @@ describe('groupBy', () => {
     );
   })
 
-  it('groups indexed sequences, maintaining indicies', () => {
+  it('groups indexed sequences, maintaining indicies when keyed sequences', () => {
+    expect(
+      Seq.of(1,2,3,4,5,6).groupBy(x => x % 2).toJS()
+    ).toEqual(
+      {1:[1,3,5], 0:[2,4,6]}
+    );
     expect(
       Seq.of(1,2,3,4,5,6).toKeyedSeq().groupBy(x => x % 2).toJS()
     ).toEqual(
-      {1:[1,,3,,5,,,], 0:[,2,,4,,6]}
+      {1:{0:1, 2:3, 4:5}, 0:{1:2, 3:4, 5:6}}
     );
   })
 

--- a/__tests__/interpose.ts
+++ b/__tests__/interpose.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { Range } from 'immutable';
 
 describe('interpose', () => {

--- a/__tests__/join.ts
+++ b/__tests__/join.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import jasmineCheck = require('jasmine-check');
 jasmineCheck.install();
 

--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { List, Map, fromJS, is } from 'immutable';
 
 declare function expect(val: any): ExpectWithIs;
@@ -12,16 +10,21 @@ interface ExpectWithIs extends Expect {
   not: ExpectWithIs;
 }
 
-describe('merge', () => {
-
-  beforeEach(function () {
-    this.addMatchers({
-      is: function(expected) {
-        return is(this.actual, expected);
+jasmine.addMatchers({
+  is: function() {
+    return {
+      compare: function(actual, expected) {
+        var passed = is(actual, expected);
+        return {
+          pass: passed,
+          message: 'Expected ' + actual + (passed ? '' : ' not') + ' to equal ' + expected
+        };
       }
-    })
-  })
+    };
+  }
+});
 
+describe('merge', () => {
   it('merges two maps', () => {
     var m1 = Map({a:1,b:2,c:3});
     var m2 = Map({d:10,b:20,e:30});

--- a/__tests__/minmax.ts
+++ b/__tests__/minmax.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/__tests__/slice.ts
+++ b/__tests__/slice.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/__tests__/sort.ts
+++ b/__tests__/sort.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { Seq, List, OrderedMap, Range } from 'immutable';
 
 describe('sort', () => {

--- a/__tests__/splice.ts
+++ b/__tests__/splice.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/__tests__/updateIn.ts
+++ b/__tests__/updateIn.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import { Map, Set, fromJS } from 'immutable';
 
 describe('updateIn', () => {

--- a/__tests__/zip.ts
+++ b/__tests__/zip.ts
@@ -1,8 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
 ///<reference path='../dist/immutable.d.ts'/>
 
-jest.autoMockOff();
-
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 

--- a/contrib/cursor/__tests__/Cursor.ts.skip
+++ b/contrib/cursor/__tests__/Cursor.ts.skip
@@ -10,7 +10,7 @@ import Cursor = require('immutable/contrib/cursor');
 describe('Cursor', () => {
 
   beforeEach(function () {
-    this.addMatchers({
+    jasmine.addMatchers({
       toValueEqual: function (expected) {
         var actual = this.actual;
         if (!Immutable.is(expected, this.actual)) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,6 @@ var gulp = require('gulp');
 var gutil = require('gulp-util');
 var header = require('gulp-header');
 var Immutable = require('./');
-var jest = require('gulp-jest');
 var jshint = require('gulp-jshint');
 var less = require('gulp-less');
 var path = require('path');
@@ -109,15 +108,6 @@ gulp.task('lint', function() {
     }))
     .pipe(jshint.reporter(stylish))
     .pipe(jshint.reporter('fail'))
-    .on('error', handleError);
-});
-
-gulp.task('test', function () {
-  return gulp.src('./')
-    .pipe(jest({
-      scriptPreprocessor: './resources/jestPreprocessor.js',
-      unmockedModulePathPatterns: ['./node_modules/react'],
-    }))
     .on('error', handleError);
 });
 
@@ -220,7 +210,7 @@ gulp.task('build', function (done) {
 });
 
 gulp.task('default', function (done) {
-  sequence('clean', 'lint', /*'test',*/ 'build', done);
+  sequence('clean', 'lint', 'build', done);
 });
 
 // watch files for changes and reload
@@ -240,14 +230,14 @@ gulp.task('dev', ['default'], function() {
 });
 
 gulp.task('rebuild-js', function (done) {
-  sequence('lint', 'js', /*'test',*/ ['pre-render'], function () {
+  sequence('lint', 'js', ['pre-render'], function () {
     browserSync.reload();
     done();
   });
 });
 
 gulp.task('rebuild-js-docs', function (done) {
-  sequence('lint', 'js-docs', /*'test',*/ ['pre-render-docs'], function () {
+  sequence('lint', 'js-docs', ['pre-render-docs'], function () {
     browserSync.reload();
     done();
   });

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "deploy": "(cd ./pages/out && git init && git config user.name \"Travis CI\" && git config user.email \"github@fb.com\" && git add . && git commit -m \"Deploy to GitHub Pages\" && git push --force --quiet \"https://${GH_TOKEN}@github.com/facebook/immutable-js.git\" master:gh-pages > /dev/null 2>1)"
   },
   "jest": {
-    "scriptPreprocessor": "resources/jestPreprocessor.js",
-    "testFileExtensions": [
-      "js",
-      "ts"
-    ],
-    "persistModuleRegistryBetweenSpecs": true
+    "moduleFileExtensions": ["js", "ts"],
+    "transform": {
+      "^.+\\.ts$": "<rootDir>/resources/jestPreprocessor.js"
+    },
+    "testRegex": "/__tests__/.*\\.(ts|js)$",
+    "unmockedModulePathPatterns": ["./node_modules/react"]
   },
   "devDependencies": {
     "acorn": "0.11.x",
@@ -60,7 +60,6 @@
     "gulp-concat": "2.6.0",
     "gulp-filter": "3.0.1",
     "gulp-header": "1.7.1",
-    "gulp-jest": "^0.2.1",
     "gulp-jshint": "^1.8.4",
     "gulp-less": "3.0.5",
     "gulp-size": "2.0.0",
@@ -69,7 +68,7 @@
     "gulp-util": "3.0.7",
     "harmonize": "1.4.4",
     "jasmine-check": "^0.1.2",
-    "jest-cli": "^0.5.10",
+    "jest": "^17.0.3",
     "jshint-stylish": "^0.4.0",
     "magic-string": "0.10.2",
     "marked": "0.3.5",

--- a/resources/jestPreprocessor.js
+++ b/resources/jestPreprocessor.js
@@ -54,11 +54,11 @@ function compileTypeScript(filePath) {
     return fs.readFileSync(outputPath, {encoding: 'utf8'});
   }
 
-  diagnostics.forEach(function(diagnostic) {
+  var report = diagnostics.map(function(diagnostic) {
     var loc = typescript.getLineAndCharacterOfPosition(diagnostic.file, diagnostic.start);
-    console.error('%s %d:%d %s', diagnostic.file.fileName, loc.line, loc.character, diagnostic.messageText);
-  });
-  throw new Error('Compiling ' + filePath + ' failed');
+    return diagnostic.file.fileName + ' ' + loc.line + ':' + loc.character + ' ' + diagnostic.messageText;
+  }).join('\n');
+  throw new Error('Compiling ' + filePath + ' failed' + '\n' + report);
 }
 
 function withLocalImmutable(filePath, jsSrc) {


### PR DESCRIPTION
This updates from `jest@0.ancient.0` to jest 17, speeding up tests and improving test runs on modern node versions.