### PR TITLE
Make header nav links dark gray; increase contrast for usability

### DIFF
--- a/pages/src/src/style.less
+++ b/pages/src/src/style.less
@@ -27,7 +27,7 @@
 }
 
 .miniHeader {
-  background: #6dbcdb;
+  background: #9ed2e7;
   position: fixed;
   width: 100%;
   z-index: 1;
@@ -63,7 +63,7 @@
 }
 
 .miniHeaderContents a {
-  color: #fff;
+  color: #525455;
   font-weight: bold;
   margin-right: 1em;
   text-decoration: none;


### PR DESCRIPTION
I noticed that the contrast between the navigation links and the
background on the Immutable.js landing page is very subtle - by
using higher contrast we can increase usability and accessibility.

![screen shot 2016-12-07 at 1 56 57 pm](https://cloud.githubusercontent.com/assets/1114467/20994361/c3374ef4-bca4-11e6-924e-52deed33d563.png)

There is a handy tool for testing contrast for accessibility;
http://webaim.org/resources/contrastchecker/

![screen shot 2016-12-07 at 4 06 09 pm](https://cloud.githubusercontent.com/assets/1114467/20994381/dd11efc8-bca4-11e6-833e-6e3ecdf4dffe.png)

On the landing page the links are white on a light gray background.
We initially set the link color to match the main font color on the
page, which is #626466. However, this was not quite enough contrast.
Bumping the font color a step darker gave us #525455, which should be
very close but have a high enough contrast to be easily readable.

![screen shot 2016-12-07 at 4 10 10 pm](https://cloud.githubusercontent.com/assets/1114467/20994396/f441ef4a-bca4-11e6-94eb-2c4edcd7d6b1.png)

![screen shot 2016-12-07 at 4 09 04 pm](https://cloud.githubusercontent.com/assets/1114467/20994403/01bb0ddc-bca5-11e6-8822-571cbc3ef7c8.png)


The dark gray (#525455) on the light blue background was also not high
enough contrast, so we lightened the light blue background.

![screen shot 2016-12-07 at 4 26 21 pm](https://cloud.githubusercontent.com/assets/1114467/20994410/0b9af452-bca5-11e6-84ed-33d97fd679f9.png)

![screen shot 2016-12-07 at 4 27 01 pm](https://cloud.githubusercontent.com/assets/1114467/20994415/1222fa36-bca5-11e6-93ae-cb1e0d505934.png)

![screen shot 2016-12-07 at 4 27 12 pm](https://cloud.githubusercontent.com/assets/1114467/20994418/168804ea-bca5-11e6-9c0a-758edc1b8d1a.png)

We considered leaving the links white on the blue background, and only
changing them on the landing page where the background is light gray.
However, to get enough contrast with a white font the light blue
background would have to be darkened beyond recognition.

![screen shot 2016-12-07 at 4 52 22 pm](https://cloud.githubusercontent.com/assets/1114467/20994425/2243337c-bca5-11e6-845b-c60afd908e8c.png)

I'm open to adjusting this as needed, and thanks for your review!

More ideas:
- We could make the main copy font color match the nav links
- We could use a dark blue instead of dark gray for the nav links

PS - I don't know how to view the website locally, so I was just changing colors in the dev tools to test the effect. lmk if I can spin up the docs site locally to manually test this change.