### PR TITLE
Fix flowtypes for OrderedSet, OrderedMap, toOrderedSet, and toOrderedMap

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -561,9 +561,78 @@ declare module 'immutable' {
     flatten(shallow?: boolean): /*this*/Map<any,any>;
   }
 
-  // OrderedMaps have nothing that Maps do not have. We do not need to override constructor & other statics
-  declare class OrderedMap<K,V> extends Map<K,V> {
+  declare class OrderedMap<K,V> extends KeyedCollection<K,V> {
+    static <K, V>(obj?: {[key: K]: V}): OrderedMap<K, V>;
+    static <K, V>(iterable: ESIterable<[K,V]>): OrderedMap<K, V>;
     static isOrderedMap(maybeOrderedMap: any): bool;
+
+    set<K_, V_>(key: K_, value: V_): OrderedMap<K|K_, V|V_>;
+    delete(key: K): this;
+    remove(key: K): this;
+    clear(): this;
+
+    update<K_,V_>(updater: (value: this) => OrderedMap<K_,V_>): OrderedMap<K_,V_>;
+    update<V_>(key: K, updater: (value: V) => V_): OrderedMap<K,V|V_>;
+    update<V_>(key: K, notSetValue: V_, updater: (value: V) => V_): OrderedMap<K,V|V_>;
+
+    merge<K_,V_>(
+      ...iterables: (ESIterable<[K_,V_]> | { [key: K_]: V_ })[]
+    ): OrderedMap<K|K_,V|V_>;
+
+    mergeWith<K_,W,X>(
+      merger: (previous: V, next: W, key: number) => X,
+      ...iterables: ESIterable<W>[]
+    ): OrderedMap<K,V|W|X>;
+
+    mergeDeep<K_,V_>(
+      ...iterables: (ESIterable<[K_,V_]> | { [key: K_]: V_ })[]
+    ): OrderedMap<K|K_,V|V_>;
+
+    mergeDeepWith<K_,W,X>(
+      merger: (previous: V, next: W, key: number) => X,
+      ...iterables: ESIterable<W>[]
+    ): OrderedMap<K,V|W|X>;
+
+    setIn(keyPath: ESIterable<any>, value: any): OrderedMap<K,V>;
+    deleteIn(keyPath: ESIterable<any>, value: any): this;
+    removeIn(keyPath: ESIterable<any>, value: any): this;
+
+    updateIn(keyPath: ESIterable<any>, notSetValue: any, value: any): OrderedMap<K,V>;
+    updateIn(keyPath: ESIterable<any>, value: any): OrderedMap<K,V>;
+
+    mergeIn(
+      keyPath: ESIterable<K>,
+      ...iterables: (ESIterable<K> | { [key: string]: any })[]
+    ): OrderedMap<K,any>;
+    mergeDeepIn(
+      keyPath: ESIterable<K>,
+      ...iterables: (ESIterable<K> | { [key: string]: any })[]
+    ): OrderedMap<K,any>;
+
+    withMutations(mutator: (mutable: this) => any): this;
+    asMutable(): this;
+    asImmutable(): this;
+
+    // Overrides that specialize return types
+    map<V_>(
+      mapper: (value: V, key: K, iter: this) => V_,
+      context?: any
+    ): OrderedMap<K,V_>;
+
+    flatMap<K_,V_>(
+      mapper: (value: V, key: K, iter: this) => ESIterable<[K_,V_]>,
+      context?: any
+    ): OrderedMap<K_,V_>;
+
+    flip(): OrderedMap<V,K>;
+
+    mapKeys<K_>(
+      mapper: (key: K, value: V, iter: this) => K_,
+      context?: any
+    ): OrderedMap<K_,V>;
+
+    flatten(depth?: number): /*this*/OrderedMap<any,any>;
+    flatten(shallow?: boolean): /*this*/OrderedMap<any,any>
   }
 
   declare class Set<T> extends SetCollection<T> {
@@ -602,9 +671,40 @@ declare module 'immutable' {
     flatten(shallow?: boolean): /*this*/Set<any>;
   }
 
-  // OrderedSets have nothing that Sets do not have. We do not need to override constructor & other statics
   declare class OrderedSet<T> extends Set<T> {
+    static <T>(iterable: ESIterable<T>): OrderedSet<T>;
+    static of<T>(...values: T[]): OrderedSet<T>;
+    static fromKeys<T>(iter: ESIterable<[T,any]>): OrderedSet<T>;
+    static fromKeys<K, V>(object: { [key: K]: V }): OrderedSet<K>;
+    static (_: void): OrderedSet<any>;
     static isOrderedSet(maybeOrderedSet: any): bool;
+
+    add<U>(value: U): OrderedSet<T|U>;
+    delete(value: T): this;
+    remove(value: T): this;
+    clear(): this;
+    union<U>(...iterables: ESIterable<U>[]): OrderedSet<T|U>;
+    merge<U>(...iterables: ESIterable<U>[]): OrderedSet<T|U>;
+    intersect<U>(...iterables: ESIterable<U>[]): OrderedSet<T&U>;
+    subtract<U>(...iterables: ESIterable<U>[]): OrderedSet<T>;
+
+    withMutations(mutator: (mutable: this) => any): this;
+    asMutable(): this;
+    asImmutable(): this;
+
+    // Overrides that specialize return types
+    map<M>(
+      mapper: (value: T, value: T, iter: this) => M,
+      context?: any
+    ): OrderedSet<M>;
+
+    flatMap<M>(
+      mapper: (value: T, value: T, iter: this) => ESIterable<M>,
+      context?: any
+    ): OrderedSet<M>;
+
+    flatten(depth?: number): /*this*/OrderedSet<any>;
+    flatten(shallow?: boolean): /*this*/OrderedSet<any>;
   }
 
   declare class Stack<T> extends IndexedCollection<T> {

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -81,9 +81,9 @@ declare module 'immutable' {
     toArray(): V[];
     toObject(): { [key: string]: V };
     toMap(): Map<K,V>;
-    toOrderedMap(): Map<K,V>;
+    toOrderedMap(): OrderedMap<K,V>;
     toSet(): Set<V>;
-    toOrderedSet(): Set<V>;
+    toOrderedSet(): OrderedSet<V>;
     toList(): List<V>;
     toStack(): Stack<V>;
     toSeq(): Seq<K,V>;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -671,6 +671,7 @@ declare module 'immutable' {
     flatten(shallow?: boolean): /*this*/Set<any>;
   }
 
+  // Overrides except for `isOrderedSet` are for specialized return types
   declare class OrderedSet<T> extends Set<T> {
     static <T>(iterable: ESIterable<T>): OrderedSet<T>;
     static of<T>(...values: T[]): OrderedSet<T>;
@@ -680,19 +681,11 @@ declare module 'immutable' {
     static isOrderedSet(maybeOrderedSet: any): bool;
 
     add<U>(value: U): OrderedSet<T|U>;
-    delete(value: T): this;
-    remove(value: T): this;
-    clear(): this;
     union<U>(...iterables: ESIterable<U>[]): OrderedSet<T|U>;
     merge<U>(...iterables: ESIterable<U>[]): OrderedSet<T|U>;
     intersect<U>(...iterables: ESIterable<U>[]): OrderedSet<T&U>;
     subtract<U>(...iterables: ESIterable<U>[]): OrderedSet<T>;
 
-    withMutations(mutator: (mutable: this) => any): this;
-    asMutable(): this;
-    asImmutable(): this;
-
-    // Overrides that specialize return types
     map<M>(
       mapper: (value: T, value: T, iter: this) => M,
       context?: any

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -506,18 +506,18 @@ declare module 'immutable' {
     ): Map<K|K_,V|V_>;
 
     mergeWith<K_,W,X>(
-      merger: (previous: V, next: W, key: number) => X,
-      ...iterables: ESIterable<W>[]
-    ): Map<K,V|W|X>;
+      merger: (previous: V, next: W, key: K) => X,
+      ...iterables: (ESIterable<[K_,W]> | { [key: K_]: W })[]
+    ): Map<K|K_,V|W|X>;
 
     mergeDeep<K_,V_>(
       ...iterables: (ESIterable<[K_,V_]> | { [key: K_]: V_ })[]
     ): Map<K|K_,V|V_>;
 
     mergeDeepWith<K_,W,X>(
-      merger: (previous: V, next: W, key: number) => X,
-      ...iterables: ESIterable<W>[]
-    ): Map<K,V|W|X>;
+      merger: (previous: V, next: W, key: K) => X,
+      ...iterables: (ESIterable<[K_,W]> | { [key: K_]: W })[]
+    ): Map<K|K_,V|W|X>;
 
     setIn(keyPath: ESIterable<any>, value: any): Map<K,V>;
     deleteIn(keyPath: ESIterable<any>, value: any): this;
@@ -580,18 +580,18 @@ declare module 'immutable' {
     ): OrderedMap<K|K_,V|V_>;
 
     mergeWith<K_,W,X>(
-      merger: (previous: V, next: W, key: number) => X,
-      ...iterables: ESIterable<W>[]
-    ): OrderedMap<K,V|W|X>;
+      merger: (previous: V, next: W, key: K) => X,
+      ...iterables: (ESIterable<[K_,W]> | { [key: K_]: W })[]
+    ): OrderedMap<K|K_,V|W|X>;
 
     mergeDeep<K_,V_>(
       ...iterables: (ESIterable<[K_,V_]> | { [key: K_]: V_ })[]
     ): OrderedMap<K|K_,V|V_>;
 
     mergeDeepWith<K_,W,X>(
-      merger: (previous: V, next: W, key: number) => X,
-      ...iterables: ESIterable<W>[]
-    ): OrderedMap<K,V|W|X>;
+      merger: (previous: V, next: W, key: K) => X,
+      ...iterables: (ESIterable<[K_,W]> | { [key: K_]: W })[]
+    ): OrderedMap<K|K_,V|W|X>;
 
     setIn(keyPath: ESIterable<any>, value: any): OrderedMap<K,V>;
     deleteIn(keyPath: ESIterable<any>, value: any): this;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -523,8 +523,15 @@ declare module 'immutable' {
     deleteIn(keyPath: ESIterable<any>, value: any): this;
     removeIn(keyPath: ESIterable<any>, value: any): this;
 
-    updateIn(keyPath: ESIterable<any>, notSetValue: any, value: any): Map<K,V>;
-    updateIn(keyPath: ESIterable<any>, value: any): Map<K,V>;
+    updateIn(
+      keyPath: ESIterable<any>,
+      notSetValue: any,
+      updater: (value: any) => any
+    ): Map<K,V>;
+    updateIn(
+      keyPath: ESIterable<any>,
+      updater: (value: any) => any
+    ): Map<K,V>;
 
     mergeIn(
       keyPath: ESIterable<K>,
@@ -597,8 +604,15 @@ declare module 'immutable' {
     deleteIn(keyPath: ESIterable<any>, value: any): this;
     removeIn(keyPath: ESIterable<any>, value: any): this;
 
-    updateIn(keyPath: ESIterable<any>, notSetValue: any, value: any): OrderedMap<K,V>;
-    updateIn(keyPath: ESIterable<any>, value: any): OrderedMap<K,V>;
+    updateIn(
+      keyPath: ESIterable<any>,
+      notSetValue: any,
+      updater: (value: any) => any
+    ): OrderedMap<K,V>;
+    updateIn(
+      keyPath: ESIterable<any>,
+      updater: (value: any) => any
+    ): OrderedMap<K,V>;
 
     mergeIn(
       keyPath: ESIterable<K>,

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -228,25 +228,23 @@ stringToNumber = Map({a: 1}).merge([[1, 'a']])
 // $ExpectError
 const stringToNumber: Map<string, number> = Map({a: 1}).merge(numberToString)
 
-/**
- * FIXME: this should throw an error, the signature should be
- *
- * ```
- * merger: (previous: V, next: V, key: K) => V,
- *    ...iterables: Iterable<K, V>[]
- * ```
- */
+stringToNumber = Map({'a': 1}).mergeWith((previous, next, key) => 1, {'a': 2, 'b': 2})
+// $ExpectError - this is actually a Map<string, number|string>
+stringToNumber = Map({'a': 1}).mergeWith((previous, next, key) => previous + next, {'a': '2', 'b': '2'})
+stringToNumberOrString = Map({'a': 1}).mergeWith((previous, next, key) => previous + next, {'a': '2', 'b': '2'})
+// $ExpectError - the array [1] is not a valid argument
 stringToNumber = Map({'a': 1}).mergeWith((previous, next, key) => 1, [1])
-// $ExpectError
-stringToNumber = Map({'a': 1}).mergeWith((previous, next, key) => previous + next, ['a'])
 
 stringToNumberOrString = Map({'a': 1}).mergeDeep({'a': 'b'})
 // $ExpectError
 stringToNumber = Map({'a': 1}).mergeDeep({'a': 'b'})
 
+stringToNumber = Map({'a': 1}).mergeDeepWith((previous, next, key) => 1, {'a': 2, 'b': 2})
+// $ExpectError - this is actually a Map<string, number|string>
+stringToNumber = Map({'a': 1}).mergeDeepWith((previous, next, key) => 1, {'a': '2', 'b': '2'})
+stringToNumberOrString = Map({'a': 1}).mergeDeepWith((previous, next, key) => 1, {'a': '2', 'b': '2'})
+// $ExpectError - the array [1] is not a valid argument
 stringToNumber = Map({'a': 1}).mergeDeepWith((previous, next, key) => 1, [1])
-// $ExpectError
-stringToNumber = Map({'a': 1}).mergeDeepWith((previous, next, key) => previous + next, ['a'])
 
 stringToNumber = Map({'a': 1}).setIn([], 0)
 
@@ -368,32 +366,23 @@ orderedStringToNumber = OrderedMap({'a': 1}).merge({'b': 2})
 orderedStringToNumber = OrderedMap({'a': 1}).merge({'b': '2'})
 orderedStringToNumberOrString = OrderedMap({'a': 1}).merge({'b': '2'})
 
-/**
- * FIXME: this should throw an error, the merger signature should be
- *
- * ```
- * merger: (previous: V, next: V, key: K) => V,
- *    ...iterables: Iterable<K, V>[]
- * ```
- *
- * We shouldn't be able to pass in an array of numbers to the merger function.
- */
+orderedStringToNumber = OrderedMap({'a': 1}).mergeWith((prev, next) => next, {'a': 2, 'b': 3})
+// $ExpectError - this is actually an OrderedMap<string, number|string>
+orderedStringToNumber = OrderedMap({'a': 1}).mergeWith((prev, next) => next, {'a': '2', 'b': '3'})
+orderedStringToNumberOrString = OrderedMap({'a': 1}).mergeWith((prev, next) => next, {'a': '2', 'b': '3'})
+// $ExpectError - the array [1] is not a valid argument
 orderedStringToNumber = OrderedMap({'a': 1}).mergeWith((prev, next) => next, [1])
+
 orderedStringToNumber = OrderedMap({'a': 1}).mergeDeep({'a': 2})
 // $ExpectError - this is actually an OrderedMap<string, number|string>
 orderedStringToNumber = OrderedMap({'a': 1}).mergeDeep({'a': '2'})
 orderedStringToNumberOrString = OrderedMap({'a': 1}).mergeDeep({'a': '2'})
 
-/**
- * FIXME: this should throw an error, the merger signature should be
- *
- * ```
- * merger: (previous: V, next: V, key: K) => V,
- *    ...iterables: Iterable<K, V>[]
- * ```
- *
- * We shouldn't be able to pass in an array of numbers to the merger function.
- */
+orderedStringToNumber = OrderedMap({'a': 1}).mergeDeepWith((prev, next) => next, {'a': 2, 'b': 3})
+// $ExpectError - this is actually an OrderedMap<string, number|string>
+orderedStringToNumber = OrderedMap({'a': 1}).mergeDeepWith((prev, next) => next, {'a': '2', 'b': '3'})
+orderedStringToNumberOrString = OrderedMap({'a': 1}).mergeDeepWith((prev, next) => next, {'a': '2', 'b': '3'})
+// $ExpectError - the array [1] is an invalid argument
 orderedStringToNumber = OrderedMap({'a': 1}).mergeDeepWith((prev, next) => next, [1])
 
 orderedStringToNumber = OrderedMap({'a': 1}).setIn([], 3)

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -390,22 +390,11 @@ orderedStringToNumber = OrderedMap({'a': 1}).deleteIn([])
 orderedStringToNumber = OrderedMap({'a': 1}).removeIn([])
 
 orderedStringToNumber = OrderedMap({'a': 1}).updateIn([], val => val + 1)
-/**
- * FIXME: this should throw an error, updater's signature should be
- *
- * ```
- * updater: (value: any) => any
- * ```
- *
- * according to the docs
- */
+// $ExpectError - 'a' in an invalid argument
 orderedStringToNumber = OrderedMap({'a': 1}).updateIn([], 'a')
 
 orderedStringToNumber = OrderedMap({'a': 1}).updateIn([], 0, val => val + 1)
-/**
- * FIXME: this should also throw an error, the updater is currently allowed to
- * be anything, rather than restricted to be a function.
- */
+// $ExpectError - 'a' is an invalid argument
 orderedStringToNumber = OrderedMap({'a': 1}).updateIn([], 0, 'a')
 
 orderedStringToNumber = OrderedMap({'a': 1}).mergeIn([], {'b': 2})

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -5,7 +5,7 @@
 // Some tests look like they are repeated in order to avoid false positives.
 // Flow might not complain about an instance of (what it thinks is) T to be assigned to T<K, V>
 
-import {
+import Immutable, {
   List,
   Map,
   Stack,
@@ -17,6 +17,33 @@ import {
   OrderedMap,
   OrderedSet
 } from 'immutable'
+import * as Immutable2 from 'immutable'
+
+/**
+ * Although this looks like dead code, importing `Immutable` and
+ * `Immutable2` tests:
+ *
+ * 1. that default import works -- `import Immutable, {...} from 'immutable'
+ * 2. that importing everything works -- `import * as X from 'immutable'`
+ * 3. that individual imports are supported
+ */
+const ImmutableList = Immutable.List
+const ImmutableMap = Immutable.Map
+const ImmutableStack = Immutable.Stack
+const ImmutableSet = Immutable.Set
+const ImmutableKeyedIterable = Immutable.KeyedIterable
+const ImmutableRange = Immutable.Range
+const ImmutableRepeat = Immutable.Repeat
+const ImmutableIndexedSeq = Immutable.IndexedSeq
+
+const Immutable2List = Immutable2.List
+const Immutable2Map = Immutable2.Map
+const Immutable2Stack = Immutable2.Stack
+const Immutable2Set = Immutable2.Set
+const Immutable2KeyedIterable = Immutable2.KeyedIterable
+const Immutable2Range = Immutable2.Range
+const Immutable2Repeat = Immutable2.Repeat
+const Immutable2IndexedSeq = Immutable2.IndexedSeq
 
 var numberList: List<number> = List()
 var numberOrStringList: List<string | number> = List()

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -13,7 +13,9 @@ import Immutable, {
   KeyedIterable,
   Range,
   Repeat,
-  IndexedSeq
+  IndexedSeq,
+  OrderedMap,
+  OrderedSet
 } from 'immutable'
 import * as Immutable2 from 'immutable'
 
@@ -39,11 +41,13 @@ var numberList: List<number> = List()
 var numberOrStringList: List<string | number> = List()
 var nullableNumberList: List<?number> = List()
 var stringToNumber: Map<string, number> = Map()
+var orderedStringToNumber: OrderedMap<string, number>
 var stringToNumberOrString: Map<string, string | number> = Map()
 var numberToString: Map<number, string> = Map()
 var stringOrNumberToNumberOrString: Map<string | number, string | number> = Map()
 var anyMap: Map<any, any> = Map()
 var numberSet: Set<number> = Set()
+var orderedStringSet: OrderedSet<string>
 var numberOrStringSet: Set<number | string> = Set()
 var stringSet: Set<string> = Set()
 var numberStack: Stack<number> = Stack()
@@ -268,6 +272,41 @@ stringToNumber = Map({'a': 1}).mapKeys((key, value, iter) => 1)
 
 anyMap = Map({'a': 1}).flatten()
 
+/* OrderedMap */
+
+orderedStringToNumber = Map({'a': 1}).toOrderedMap()
+orderedStringToNumber = OrderedMap({'a': 1})
+orderedStringToNumber = OrderedMap(Map({'a': 1}))
+orderedStringToNumber = OrderedMap()
+orderedStringToNumber = OrderedMap().set('b', 2)
+orderedStringToNumber = OrderedMap({'a': 1}).delete('a')
+orderedStringToNumber = OrderedMap({'a': 1}).remove('a')
+orderedStringToNumber = OrderedMap({'a': 1}).clear()
+orderedStringToNumber = OrderedMap({'a': 1}).update(() => OrderedMap({'b': 1}))
+orderedStringToNumber = OrderedMap({'a': 1}).update('a', value => value + 1)
+orderedStringToNumber = OrderedMap({'a': 1}).update('a', 0, value => value + 1)
+orderedStringToNumber = OrderedMap({'a': 1}).merge({'b': 2})
+orderedStringToNumber = OrderedMap({'a': 1}).mergeWith((prev, next) => next, [1])
+orderedStringToNumber = OrderedMap({'a': 1}).mergeDeep({'a': 2})
+orderedStringToNumber = OrderedMap({'a': 1}).mergeDeepWith((prev, next) => next, [1])
+orderedStringToNumber = OrderedMap({'a': 1}).setIn([], 3)
+orderedStringToNumber = OrderedMap({'a': 1}).deleteIn([])
+orderedStringToNumber = OrderedMap({'a': 1}).removeIn([])
+orderedStringToNumber = OrderedMap({'a': 1}).updateIn([], val => val + 1)
+orderedStringToNumber = OrderedMap({'a': 1}).updateIn([], 0, val => val + 1)
+orderedStringToNumber = OrderedMap({'a': 1}).mergeIn([], {'b': 2})
+orderedStringToNumber = OrderedMap({'a': 1}).mergeDeepIn([], {'b': 2})
+orderedStringToNumber = OrderedMap({'a': 1}).withMutations(mutable => mutable.set('b', 2))
+orderedStringToNumber = OrderedMap({'a': 1}).asMutable();
+orderedStringToNumber = OrderedMap({'a': 1}).asImmutable();
+orderedStringToNumber = OrderedMap({'a': 1}).map((v) => v + 1)
+orderedStringToNumber = OrderedMap({'a': 1}).flatMap((v, k) => (OrderedMap({ [k]: v + 1 })))
+orderedStringToNumber = OrderedMap({'a': 1}).flip().flip()
+orderedStringToNumber = OrderedMap({'a': 1}).mapKeys(x => x)
+orderedStringToNumber = OrderedMap({'a': 1}).flatten()
+orderedStringToNumber = OrderedMap({'a': 1}).flatten(1)
+orderedStringToNumber = OrderedMap({'a': 1}).flatten(true)
+
 /* Set */
 
 numberSet = Set()
@@ -361,6 +400,30 @@ numberSet = Set([1]).flatMap((value, index, iter) => ['a'])
 
 numberSet = Set([1]).flatten()
 
+/* OrderedSet */
+
+orderedStringSet = Set(['a']).toOrderedSet()
+orderedStringSet = OrderedSet(['a'])
+orderedStringSet = OrderedSet.of('a', 'b', 'c')
+orderedStringSet = OrderedSet.fromKeys(Map({'a': 1}))
+orderedStringSet = OrderedSet.fromKeys({ 'a': 1 })
+orderedStringSet = OrderedSet()
+orderedStringSet = OrderedSet().add('yo')
+orderedStringSet = OrderedSet.of('a').delete('a')
+orderedStringSet = OrderedSet.of('a').remove('a')
+orderedStringSet = OrderedSet.of('a').clear()
+orderedStringSet = OrderedSet.of('a').union(OrderedSet.of('b'))
+orderedStringSet = OrderedSet.of('a').merge(OrderedSet.of('b'))
+orderedStringSet = OrderedSet.of('a', 'b').intersect(OrderedSet.of('a'))
+orderedStringSet = OrderedSet.of('a', 'b').subtract(OrderedSet.of('a'))
+orderedStringSet = OrderedSet().withMutations(mutable => mutable.add('a'))
+orderedStringSet = OrderedSet.of('a').asMutable();
+orderedStringSet = OrderedSet.of('a').asImmutable();
+orderedStringSet = OrderedSet.of('a', 'b').map(m => m);
+orderedStringSet = OrderedSet.of('a', 'b').flatMap(m => [m]);
+orderedStringSet = OrderedSet.of('a', 'b').flatten(1);
+orderedStringSet = OrderedSet.of('a', 'b').flatten(false);
+
 /* Stack */
 
 numberStack = Stack([1, 2])
@@ -439,7 +502,6 @@ numberStack = Stack(['a']).flatten()
 { const stringSequence: IndexedSeq<string> = Repeat(0, 1) }
 // $ExpectError
 { const stringSequence: IndexedSeq<string> = Range(0, 0, 0) }
-
 
 /* Record */
 // TODO


### PR DESCRIPTION
Unfortunately extending Set and Map caused issues with OrderedSet
and OrderedMap flow annotations. For example,

```
const orderedSet: OrderedSet<number> = OrderedSet.of(1,2,3);
```

was not valid, because `of` was incorrectly assumed to return a
`Set<number>` rather than an `OrderedSet<number>`.

The fix was to copy and paste the Set and Map flow annotations,
adjusting for OrderedSet and OrderedMap as appropriate.

See #1015 for more details.

----

Add negative flow test cases for OrderedSet and OrderedMap

One thing that came up as a result of this is that it seems
like the current flow definitions are laxer than typescript
definitions. For example, typescript's intersect looks like

```
intersect(...iterables: Array<T>[]): Set<T>
```

whereas flow's intersect looks like

```
intersect<U>(...iterables: ESIterable<U>[]): Set<T&U>
```

Also removed unnecessary OrderedSet overrides such as

  * delete
  * remove
  * clear

since we were already extending Set.

Also removed unused variables in immutable-flow tests.