### PR TITLE
fix for typescript error

### DIFF
--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -1420,7 +1420,7 @@ declare module Immutable {
     /**
      * `Seq` which represents an ordered indexed list of values.
      */
-    module Indexed {
+    export module Indexed {
 
       /**
        * Provides an Seq.Indexed of the values provided.


### PR DESCRIPTION
Fixes the following typescript error:
All declarations of merged declaration 'Indexed' must be exported or not exported.

Typescript 2.1.4