### PR TITLE
Add missing characters to end of sentence in documentation

### DIFF
--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -233,7 +233,7 @@
      * Returns a new List with `value` at `index` with a size 1 more than this
      * List. Values at indices above `index` are shifted over by 1.
      *
-     * This is synonymous with `list.splice(index, 0, value)
+     * This is synonymous with `list.splice(index, 0, value)`.
      *
      * ```js
      * List([0, 1, 2, 3, 4]).insert(6, 5).toJS();

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -233,7 +233,7 @@ declare module Immutable {
      * Returns a new List with `value` at `index` with a size 1 more than this
      * List. Values at indices above `index` are shifted over by 1.
      *
-     * This is synonymous with `list.splice(index, 0, value)
+     * This is synonymous with `list.splice(index, 0, value)`.
      *
      * ```js
      * List([0, 1, 2, 3, 4]).insert(6, 5).toJS();

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -233,7 +233,7 @@ declare module Immutable {
      * Returns a new List with `value` at `index` with a size 1 more than this
      * List. Values at indices above `index` are shifted over by 1.
      *
-     * This is synonymous with `list.splice(index, 0, value)
+     * This is synonymous with `list.splice(index, 0, value)`.
      *
      * ```js
      * List([0, 1, 2, 3, 4]).insert(6, 5).toJS();


### PR DESCRIPTION
I noticed that the documentation for the `insert`-method was missing a few characters. So I fixed it.