### PR TITLE
export hash function

### DIFF
--- a/src/Immutable.js
+++ b/src/Immutable.js
@@ -20,6 +20,7 @@ import { Range } from './Range'
 import { Repeat } from './Repeat'
 import { is } from './is'
 import { fromJS } from './fromJS'
+import { hash } from './Hash'
 import { Iterable } from './IterableImpl'
 
 
@@ -41,7 +42,8 @@ export default {
   Repeat: Repeat,
 
   is: is,
-  fromJS: fromJS
+  fromJS: fromJS,
+  hash: hash
 
 };
 
@@ -62,5 +64,6 @@ export {
   Repeat,
 
   is,
-  fromJS
+  fromJS,
+  hash
 }

--- a/src/Immutable.js
+++ b/src/Immutable.js
@@ -46,21 +46,21 @@ export default {
 };
 
 export {
-	Iterable,
+  Iterable,
 
-	Seq,
-	Collection,
-	Map,
-	OrderedMap,
-	List,
-	Stack,
-	Set,
-	OrderedSet,
+  Seq,
+  Collection,
+  Map,
+  OrderedMap,
+  List,
+  Stack,
+  Set,
+  OrderedSet,
 
-	Record,
-	Range,
-	Repeat,
+  Record,
+  Range,
+  Repeat,
 
-	is,
-	fromJS
+  is,
+  fromJS
 }


### PR DESCRIPTION
It would be useful to have access to the hash function in the case where one needs to ensure equality in custom objects. For example, if wanted to use `Immutable.Set()` to store a custom object, the set would contain duplicates:

```
class Principal {
  constructor(type, id) {
    this.type = type;
    this.id = id;
  }
}

const principals = [
  new Principal('type_0', 'id_0'),
  new Principal('type_0', 'id_0')
];

const principalsSet = Immutable.Set().withMutations((set) => {
  principals.forEach((principal) => {
    set.add(principal);
  });
});

principalsSet.size; // 2, but intend for it to be 1
```

In order for `Immutable.Set` to drop duplicate `Principal` objects, I would need to additionally implement `valueOf`, or both `equals` and `hashCode`, on the `Principal` class. Having access to `Immutable.hash()` would make this much easier.

I'm exposing the internal hash function along with the main `Immutable` API, however, it's worth considering exporting this as a standalone utility function.
