### PR TITLE
Change http to https in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Have a question?
 
-Please ask questions on [Stack Overflow](http://stackoverflow.com/questions/tagged/immutable.js) instead of opening a Github Issue. There are more people on Stack Overflow who
+Please ask questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/immutable.js) instead of opening a Github Issue. There are more people on Stack Overflow who
 can answer questions, and good answers can be searchable and canonical.
 
 # Issues

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
 <!--
 Have a general question?
 
-First check out the Docs: http://facebook.github.io/immutable-js/docs/
-Or ask on Stack Overflow: http://stackoverflow.com/questions/tagged/immutable.js?sort=votes
+First check out the Docs: https://facebook.github.io/immutable-js/docs/
+Or ask on Stack Overflow: https://stackoverflow.com/questions/tagged/immutable.js?sort=votes
 Stack Overflow gets more attention than this issue list, and is much easier to search.
 
 Found a bug?

--- a/contrib/cursor/README.md
+++ b/contrib/cursor/README.md
@@ -8,7 +8,7 @@ aware of changes to the entire data structure: an `onChange` function which is
 called whenever a cursor or sub-cursor calls `update`.
 
 This is particularly useful when used in conjuction with component-based UI
-libraries like [React](http://facebook.github.io/react/) or to simulate
+libraries like [React](https://facebook.github.io/react/) or to simulate
 "state" throughout an application while maintaining a single flow of logic.
 
 

--- a/pages/src/docs/src/DocHeader.js
+++ b/pages/src/docs/src/DocHeader.js
@@ -16,7 +16,7 @@ var DocHeader = React.createClass({
               </SVGSet>
             </a>
             <a href="./" target="_self">Docs</a>
-            <a href="http://stackoverflow.com/questions/tagged/immutable.js?sort=votes">Questions</a>
+            <a href="https://stackoverflow.com/questions/tagged/immutable.js?sort=votes">Questions</a>
             <a href="https://github.com/facebook/immutable-js/">Github</a>
           </div>
         </div>

--- a/pages/src/src/Header.js
+++ b/pages/src/src/Header.js
@@ -57,7 +57,7 @@ var Header = React.createClass({
               </SVGSet>
             </a>
             <a href="docs/" target="_self">Docs</a>
-            <a href="http://stackoverflow.com/questions/tagged/immutable.js?sort=votes">Questions</a>
+            <a href="https://stackoverflow.com/questions/tagged/immutable.js?sort=votes">Questions</a>
             <a href="https://github.com/facebook/immutable-js/">GitHub</a>
           </div>
         </div>
@@ -67,7 +67,7 @@ var Header = React.createClass({
           <div className="filler">
             <div className="miniHeaderContents">
               <a href="docs/" target="_self">Docs</a>
-              <a href="http://stackoverflow.com/questions/tagged/immutable.js?sort=votes">Questions</a>
+              <a href="https://stackoverflow.com/questions/tagged/immutable.js?sort=votes">Questions</a>
               <a href="https://github.com/facebook/immutable-js/">GitHub</a>
             </div>
           </div>

--- a/pages/third_party/typescript/README.md
+++ b/pages/third_party/typescript/README.md
@@ -4,7 +4,7 @@
 
 # TypeScript
 
-[TypeScript](http://www.typescriptlang.org/) is a language for application-scale JavaScript. TypeScript adds optional types, classes, and modules to JavaScript. TypeScript supports tools for large-scale JavaScript applications for any browser, for any host, on any OS. TypeScript compiles to readable, standards-based JavaScript. Try it out at the [playground](http://www.typescriptlang.org/Playground), and stay up to date via [our blog](http://blogs.msdn.com/typescript) and [twitter account](https://twitter.com/typescriptlang).
+[TypeScript](https://www.typescriptlang.org/) is a language for application-scale JavaScript. TypeScript adds optional types, classes, and modules to JavaScript. TypeScript supports tools for large-scale JavaScript applications for any browser, for any host, on any OS. TypeScript compiles to readable, standards-based JavaScript. Try it out at the [playground](https://www.typescriptlang.org/Playground), and stay up to date via [our blog](https://blogs.msdn.microsoft.com/typescript/) and [twitter account](https://twitter.com/typescriptlang).
 
 
 ## Contribute
@@ -12,22 +12,22 @@
 There are many ways to [contribute](https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md) to TypeScript.
 * [Submit bugs](https://github.com/Microsoft/TypeScript/issues) and help us verify fixes as they are checked in.
 * Review the [source code changes](https://github.com/Microsoft/TypeScript/pulls).
-* Engage with other TypeScript users and developers on [StackOverflow](http://stackoverflow.com/questions/tagged/typescript). 
-* Join the [#typescript](http://twitter.com/#!/search/realtime/%23typescript) discussion on Twitter.
+* Engage with other TypeScript users and developers on [StackOverflow](https://stackoverflow.com/questions/tagged/typescript). 
+* Join the [#typescript](https://twitter.com/#!/search/realtime/%23typescript) discussion on Twitter.
 * [Contribute bug fixes](https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md).
-* Read the language specification ([docx](http://go.microsoft.com/fwlink/?LinkId=267121), [pdf](http://go.microsoft.com/fwlink/?LinkId=267238)).
+* Read the [language specification](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md) ([docx](https://github.com/Microsoft/TypeScript/raw/master/doc/TypeScript%20Language%20Specification.docx), [pdf](https://github.com/Microsoft/TypeScript/raw/master/doc/TypeScript%20Language%20Specification.pdf)).
 
 
 ## Documentation
 
-*  [Quick tutorial](http://www.typescriptlang.org/Tutorial)
-*  [Programming handbook](http://www.typescriptlang.org/Handbook)
+*  [Quick tutorial](https://www.typescriptlang.org/Tutorial)
+*  [Programming handbook](https://www.typescriptlang.org/Handbook)
 *  [Language specification](https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md)
-*  [Homepage](http://www.typescriptlang.org/)
+*  [Homepage](https://www.typescriptlang.org/)
 
 ## Building
 
-In order to build the TypeScript compiler, ensure that you have [Git](http://git-scm.com/downloads) and [Node.js](http://nodejs.org/) installed.
+In order to build the TypeScript compiler, ensure that you have [Git](https://git-scm.com/downloads) and [Node.js](https://nodejs.org/) installed.
 
 Clone a copy of the repo:
 


### PR DESCRIPTION
I noticed a lot of URLs were still on the old http which is no longer cool.
So I updated to https since it's 2017 :tada:

I also fixed a couple dead links for TypeScript 💯 