### PR TITLE
Fix flowtypes for Iterable#map()

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -131,6 +131,11 @@ declare module 'immutable' {
     flatten(depth?: number): /*this*/Iterable<any,any>;
     flatten(shallow?: boolean): /*this*/Iterable<any,any>;
 
+    map<M>(
+      mapper: (value: V, key: K, iter: this) => M,
+      context?: any
+    ): /*this*/Iterable<K,M>;
+
     filter(
       predicate: (value: V, key: K, iter: this) => mixed,
       context?: any


### PR DESCRIPTION
I found that the definition of `Iterable#map` is missed in `immutable.js.flow`. But `Immutable.d.ts` has the definition for this method.

https://github.com/facebook/immutable-js/blob/29a5c55727c523b0d83c53c7ccd1032aaa579f49/type-definitions/Immutable.d.ts#L2155-L2158