### PR TITLE
Fix `List.isList` return type in the docs

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -148,7 +148,7 @@ declare module Immutable {
      * List.isList(List([])); // true
      * ```
      */
-    function isList(maybeList: any): maybeList is List<any>;
+    function isList(maybeList: any): boolean;
 
     /**
      * Creates a new List containing `values`.


### PR DESCRIPTION
`List.isList` shows a return type of `maybeList` in the documentation, but the examples clearly show it returning a `boolean`.