### PR TITLE
Test local files

### DIFF
--- a/__tests__/ArraySeq.ts
+++ b/__tests__/ArraySeq.ts
@@ -1,6 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
-import { Seq } from 'immutable';
+
+import { Seq } from '../';
 
 describe('ArraySequence', () => {
 

--- a/__tests__/Conversion.ts
+++ b/__tests__/Conversion.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { Map, OrderedMap, List, Record, is, fromJS } from 'immutable';
+import { Map, OrderedMap, List, Record, is, fromJS } from '../';
 
 declare function expect(val: any): ExpectWithIs;
 

--- a/__tests__/Equality.ts
+++ b/__tests__/Equality.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { List, Map, Set, Seq, is } from 'immutable';
+import { List, Map, Set, Seq, is } from '../';
 
 describe('Equality', () => {
 

--- a/__tests__/IndexedSeq.ts
+++ b/__tests__/IndexedSeq.ts
@@ -1,9 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
+
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { Seq } from 'immutable';
+import { Seq } from '../';
 
 describe('IndexedSequence', () => {
 

--- a/__tests__/IterableSeq.ts
+++ b/__tests__/IterableSeq.ts
@@ -1,7 +1,7 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
+
 declare var Symbol: any;
-import { Seq } from 'immutable';
+import { Seq } from '../';
 
 describe('IterableSequence', () => {
 

--- a/__tests__/KeyedSeq.ts
+++ b/__tests__/KeyedSeq.ts
@@ -1,9 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
+
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { Seq, Range } from 'immutable';
+import { Seq, Range } from '../';
 
 describe('KeyedSeq', () => {
 

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { List, Range, Seq, Set, fromJS } from 'immutable';
+import { List, Range, Seq, Set, fromJS } from '../';
 
 function arrayOfSize(s) {
   var a = new Array(s);

--- a/__tests__/ListJS.js
+++ b/__tests__/ListJS.js
@@ -1,4 +1,4 @@
-var Immutable = require('immutable');
+var Immutable = require('../');
 var List = Immutable.List;
 
 var NON_NUMBERS = {

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { Map, Seq, List, Range, is } from 'immutable';
+import { Map, Seq, List, Range, is } from '../';
 
 describe('Map', () => {
 

--- a/__tests__/ObjectSeq.ts
+++ b/__tests__/ObjectSeq.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { Seq } from 'immutable';
+import { Seq } from '../';
 
 describe('ObjectSequence', () => {
 

--- a/__tests__/OrderedMap.ts
+++ b/__tests__/OrderedMap.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { OrderedMap, Seq } from 'immutable';
+import { OrderedMap, Seq } from '../';
 
 describe('OrderedMap', () => {
 

--- a/__tests__/OrderedSet.ts
+++ b/__tests__/OrderedSet.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { OrderedSet } from 'immutable';
+import { OrderedSet } from '../';
 
 describe('OrderedSet', () => {
 

--- a/__tests__/Range.ts
+++ b/__tests__/Range.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { Range} from 'immutable';
+import { Range } from '../';
 
 describe('Range', () => {
 

--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { Record, Seq } from 'immutable';
+import { Record, Seq } from '../';
 
 describe('Record', () => {
 

--- a/__tests__/RecordJS.js
+++ b/__tests__/RecordJS.js
@@ -1,4 +1,4 @@
-var Immutable = require('immutable');
+var Immutable = require('../');
 var Record = Immutable.Record;
 
 describe('Record', () => {

--- a/__tests__/Repeat.ts
+++ b/__tests__/Repeat.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { Repeat } from 'immutable';
+import { Repeat } from '../';
 
 describe('Repeat', () => {
 

--- a/__tests__/Seq.ts
+++ b/__tests__/Seq.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { Iterable, Seq } from 'immutable';
+import { Iterable, Seq } from '../';
 
 describe('Seq', () => {
 

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -1,7 +1,7 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
+
 declare var Symbol: any;
-import { List, Map, OrderedSet, Seq, Set, is } from 'immutable';
+import { List, Map, OrderedSet, Seq, Set, is } from '../';
 
 declare function expect(val: any): ExpectWithIs;
 

--- a/__tests__/Stack.ts
+++ b/__tests__/Stack.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { Seq, Stack } from 'immutable';
+import { Seq, Stack } from '../';
 
 function arrayOfSize(s) {
   var a = new Array(s);

--- a/__tests__/concat.ts
+++ b/__tests__/concat.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { Seq, Set, List, is } from 'immutable';
+import { Seq, Set, List, is } from '../';
 
 declare function expect(val: any): ExpectWithIs;
 

--- a/__tests__/count.ts
+++ b/__tests__/count.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { Seq, Range } from 'immutable';
+import { Seq, Range } from '../';
 
 describe('count', () => {
 

--- a/__tests__/find.ts
+++ b/__tests__/find.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { List, Range, Seq } from 'immutable';
+import { List, Range, Seq } from '../';
 
 describe('find', () => {
 

--- a/__tests__/flatten.ts
+++ b/__tests__/flatten.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { Iterable, Seq, Range, List, fromJS } from 'immutable';
+import { Iterable, Seq, Range, List, fromJS } from '../';
 
 type SeqType = number | number[] | Iterable<number,number>;
 

--- a/__tests__/get.ts
+++ b/__tests__/get.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { Range } from 'immutable';
+import { Range } from '../';
 
 describe('get', () => {
 

--- a/__tests__/groupBy.ts
+++ b/__tests__/groupBy.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { Iterable, Seq, Map } from 'immutable';
+import { Iterable, Seq, Map } from '../';
 
 describe('groupBy', () => {
 

--- a/__tests__/interpose.ts
+++ b/__tests__/interpose.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { Range } from 'immutable';
+import { Range } from '../';
 
 describe('interpose', () => {
 

--- a/__tests__/join.ts
+++ b/__tests__/join.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import jasmineCheck = require('jasmine-check');
 jasmineCheck.install();
 
-import { Seq } from 'immutable';
+import { Seq } from '../';
 
 describe('join', () => {
 

--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { List, Map, fromJS, is } from 'immutable';
+import { List, Map, fromJS, is } from '../';
 
 declare function expect(val: any): ExpectWithIs;
 

--- a/__tests__/minmax.ts
+++ b/__tests__/minmax.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { Seq, is } from 'immutable';
+import { Seq, is } from '../';
 
 var genHeterogeneousishArray = gen.oneOf([
   gen.array(gen.oneOf([gen.string, gen.undefined])),

--- a/__tests__/slice.ts
+++ b/__tests__/slice.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { List, Range, Seq } from 'immutable';
+import { List, Range, Seq } from '../';
 
 describe('slice', () => {
 

--- a/__tests__/sort.ts
+++ b/__tests__/sort.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { Seq, List, OrderedMap, Range } from 'immutable';
+import { Seq, List, OrderedMap, Range } from '../';
 
 describe('sort', () => {
 

--- a/__tests__/splice.ts
+++ b/__tests__/splice.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { List, Range, Seq } from 'immutable';
+import { List, Range, Seq } from '../';
 
 describe('splice', () => {
 

--- a/__tests__/updateIn.ts
+++ b/__tests__/updateIn.ts
@@ -1,7 +1,6 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
-import { Map, Set, fromJS } from 'immutable';
+import { Map, Set, fromJS } from '../';
 
 describe('updateIn', () => {
 

--- a/__tests__/zip.ts
+++ b/__tests__/zip.ts
@@ -1,10 +1,9 @@
 ///<reference path='../resources/jest.d.ts'/>
-///<reference path='../dist/immutable.d.ts'/>
 
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { Iterable, List, Range, Seq } from 'immutable';
+import { Iterable, List, Range, Seq } from '../';
 
 describe('zip', () => {
 

--- a/resources/jestPreprocessor.js
+++ b/resources/jestPreprocessor.js
@@ -61,21 +61,14 @@ function compileTypeScript(filePath) {
   throw new Error('Compiling ' + filePath + ' failed' + '\n' + report);
 }
 
-function withLocalImmutable(filePath, jsSrc) {
-  return jsSrc.replace(
-    /(require\(['"])immutable/g,
-    (_, req) => req + path.relative(path.dirname(filePath), process.cwd())
-  );
-}
-
 module.exports = {
   process: function(src, filePath) {
     if (filePath.match(/\.ts$/) && !filePath.match(/\.d\.ts$/)) {
-      return withLocalImmutable(filePath, compileTypeScript(filePath));
+      return compileTypeScript(filePath);
     }
 
     if (filePath.match(/\.js$/) && ~filePath.indexOf('/__tests__/')) {
-      return withLocalImmutable(filePath, react.transform(src, {harmony: true}));
+      return react.transform(src, {harmony: true});
     }
 
     return src;


### PR DESCRIPTION
Tests previously required "immutable" directly. Minor benefit of having tests which double as example code. However this requires flakey test infra which may fail in unpredictable ways since "immutable" is a dependency of one of the development tools used, thus found in node_modules.

This PR leverages the non-ambient TS types to test the local files directly.