### PR TITLE
Update Record typedef (ts)

### DIFF
--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -40,7 +40,7 @@ describe('Record', () => {
 
     var t1 = new MyType({a: 10, b:20});
     expect(() => {
-      t1.set('d', 4);
+      (t1 as any).set('d', 4);
     }).toThrow('Cannot set unknown key "d" on Record');
   });
 
@@ -88,7 +88,7 @@ describe('Record', () => {
 
     expect(t.get('a')).toEqual(1);
     expect(t.get('b')).toEqual(20);
-    expect(t.get('c')).toBeUndefined();
+    expect((t as any).get('c')).toBeUndefined();
   })
 
   it('returns itself when setting identical values', () => {
@@ -109,6 +109,23 @@ describe('Record', () => {
     var t4 = t2.set('a', 3);
     expect(t3).not.toBe(t1);
     expect(t4).not.toBe(t2);
+  })
+
+  it('allows for class extension', () => {
+    class ABClass extends Record({a:1, b:2}) {
+      setA(a: number) {
+        return this.set('a', a);
+      }
+
+      setB(b: number) {
+        return this.set('b', b);
+      }
+    }
+
+    var t1 = new ABClass({a: 1});
+    var t2 = t1.setA(3);
+    var t3 = t2.setB(10);
+    expect(t3.toObject()).toEqual({a:3, b:10});
   })
 
 });

--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -1413,8 +1413,6 @@
    * Record. This is not a common pattern in functional environments, but is in
    * many JS programs.
    *
-   * Note: TypeScript does not support this type of subclassing.
-   *
    *     class ABRecord extends Record({a:1,b:2}) {
    *       getAB() {
    *         return this.a + this.b;
@@ -1426,20 +1424,97 @@
    *
    */
   export module Record {
-    export interface Class {
-      new (): Map<string, any>;
-      new (values: {[key: string]: any}): Map<string, any>;
-      new (values: Iterable<string, any>): Map<string, any>; // deprecated
+    export interface Class<T extends Object> {
+      new (): Instance<T>;
+      new (values: Partial<T>): Instance<T>;
+      new (values: Iterable<string, any>): Instance<T>; // deprecated
 
-      (): Map<string, any>;
-      (values: {[key: string]: any}): Map<string, any>;
-      (values: Iterable<string, any>): Map<string, any>; // deprecated
+      (): Instance<T>;
+      (values: Partial<T>): Instance<T>;
+      (values: Iterable<string, any>): Instance<T>; // deprecated
+    }
+
+    export interface Instance<T extends Object> {
+      size: number;
+
+      // Reading values
+
+      has(key: string): boolean;
+      get<K extends keyof T>(key: K): T[K];
+
+      // Value equality
+
+      equals(other: any): boolean;
+      hashCode(): number;
+
+      // Persistent changes
+
+      set<K extends keyof T>(key: K, value: T[K]): this;
+      update<K extends keyof T>(key: K, updater: (value: T[K]) => T[K]): this;
+      merge(...iterables: Array<Partial<T> | Iterable<any, any>>): this;
+      mergeDeep(...iterables: Array<Partial<T> | Iterable<any, any>>): this;
+
+      /**
+       * @alias remove
+       */
+      delete<K extends keyof T>(key: K): this;
+      remove<K extends keyof T>(key: K): this;
+      clear(): this;
+
+      // Deep persistent changes
+
+      setIn(keyPath: Array<any> | Iterable<any, any>, value: any): this;
+      updateIn(keyPath: Array<any> | Iterable<any, any>, updater: (value: any) => any): this;
+      mergeIn(keyPath: Array<any> | Iterable<any, any>, ...iterables: Array<Partial<T> | Iterable<any, any>>): this;
+      mergeDeepIn(keyPath: Array<any> | Iterable<any, any>, ...iterables: Array<Partial<T> | Iterable<any, any>>): this;
+
+      /**
+       * @alias removeIn
+       */
+      deleteIn(keyPath: Array<any> | Iterable<any, any>): this;
+      removeIn(keyPath: Array<any> | Iterable<any, any>): this;
+
+      // Conversion to JavaScript types
+
+      /**
+       * Deeply converts this Record to equivalent JS.
+       *
+       * @alias toJSON
+       */
+      toJS(): any;
+
+      /**
+       * Shallowly converts this Record to equivalent JS.
+       */
+      toObject(): T;
+
+      // Transient changes
+
+      /**
+       * Note: Not all methods can be used on a mutable collection or within
+       * `withMutations`! Only `set` may be used mutatively.
+       *
+       * @see `Map#withMutations`
+       */
+      withMutations(mutator: (mutable: this) => any): this;
+
+      /**
+       * @see `Map#asMutable`
+       */
+      asMutable(): this;
+
+      /**
+       * @see `Map#asImmutable`
+       */
+      asImmutable(): this;
+
+      // Sequence algorithms
+
+      [Symbol.iterator](): Iterator<[keyof T, T[keyof T]]>;
     }
   }
 
-  export function Record(
-    defaultValues: {[key: string]: any}, name?: string
-  ): Record.Class;
+  export function Record<T>(defaultValues: T, name?: string): Record.Class<T>;
 
 
   /**

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -1413,8 +1413,6 @@ declare module Immutable {
    * Record. This is not a common pattern in functional environments, but is in
    * many JS programs.
    *
-   * Note: TypeScript does not support this type of subclassing.
-   *
    *     class ABRecord extends Record({a:1,b:2}) {
    *       getAB() {
    *         return this.a + this.b;
@@ -1426,20 +1424,97 @@ declare module Immutable {
    *
    */
   export module Record {
-    export interface Class {
-      new (): Map<string, any>;
-      new (values: {[key: string]: any}): Map<string, any>;
-      new (values: Iterable<string, any>): Map<string, any>; // deprecated
+    export interface Class<T extends Object> {
+      new (): Instance<T>;
+      new (values: Partial<T>): Instance<T>;
+      new (values: Iterable<string, any>): Instance<T>; // deprecated
 
-      (): Map<string, any>;
-      (values: {[key: string]: any}): Map<string, any>;
-      (values: Iterable<string, any>): Map<string, any>; // deprecated
+      (): Instance<T>;
+      (values: Partial<T>): Instance<T>;
+      (values: Iterable<string, any>): Instance<T>; // deprecated
+    }
+
+    export interface Instance<T extends Object> {
+      size: number;
+
+      // Reading values
+
+      has(key: string): boolean;
+      get<K extends keyof T>(key: K): T[K];
+
+      // Value equality
+
+      equals(other: any): boolean;
+      hashCode(): number;
+
+      // Persistent changes
+
+      set<K extends keyof T>(key: K, value: T[K]): this;
+      update<K extends keyof T>(key: K, updater: (value: T[K]) => T[K]): this;
+      merge(...iterables: Array<Partial<T> | Iterable<any, any>>): this;
+      mergeDeep(...iterables: Array<Partial<T> | Iterable<any, any>>): this;
+
+      /**
+       * @alias remove
+       */
+      delete<K extends keyof T>(key: K): this;
+      remove<K extends keyof T>(key: K): this;
+      clear(): this;
+
+      // Deep persistent changes
+
+      setIn(keyPath: Array<any> | Iterable<any, any>, value: any): this;
+      updateIn(keyPath: Array<any> | Iterable<any, any>, updater: (value: any) => any): this;
+      mergeIn(keyPath: Array<any> | Iterable<any, any>, ...iterables: Array<Partial<T> | Iterable<any, any>>): this;
+      mergeDeepIn(keyPath: Array<any> | Iterable<any, any>, ...iterables: Array<Partial<T> | Iterable<any, any>>): this;
+
+      /**
+       * @alias removeIn
+       */
+      deleteIn(keyPath: Array<any> | Iterable<any, any>): this;
+      removeIn(keyPath: Array<any> | Iterable<any, any>): this;
+
+      // Conversion to JavaScript types
+
+      /**
+       * Deeply converts this Record to equivalent JS.
+       *
+       * @alias toJSON
+       */
+      toJS(): any;
+
+      /**
+       * Shallowly converts this Record to equivalent JS.
+       */
+      toObject(): T;
+
+      // Transient changes
+
+      /**
+       * Note: Not all methods can be used on a mutable collection or within
+       * `withMutations`! Only `set` may be used mutatively.
+       *
+       * @see `Map#withMutations`
+       */
+      withMutations(mutator: (mutable: this) => any): this;
+
+      /**
+       * @see `Map#asMutable`
+       */
+      asMutable(): this;
+
+      /**
+       * @see `Map#asImmutable`
+       */
+      asImmutable(): this;
+
+      // Sequence algorithms
+
+      [Symbol.iterator](): Iterator<[keyof T, T[keyof T]]>;
     }
   }
 
-  export function Record(
-    defaultValues: {[key: string]: any}, name?: string
-  ): Record.Class;
+  export function Record<T>(defaultValues: T, name?: string): Record.Class<T>;
 
 
   /**

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -1413,8 +1413,6 @@ declare module Immutable {
    * Record. This is not a common pattern in functional environments, but is in
    * many JS programs.
    *
-   * Note: TypeScript does not support this type of subclassing.
-   *
    *     class ABRecord extends Record({a:1,b:2}) {
    *       getAB() {
    *         return this.a + this.b;
@@ -1426,20 +1424,97 @@ declare module Immutable {
    *
    */
   export module Record {
-    export interface Class {
-      new (): Map<string, any>;
-      new (values: {[key: string]: any}): Map<string, any>;
-      new (values: Iterable<string, any>): Map<string, any>; // deprecated
+    export interface Class<T extends Object> {
+      new (): Instance<T>;
+      new (values: Partial<T>): Instance<T>;
+      new (values: Iterable<string, any>): Instance<T>; // deprecated
 
-      (): Map<string, any>;
-      (values: {[key: string]: any}): Map<string, any>;
-      (values: Iterable<string, any>): Map<string, any>; // deprecated
+      (): Instance<T>;
+      (values: Partial<T>): Instance<T>;
+      (values: Iterable<string, any>): Instance<T>; // deprecated
+    }
+
+    export interface Instance<T extends Object> {
+      size: number;
+
+      // Reading values
+
+      has(key: string): boolean;
+      get<K extends keyof T>(key: K): T[K];
+
+      // Value equality
+
+      equals(other: any): boolean;
+      hashCode(): number;
+
+      // Persistent changes
+
+      set<K extends keyof T>(key: K, value: T[K]): this;
+      update<K extends keyof T>(key: K, updater: (value: T[K]) => T[K]): this;
+      merge(...iterables: Array<Partial<T> | Iterable<any, any>>): this;
+      mergeDeep(...iterables: Array<Partial<T> | Iterable<any, any>>): this;
+
+      /**
+       * @alias remove
+       */
+      delete<K extends keyof T>(key: K): this;
+      remove<K extends keyof T>(key: K): this;
+      clear(): this;
+
+      // Deep persistent changes
+
+      setIn(keyPath: Array<any> | Iterable<any, any>, value: any): this;
+      updateIn(keyPath: Array<any> | Iterable<any, any>, updater: (value: any) => any): this;
+      mergeIn(keyPath: Array<any> | Iterable<any, any>, ...iterables: Array<Partial<T> | Iterable<any, any>>): this;
+      mergeDeepIn(keyPath: Array<any> | Iterable<any, any>, ...iterables: Array<Partial<T> | Iterable<any, any>>): this;
+
+      /**
+       * @alias removeIn
+       */
+      deleteIn(keyPath: Array<any> | Iterable<any, any>): this;
+      removeIn(keyPath: Array<any> | Iterable<any, any>): this;
+
+      // Conversion to JavaScript types
+
+      /**
+       * Deeply converts this Record to equivalent JS.
+       *
+       * @alias toJSON
+       */
+      toJS(): any;
+
+      /**
+       * Shallowly converts this Record to equivalent JS.
+       */
+      toObject(): T;
+
+      // Transient changes
+
+      /**
+       * Note: Not all methods can be used on a mutable collection or within
+       * `withMutations`! Only `set` may be used mutatively.
+       *
+       * @see `Map#withMutations`
+       */
+      withMutations(mutator: (mutable: this) => any): this;
+
+      /**
+       * @see `Map#asMutable`
+       */
+      asMutable(): this;
+
+      /**
+       * @see `Map#asImmutable`
+       */
+      asImmutable(): this;
+
+      // Sequence algorithms
+
+      [Symbol.iterator](): Iterator<[keyof T, T[keyof T]]>;
     }
   }
 
-  export function Record(
-    defaultValues: {[key: string]: any}, name?: string
-  ): Record.Class;
+  export function Record<T>(defaultValues: T, name?: string): Record.Class<T>;
 
 
   /**


### PR DESCRIPTION
This uses keyof, Partial, and T[K] typescript advanced types to provide much better type correctness for use of Records

Fixes #909