### PR TITLE
Improve type for equals()

### DIFF
--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -2177,7 +2177,7 @@
      * Note: This is equivalent to `Immutable.is(this, other)`, but provided to
      * allow for chained expressions.
      */
-    equals(other: Iterable<K, V>): boolean;
+    equals(other: any): boolean;
 
     /**
      * Computes and returns the hashed identity for this Iterable.

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -2177,7 +2177,7 @@ declare module Immutable {
      * Note: This is equivalent to `Immutable.is(this, other)`, but provided to
      * allow for chained expressions.
      */
-    equals(other: Iterable<K, V>): boolean;
+    equals(other: any): boolean;
 
     /**
      * Computes and returns the hashed identity for this Iterable.

--- a/dist/immutable.js.flow
+++ b/dist/immutable.js.flow
@@ -40,7 +40,7 @@ declare class _Iterable<K, V, KI, II, SI> {
   static isAssociative(maybeAssociative: any): boolean;
   static isOrdered(maybeOrdered: any): boolean;
 
-  equals(other: Iterable<K,V>): boolean;
+  equals(other: any): boolean;
   hashCode(): number;
   get(key: K): V;
   get<V_>(key: K, notSetValue: V_): V|V_;

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2177,7 +2177,7 @@ declare module Immutable {
      * Note: This is equivalent to `Immutable.is(this, other)`, but provided to
      * allow for chained expressions.
      */
-    equals(other: Iterable<K, V>): boolean;
+    equals(other: any): boolean;
 
     /**
      * Computes and returns the hashed identity for this Iterable.

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -40,7 +40,7 @@ declare class _Iterable<K, V, KI, II, SI> {
   static isAssociative(maybeAssociative: any): boolean;
   static isOrdered(maybeOrdered: any): boolean;
 
-  equals(other: Iterable<K,V>): boolean;
+  equals(other: any): boolean;
   hashCode(): number;
   get(key: K): V;
   get<V_>(key: K, notSetValue: V_): V|V_;


### PR DESCRIPTION
The equals() function should really accept anything.

As discussed in #876