### PR TITLE
Deprecate Map.of()

### DIFF
--- a/pages/lib/genTypeDefData.js
+++ b/pages/lib/genTypeDefData.js
@@ -475,6 +475,6 @@ function setIn(obj, path, value) {
 
 function shouldIgnore(comment) {
   return Boolean(comment && comment.notes && comment.notes.find(
-    note => note.name === 'ignore'
+    note => note.name === 'ignore' || note.name === 'deprecated'
   ));
 }

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -525,6 +525,8 @@ declare module Immutable {
      * ).toJS();
      * // { '0': 'numerical key', key: 'value', 'numerical value': 3 }
      * ```
+     *
+     * @deprecated Use Map([ [ 'k', 'v' ] ]) or Map({ k: 'v' })
      */
     function of(...keyValues: any[]): Map<any, any>;
   }


### PR DESCRIPTION
This function is very hard to type correctly and can result in accidental ambiguity or mistakes.