### PR TITLE
Change documentation for merge() family to use oldVal and newVal

### DIFF
--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -484,7 +484,7 @@
      * @see `Map#mergeWith`
      */
     mergeWith(
-      merger: (previous: T, next: T, key: number) => T,
+      merger: (oldVal: T, newVal: T, key: number) => T,
       ...iterables: Array<Iterable.Indexed<T> | Array<T>>
     ): this;
 
@@ -500,7 +500,7 @@
      * @see `Map#mergeDeepWith`
      */
     mergeDeepWith(
-      merger: (previous: T, next: T, key: number) => T,
+      merger: (oldVal: T, newVal: T, key: number) => T,
       ...iterables: Array<Iterable.Indexed<T> | Array<T>>
     ): this;
 
@@ -902,13 +902,13 @@
      *
      *     var x = Immutable.Map({a: 10, b: 20, c: 30});
      *     var y = Immutable.Map({b: 40, a: 50, d: 60});
-     *     x.mergeWith((prev, next) => prev / next, y) // { a: 0.2, b: 0.5, c: 30, d: 60 }
-     *     y.mergeWith((prev, next) => prev / next, x) // { b: 2, a: 5, d: 60, c: 30 }
+     *     x.mergeWith((oldVal, newVal) => oldVal / newVal, y) // { a: 0.2, b: 0.5, c: 30, d: 60 }
+     *     y.mergeWith((oldVal, newVal) => oldVal / newVal, x) // { b: 2, a: 5, d: 60, c: 30 }
      *
      * Note: `mergeWith` can be used in `withMutations`.
      */
     mergeWith(
-      merger: (previous: V, next: V, key: K) => V,
+      merger: (oldVal: V, newVal: V, key: K) => V,
       ...iterables: Array<Iterable<K, V> | {[key: string]: V}>
     ): this;
 
@@ -930,13 +930,13 @@
      *
      *     var x = Immutable.fromJS({a: { x: 10, y: 10 }, b: { x: 20, y: 50 } });
      *     var y = Immutable.fromJS({a: { x: 2 }, b: { y: 5 }, c: { z: 3 } });
-     *     x.mergeDeepWith((prev, next) => prev / next, y)
+     *     x.mergeDeepWith((oldVal, newVal) => oldVal / newVal, y)
      *     // {a: { x: 5, y: 10 }, b: { x: 20, y: 10 }, c: { z: 3 } }
      *
      * Note: `mergeDeepWith` can be used in `withMutations`.
      */
     mergeDeepWith(
-      merger: (previous: V, next: V, key: K) => V,
+      merger: (oldVal: V, newVal: V, key: K) => V,
       ...iterables: Array<Iterable<K, V> | {[key: string]: V}>
     ): this;
 

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -484,7 +484,7 @@ declare module Immutable {
      * @see `Map#mergeWith`
      */
     mergeWith(
-      merger: (previous: T, next: T, key: number) => T,
+      merger: (oldVal: T, newVal: T, key: number) => T,
       ...iterables: Array<Iterable.Indexed<T> | Array<T>>
     ): this;
 
@@ -500,7 +500,7 @@ declare module Immutable {
      * @see `Map#mergeDeepWith`
      */
     mergeDeepWith(
-      merger: (previous: T, next: T, key: number) => T,
+      merger: (oldVal: T, newVal: T, key: number) => T,
       ...iterables: Array<Iterable.Indexed<T> | Array<T>>
     ): this;
 
@@ -902,13 +902,13 @@ declare module Immutable {
      *
      *     var x = Immutable.Map({a: 10, b: 20, c: 30});
      *     var y = Immutable.Map({b: 40, a: 50, d: 60});
-     *     x.mergeWith((prev, next) => prev / next, y) // { a: 0.2, b: 0.5, c: 30, d: 60 }
-     *     y.mergeWith((prev, next) => prev / next, x) // { b: 2, a: 5, d: 60, c: 30 }
+     *     x.mergeWith((oldVal, newVal) => oldVal / newVal, y) // { a: 0.2, b: 0.5, c: 30, d: 60 }
+     *     y.mergeWith((oldVal, newVal) => oldVal / newVal, x) // { b: 2, a: 5, d: 60, c: 30 }
      *
      * Note: `mergeWith` can be used in `withMutations`.
      */
     mergeWith(
-      merger: (previous: V, next: V, key: K) => V,
+      merger: (oldVal: V, newVal: V, key: K) => V,
       ...iterables: Array<Iterable<K, V> | {[key: string]: V}>
     ): this;
 
@@ -930,13 +930,13 @@ declare module Immutable {
      *
      *     var x = Immutable.fromJS({a: { x: 10, y: 10 }, b: { x: 20, y: 50 } });
      *     var y = Immutable.fromJS({a: { x: 2 }, b: { y: 5 }, c: { z: 3 } });
-     *     x.mergeDeepWith((prev, next) => prev / next, y)
+     *     x.mergeDeepWith((oldVal, newVal) => oldVal / newVal, y)
      *     // {a: { x: 5, y: 10 }, b: { x: 20, y: 10 }, c: { z: 3 } }
      *
      * Note: `mergeDeepWith` can be used in `withMutations`.
      */
     mergeDeepWith(
-      merger: (previous: V, next: V, key: K) => V,
+      merger: (oldVal: V, newVal: V, key: K) => V,
       ...iterables: Array<Iterable<K, V> | {[key: string]: V}>
     ): this;
 

--- a/dist/immutable.js
+++ b/dist/immutable.js
@@ -2703,19 +2703,19 @@ function mergeIntoMapWith(map, merger, iterables) {
   return mergeIntoCollectionWith(map, merger, iters);
 }
 
-function deepMerger(existing, value) {
-  return existing && existing.mergeDeep && isIterable(value) ?
-    existing.mergeDeep(value) :
-    is(existing, value) ? existing : value;
+function deepMerger(oldVal, newVal) {
+  return oldVal && oldVal.mergeDeep && isIterable(newVal) ?
+    oldVal.mergeDeep(newVal) :
+    is(oldVal, newVal) ? oldVal : newVal;
 }
 
 function deepMergerWith(merger) {
-  return function (existing, value, key) {
-    if (existing && existing.mergeDeepWith && isIterable(value)) {
-      return existing.mergeDeepWith(merger, value);
+  return function (oldVal, newVal, key) {
+    if (oldVal && oldVal.mergeDeepWith && isIterable(newVal)) {
+      return oldVal.mergeDeepWith(merger, newVal);
     }
-    var nextValue = merger(existing, value, key);
-    return is(existing, nextValue) ? existing : nextValue;
+    var nextValue = merger(oldVal, newVal, key);
+    return is(oldVal, nextValue) ? oldVal : nextValue;
   };
 }
 
@@ -2730,7 +2730,7 @@ function mergeIntoCollectionWith(collection, merger, iters) {
   return collection.withMutations(function (collection) {
     var mergeIntoMap = merger ?
       function (value, key) {
-        collection.update(key, NOT_SET, function (existing) { return existing === NOT_SET ? value : merger(existing, value, key); }
+        collection.update(key, NOT_SET, function (oldVal) { return oldVal === NOT_SET ? value : merger(oldVal, value, key); }
         );
       } :
       function (value, key) {

--- a/dist/immutable.js.flow
+++ b/dist/immutable.js.flow
@@ -569,14 +569,14 @@ declare class List<+T> extends IndexedCollection<T> {
   merge<U>(...iterables: ESIterable<U>[]): List<T | U>;
 
   mergeWith<U, V>(
-    merger: (previous: T, next: U, key: number) => V,
+    merger: (oldVal: T, newVal: U, key: number) => V,
     ...iterables: ESIterable<U>[]
   ): List<T | U | V>;
 
   mergeDeep<U>(...iterables: ESIterable<U>[]): List<T | U>;
 
   mergeDeepWith<U, V>(
-    merger: (previous: T, next: U, key: number) => V,
+    merger: (oldVal: T, newVal: U, key: number) => V,
     ...iterables: ESIterable<U>[]
   ): List<T | U | V>;
 
@@ -708,7 +708,7 @@ declare class Map<K, +V> extends KeyedCollection<K, V> {
   ): Map<K | K_, V | V_>;
 
   mergeWith<K_, W, X>(
-    merger: (previous: V, next: W, key: K) => X,
+    merger: (oldVal: V, newVal: W, key: K) => X,
     ...iterables: (ESIterable<[K_, W]> | { [key: K_]: W })[]
   ): Map<K | K_, V | W | X>;
 
@@ -717,7 +717,7 @@ declare class Map<K, +V> extends KeyedCollection<K, V> {
   ): Map<K | K_, V | V_>;
 
   mergeDeepWith<K_, W, X>(
-    merger: (previous: V, next: W, key: K) => X,
+    merger: (oldVal: V, newVal: W, key: K) => X,
     ...iterables: (ESIterable<[K_, W]> | { [key: K_]: W })[]
   ): Map<K | K_, V | W | X>;
 
@@ -796,7 +796,7 @@ declare class OrderedMap<K, +V> extends KeyedCollection<K, V> {
   ): OrderedMap<K | K_, V | V_>;
 
   mergeWith<K_, W, X>(
-    merger: (previous: V, next: W, key: K) => X,
+    merger: (oldVal: V, newVal: W, key: K) => X,
     ...iterables: (ESIterable<[K_, W]> | { [key: K_]: W })[]
   ): OrderedMap<K | K_, V | W | X>;
 
@@ -805,7 +805,7 @@ declare class OrderedMap<K, +V> extends KeyedCollection<K, V> {
   ): OrderedMap<K | K_, V | V_>;
 
   mergeDeepWith<K_, W, X>(
-    merger: (previous: V, next: W, key: K) => X,
+    merger: (oldVal: V, newVal: W, key: K) => X,
     ...iterables: (ESIterable<[K_, W]> | { [key: K_]: W })[]
   ): OrderedMap<K | K_, V | W | X>;
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -755,19 +755,19 @@ function mergeIntoMapWith(map, merger, iterables) {
   return mergeIntoCollectionWith(map, merger, iters);
 }
 
-export function deepMerger(existing, value) {
-  return existing && existing.mergeDeep && isIterable(value) ?
-    existing.mergeDeep(value) :
-    is(existing, value) ? existing : value;
+export function deepMerger(oldVal, newVal) {
+  return oldVal && oldVal.mergeDeep && isIterable(newVal) ?
+    oldVal.mergeDeep(newVal) :
+    is(oldVal, newVal) ? oldVal : newVal;
 }
 
 export function deepMergerWith(merger) {
-  return (existing, value, key) => {
-    if (existing && existing.mergeDeepWith && isIterable(value)) {
-      return existing.mergeDeepWith(merger, value);
+  return (oldVal, newVal, key) => {
+    if (oldVal && oldVal.mergeDeepWith && isIterable(newVal)) {
+      return oldVal.mergeDeepWith(merger, newVal);
     }
-    var nextValue = merger(existing, value, key);
-    return is(existing, nextValue) ? existing : nextValue;
+    var nextValue = merger(oldVal, newVal, key);
+    return is(oldVal, nextValue) ? oldVal : nextValue;
   };
 }
 
@@ -782,8 +782,8 @@ export function mergeIntoCollectionWith(collection, merger, iters) {
   return collection.withMutations(collection => {
     var mergeIntoMap = merger ?
       (value, key) => {
-        collection.update(key, NOT_SET, existing =>
-          existing === NOT_SET ? value : merger(existing, value, key)
+        collection.update(key, NOT_SET, oldVal =>
+          oldVal === NOT_SET ? value : merger(oldVal, value, key)
         );
       } :
       (value, key) => {

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -484,7 +484,7 @@ declare module Immutable {
      * @see `Map#mergeWith`
      */
     mergeWith(
-      merger: (previous: T, next: T, key: number) => T,
+      merger: (oldVal: T, newVal: T, key: number) => T,
       ...iterables: Array<Iterable.Indexed<T> | Array<T>>
     ): this;
 
@@ -500,7 +500,7 @@ declare module Immutable {
      * @see `Map#mergeDeepWith`
      */
     mergeDeepWith(
-      merger: (previous: T, next: T, key: number) => T,
+      merger: (oldVal: T, newVal: T, key: number) => T,
       ...iterables: Array<Iterable.Indexed<T> | Array<T>>
     ): this;
 
@@ -902,13 +902,13 @@ declare module Immutable {
      *
      *     var x = Immutable.Map({a: 10, b: 20, c: 30});
      *     var y = Immutable.Map({b: 40, a: 50, d: 60});
-     *     x.mergeWith((prev, next) => prev / next, y) // { a: 0.2, b: 0.5, c: 30, d: 60 }
-     *     y.mergeWith((prev, next) => prev / next, x) // { b: 2, a: 5, d: 60, c: 30 }
+     *     x.mergeWith((oldVal, newVal) => oldVal / newVal, y) // { a: 0.2, b: 0.5, c: 30, d: 60 }
+     *     y.mergeWith((oldVal, newVal) => oldVal / newVal, x) // { b: 2, a: 5, d: 60, c: 30 }
      *
      * Note: `mergeWith` can be used in `withMutations`.
      */
     mergeWith(
-      merger: (previous: V, next: V, key: K) => V,
+      merger: (oldVal: V, newVal: V, key: K) => V,
       ...iterables: Array<Iterable<K, V> | {[key: string]: V}>
     ): this;
 
@@ -930,13 +930,13 @@ declare module Immutable {
      *
      *     var x = Immutable.fromJS({a: { x: 10, y: 10 }, b: { x: 20, y: 50 } });
      *     var y = Immutable.fromJS({a: { x: 2 }, b: { y: 5 }, c: { z: 3 } });
-     *     x.mergeDeepWith((prev, next) => prev / next, y)
+     *     x.mergeDeepWith((oldVal, newVal) => oldVal / newVal, y)
      *     // {a: { x: 5, y: 10 }, b: { x: 20, y: 10 }, c: { z: 3 } }
      *
      * Note: `mergeDeepWith` can be used in `withMutations`.
      */
     mergeDeepWith(
-      merger: (previous: V, next: V, key: K) => V,
+      merger: (oldVal: V, newVal: V, key: K) => V,
       ...iterables: Array<Iterable<K, V> | {[key: string]: V}>
     ): this;
 

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -569,14 +569,14 @@ declare class List<+T> extends IndexedCollection<T> {
   merge<U>(...iterables: ESIterable<U>[]): List<T | U>;
 
   mergeWith<U, V>(
-    merger: (previous: T, next: U, key: number) => V,
+    merger: (oldVal: T, newVal: U, key: number) => V,
     ...iterables: ESIterable<U>[]
   ): List<T | U | V>;
 
   mergeDeep<U>(...iterables: ESIterable<U>[]): List<T | U>;
 
   mergeDeepWith<U, V>(
-    merger: (previous: T, next: U, key: number) => V,
+    merger: (oldVal: T, newVal: U, key: number) => V,
     ...iterables: ESIterable<U>[]
   ): List<T | U | V>;
 
@@ -708,7 +708,7 @@ declare class Map<K, +V> extends KeyedCollection<K, V> {
   ): Map<K | K_, V | V_>;
 
   mergeWith<K_, W, X>(
-    merger: (previous: V, next: W, key: K) => X,
+    merger: (oldVal: V, newVal: W, key: K) => X,
     ...iterables: (ESIterable<[K_, W]> | { [key: K_]: W })[]
   ): Map<K | K_, V | W | X>;
 
@@ -717,7 +717,7 @@ declare class Map<K, +V> extends KeyedCollection<K, V> {
   ): Map<K | K_, V | V_>;
 
   mergeDeepWith<K_, W, X>(
-    merger: (previous: V, next: W, key: K) => X,
+    merger: (oldVal: V, newVal: W, key: K) => X,
     ...iterables: (ESIterable<[K_, W]> | { [key: K_]: W })[]
   ): Map<K | K_, V | W | X>;
 
@@ -796,7 +796,7 @@ declare class OrderedMap<K, +V> extends KeyedCollection<K, V> {
   ): OrderedMap<K | K_, V | V_>;
 
   mergeWith<K_, W, X>(
-    merger: (previous: V, next: W, key: K) => X,
+    merger: (oldVal: V, newVal: W, key: K) => X,
     ...iterables: (ESIterable<[K_, W]> | { [key: K_]: W })[]
   ): OrderedMap<K | K_, V | W | X>;
 
@@ -805,7 +805,7 @@ declare class OrderedMap<K, +V> extends KeyedCollection<K, V> {
   ): OrderedMap<K | K_, V | V_>;
 
   mergeDeepWith<K_, W, X>(
-    merger: (previous: V, next: W, key: K) => X,
+    merger: (oldVal: V, newVal: W, key: K) => X,
     ...iterables: (ESIterable<[K_, W]> | { [key: K_]: W })[]
   ): OrderedMap<K | K_, V | W | X>;
 


### PR DESCRIPTION
Instead of existing previous and next. Clarity around incoming new value vs linear order values.

Fixes #539