### PR TITLE
Officially deprecate the Cursor API.

### DIFF
--- a/contrib/cursor/README.md
+++ b/contrib/cursor/README.md
@@ -1,3 +1,13 @@
+# DEPRECATED
+
+The Cursor API is deprecated and will be removed in a future major release.
+
+It is strongly suggested that you use the excellent `immutable-cursor` module
+which has an extremely similar API but is much higher quality.
+
+https://github.com/redbadger/immutable-cursor
+
+
 Cursors
 -------
 

--- a/contrib/cursor/index.js
+++ b/contrib/cursor/index.js
@@ -8,6 +8,25 @@
  */
 
 /**
+ * DEPRECATED
+ *
+ * The Cursor API is deprecated and will be removed in a future major release.
+ *
+ * It is strongly suggested that you use the excellent `immutable-cursor` module
+ * which has an extremely similar API but is much higher quality.
+ *
+ * https://github.com/redbadger/immutable-cursor
+ */
+typeof console === 'object' && console.warn && console.warn(
+  'The Cursor API is deprecated and will be removed in a future major release.\n' +
+  '\n' +
+  'It is strongly suggested that you use the excellent `immutable-cursor` module\n' +
+  'which has an extremely similar API but is much higher quality.\n' +
+  '\n' +
+  'https://github.com/redbadger/immutable-cursor\n' +
+);
+
+/**
  * Cursor is expected to be required in a node or other CommonJS context:
  *
  *     var Cursor = require('immutable/contrib/cursor');


### PR DESCRIPTION
The immutable-cursor package is just so much better, go use that.

This adds warnings to the readme, to the source, and to console.