### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,21 @@ TypeScript, so you shouldn't need to do anything at all!
 
 #### Using TypeScript with Immutable.js v4
 
+TypeScript version need to be higher than 2.1.0.
 Immutable.js type definitions embrace ES2015. While Immutable.js itself supports
 legacy browsers and environments, its type definitions require TypeScript's 2015
 lib. Include either `"target": "es2015"` or `"lib": "es2015"` in your
 `tsconfig.json`, or provide `--target es2015` or `--lib es2015` to the
 `tsc` command.
+
+```js
+import * as Immutable from "immutable";
+var map1: Immutable.Map<string, number>;
+map1 = Immutable.Map({a:1, b:2, c:3});
+var map2 = map1.set('b', 50);
+map1.get('b'); // 2
+map2.get('b'); // 50
+```
 
 #### Using TypeScript with Immutable.js v3 and earlier:
 

--- a/README.md
+++ b/README.md
@@ -88,12 +88,11 @@ Use these Immutable collections and sequences as you would use native
 collections in your [Flowtype](https://flowtype.org/) or [TypeScript](http://typescriptlang.org) programs while still taking
 advantage of type generics, error detection, and auto-complete in your IDE.
 
-Installing `immutable` via npm brings with it type definitions for Flow and
-TypeScript, so you shouldn't need to do anything at all!
+Installing `immutable` via npm brings with it type definitions for Flow (v0.39.0 or higher) 
+and TypeScript (v2.1.0 or higher), so you shouldn't need to do anything at all!
 
 #### Using TypeScript with Immutable.js v4
 
-TypeScript version need to be higher than 2.1.0, 
 Immutable.js type definitions embrace ES2015. While Immutable.js itself supports
 legacy browsers and environments, its type definitions require TypeScript's 2015
 lib. Include either `"target": "es2015"` or `"lib": "es2015"` in your
@@ -101,10 +100,9 @@ lib. Include either `"target": "es2015"` or `"lib": "es2015"` in your
 `tsc` command.
 
 ```js
-import * as Immutable from "immutable";
-var map1: Immutable.Map<string, number>;
-map1 = Immutable.Map({a:1, b:2, c:3});
-var map2 = map1.set('b', 50);
+import { Map } from "immutable";
+const map1 = Map({ a: 1, b: 2, c: 3 });
+const map2 = map1.set('b', 50);
 map1.get('b'); // 2
 map2.get('b'); // 50
 ```

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Use these Immutable collections and sequences as you would use native
 collections in your [Flowtype](https://flowtype.org/) or [TypeScript](http://typescriptlang.org) programs while still taking
 advantage of type generics, error detection, and auto-complete in your IDE.
 
-Installing `immutable` via npm brings with it type definitions for Flow (v0.39.0 or higher) 
+Installing `immutable` via npm brings with it type definitions for Flow (v0.39.0 or higher)
 and TypeScript (v2.1.0 or higher), so you shouldn't need to do anything at all!
 
 #### Using TypeScript with Immutable.js v4

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ TypeScript, so you shouldn't need to do anything at all!
 
 #### Using TypeScript with Immutable.js v4
 
-TypeScript version need to be higher than 2.1.0.
+TypeScript version need to be higher than 2.1.0, 
 Immutable.js type definitions embrace ES2015. While Immutable.js itself supports
 legacy browsers and environments, its type definitions require TypeScript's 2015
 lib. Include either `"target": "es2015"` or `"lib": "es2015"` in your


### PR DESCRIPTION
I found that when using immutable.js v4, the TypeScript version needs to be higher than v.2.1.0, and need to use import instead of require