### PR TITLE
Existing TS typing for `Collection.filter` sometimes causes issues

### DIFF
--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -3283,6 +3283,10 @@
       predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
+    filter<M>(
+      predicate: (value: V, key: K, iter: this) => boolean,
+      context?: any
+    ): Collection<K, M>;
 
     /**
      * Returns a new Collection of the same type with only the entries for which

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -3283,6 +3283,10 @@ declare module Immutable {
       predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
+    filter<M>(
+      predicate: (value: V, key: K, iter: this) => boolean,
+      context?: any
+    ): Collection<K, M>;
 
     /**
      * Returns a new Collection of the same type with only the entries for which

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -3283,6 +3283,10 @@ declare module Immutable {
       predicate: (value: V, key: K, iter: this) => boolean,
       context?: any
     ): this;
+    filter<M>(
+      predicate: (value: V, key: K, iter: this) => boolean,
+      context?: any
+    ): Collection<K, M>;
 
     /**
      * Returns a new Collection of the same type with only the entries for which


### PR DESCRIPTION
Right now in TypeScript typings `Collection.filter` returns `this`,
which means it's a subtype of the containing class. I.e. if we have a
type `Collection<number, string>`, `Collection.filter` would return
`Collection<number, string>`.

It causes some issues like those:

```typescript
function foobar(): List<string> {
  const a = List.of<string | number>("a", 1, "b");
  const b = a.filter(i => typeof i === "string").toList();
  return b;
}
```

causes a type error:

```
Error:(689, 3) TS2322:Type 'List<string | number>' is not assignable to type 'List<string>'.
  Type 'string | number' is not assignable to type 'string'.
    Type 'number' is not assignable to type 'string'.
```

Same thing happens if we work with subclasses, like:

```typescript
class A {
}

class B extends A {
  public foo(): string {
    return "B";
  }
}

class C extends A {
  public bar(): string {
    return "C";
  }
}

function foobar(): List<C> {
  const a = List.of<A>(new B(), new C());
  const b = a.filter(i => i instanceof C).toList();
  return b;
}
```

shows an error:

```
Error:(702, 3) TS2322:Type 'List<A>' is not assignable to type 'List<C>'.
  Type 'A' is not assignable to type 'C'.
    Property 'bar' is missing in type 'A'.
```

Not sure what's the right solution would be. Maybe just add another
typing for `filter`, along with already existing one, which accepts
a value type in the returned collection, like I did in this
Pull Request?

Then, if you have a case like I described above, you can just provide a
type for M, like `foo.filter<string>(a => typeof a === "string)`.

What do you think?