### PR TITLE
Improve filter typescript def to leverage predicate functions

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -484,6 +484,21 @@ describe('List', () => {
     expect(r.toArray()).toEqual(['b', 'd', 'f']);
   });
 
+  it('filters values based on type', () => {
+    class A {}
+    class B extends A {
+      b(): void { return; }
+    }
+    class C extends A {
+      c(): void { return; }
+    }
+    let l1 = List<A>([ new B(), new C(), new B(), new C() ]);
+    // tslint:disable-next-line:arrow-parens
+    let l2: List<C> = l1.filter((v): v is C => v instanceof C);
+    expect(l2.size).toEqual(2);
+    expect(l2.every(v => v instanceof C)).toBe(true);
+  });
+
   it('reduces values', () => {
     let v = List.of(1, 10, 100);
     let r = v.reduce<number>((reduction, value) => reduction + value);

--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -767,6 +767,22 @@
       mapper: (value: T, key: number, iter: this) => Iterable<M>,
       context?: any
     ): List<M>;
+
+    /**
+     * Returns a new List with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends T>(
+      predicate: (value: T, index: number, iter: this) => value is F,
+      context?: any
+    ): List<F>;
+    filter(
+      predicate: (value: T, index: number, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -1359,6 +1375,22 @@
       mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
       context?: any
     ): Map<KM, VM>;
+
+    /**
+     * Returns a new Map with only the entries for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends V>(
+      predicate: (value: V, key: K, iter: this) => value is F,
+      context?: any
+    ): Map<K, F>;
+    filter(
+      predicate: (value: V, key: K, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -1451,6 +1483,22 @@
       mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
       context?: any
     ): OrderedMap<KM, VM>;
+
+    /**
+     * Returns a new OrderedMap with only the entries for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends V>(
+      predicate: (value: V, key: K, iter: this) => value is F,
+      context?: any
+    ): OrderedMap<K, F>;
+    filter(
+      predicate: (value: V, key: K, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -1636,6 +1684,22 @@
       mapper: (value: T, key: T, iter: this) => Iterable<M>,
       context?: any
     ): Set<M>;
+
+    /**
+     * Returns a new Set with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends T>(
+      predicate: (value: T, key: T, iter: this) => value is F,
+      context?: any
+    ): Set<F>;
+    filter(
+      predicate: (value: T, key: T, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -1710,6 +1774,22 @@
       mapper: (value: T, key: T, iter: this) => Iterable<M>,
       context?: any
     ): OrderedSet<M>;
+
+    /**
+     * Returns a new OrderedSet with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends T>(
+      predicate: (value: T, key: T, iter: this) => value is F,
+      context?: any
+    ): OrderedSet<F>;
+    filter(
+      predicate: (value: T, key: T, iter: this) => any,
+      context?: any
+    ): this;
 
     /**
      * Returns an OrderedSet of the same type "zipped" with the provided
@@ -1908,6 +1988,22 @@
       mapper: (value: T, key: number, iter: this) => M,
       context?: any
     ): Stack<M>;
+
+    /**
+     * Returns a new Set with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends T>(
+      predicate: (value: T, index: number, iter: this) => value is F,
+      context?: any
+    ): Set<F>;
+    filter(
+      predicate: (value: T, index: number, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -2289,6 +2385,22 @@
         mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
         context?: any
       ): Seq.Keyed<KM, VM>;
+
+      /**
+       * Returns a new Seq with only the entries for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends V>(
+        predicate: (value: V, key: K, iter: this) => value is F,
+        context?: any
+      ): Seq.Keyed<K, F>;
+      filter(
+        predicate: (value: V, key: K, iter: this) => any,
+        context?: any
+      ): this;
     }
 
 
@@ -2359,6 +2471,22 @@
         mapper: (value: T, key: number, iter: this) => Iterable<M>,
         context?: any
       ): Seq.Indexed<M>;
+
+      /**
+       * Returns a new Seq with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends T>(
+        predicate: (value: T, index: number, iter: this) => value is F,
+        context?: any
+      ): Seq.Indexed<F>;
+      filter(
+        predicate: (value: T, index: number, iter: this) => any,
+        context?: any
+      ): this;
     }
 
 
@@ -2433,6 +2561,22 @@
         mapper: (value: T, key: T, iter: this) => Iterable<M>,
         context?: any
       ): Seq.Set<M>;
+
+      /**
+       * Returns a new Seq with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends T>(
+        predicate: (value: T, key: T, iter: this) => value is F,
+        context?: any
+      ): Seq.Set<F>;
+      filter(
+        predicate: (value: T, key: T, iter: this) => any,
+        context?: any
+      ): this;
     }
 
   }
@@ -2526,6 +2670,22 @@
       mapper: (value: V, key: K, iter: this) => Iterable<M>,
       context?: any
     ): Seq<K, M>;
+
+    /**
+     * Returns a new Seq with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends V>(
+      predicate: (value: V, key: K, iter: this) => value is F,
+      context?: any
+    ): Seq<K, F>;
+    filter(
+      predicate: (value: V, key: K, iter: this) => any,
+      context?: any
+    ): this;
   }
 
   /**
@@ -2689,6 +2849,22 @@
         mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
         context?: any
       ): Collection.Keyed<KM, VM>;
+
+      /**
+       * Returns a new Collection with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends V>(
+        predicate: (value: V, key: K, iter: this) => value is F,
+        context?: any
+      ): Collection.Keyed<K, F>;
+      filter(
+        predicate: (value: V, key: K, iter: this) => any,
+        context?: any
+      ): this;
 
       [Symbol.iterator](): IterableIterator<[K, V]>;
     }
@@ -2915,6 +3091,22 @@
         context?: any
       ): Collection.Indexed<M>;
 
+      /**
+       * Returns a new Collection with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends T>(
+        predicate: (value: T, index: number, iter: this) => value is F,
+        context?: any
+      ): Collection.Indexed<F>;
+      filter(
+        predicate: (value: T, index: number, iter: this) => any,
+        context?: any
+      ): this;
+
       [Symbol.iterator](): IterableIterator<T>;
     }
 
@@ -2993,6 +3185,22 @@
         mapper: (value: T, key: T, iter: this) => Iterable<M>,
         context?: any
       ): Collection.Set<M>;
+
+      /**
+       * Returns a new Collection with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends T>(
+        predicate: (value: T, key: T, iter: this) => value is F,
+        context?: any
+      ): Collection.Set<F>;
+      filter(
+        predicate: (value: T, key: T, iter: this) => any,
+        context?: any
+      ): this;
 
       [Symbol.iterator](): IterableIterator<T>;
     }
@@ -3349,8 +3557,12 @@
      * Note: `filter()` always returns a new instance, even if it results in
      * not filtering out any values.
      */
+    filter<F extends V>(
+      predicate: (value: V, key: K, iter: this) => value is F,
+      context?: any
+    ): Collection<K, F>;
     filter(
-      predicate: (value: V, key: K, iter: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => any,
       context?: any
     ): this;
 

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -767,6 +767,22 @@ declare module Immutable {
       mapper: (value: T, key: number, iter: this) => Iterable<M>,
       context?: any
     ): List<M>;
+
+    /**
+     * Returns a new List with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends T>(
+      predicate: (value: T, index: number, iter: this) => value is F,
+      context?: any
+    ): List<F>;
+    filter(
+      predicate: (value: T, index: number, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -1359,6 +1375,22 @@ declare module Immutable {
       mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
       context?: any
     ): Map<KM, VM>;
+
+    /**
+     * Returns a new Map with only the entries for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends V>(
+      predicate: (value: V, key: K, iter: this) => value is F,
+      context?: any
+    ): Map<K, F>;
+    filter(
+      predicate: (value: V, key: K, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -1451,6 +1483,22 @@ declare module Immutable {
       mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
       context?: any
     ): OrderedMap<KM, VM>;
+
+    /**
+     * Returns a new OrderedMap with only the entries for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends V>(
+      predicate: (value: V, key: K, iter: this) => value is F,
+      context?: any
+    ): OrderedMap<K, F>;
+    filter(
+      predicate: (value: V, key: K, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -1636,6 +1684,22 @@ declare module Immutable {
       mapper: (value: T, key: T, iter: this) => Iterable<M>,
       context?: any
     ): Set<M>;
+
+    /**
+     * Returns a new Set with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends T>(
+      predicate: (value: T, key: T, iter: this) => value is F,
+      context?: any
+    ): Set<F>;
+    filter(
+      predicate: (value: T, key: T, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -1710,6 +1774,22 @@ declare module Immutable {
       mapper: (value: T, key: T, iter: this) => Iterable<M>,
       context?: any
     ): OrderedSet<M>;
+
+    /**
+     * Returns a new OrderedSet with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends T>(
+      predicate: (value: T, key: T, iter: this) => value is F,
+      context?: any
+    ): OrderedSet<F>;
+    filter(
+      predicate: (value: T, key: T, iter: this) => any,
+      context?: any
+    ): this;
 
     /**
      * Returns an OrderedSet of the same type "zipped" with the provided
@@ -1908,6 +1988,22 @@ declare module Immutable {
       mapper: (value: T, key: number, iter: this) => M,
       context?: any
     ): Stack<M>;
+
+    /**
+     * Returns a new Set with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends T>(
+      predicate: (value: T, index: number, iter: this) => value is F,
+      context?: any
+    ): Set<F>;
+    filter(
+      predicate: (value: T, index: number, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -2289,6 +2385,22 @@ declare module Immutable {
         mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
         context?: any
       ): Seq.Keyed<KM, VM>;
+
+      /**
+       * Returns a new Seq with only the entries for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends V>(
+        predicate: (value: V, key: K, iter: this) => value is F,
+        context?: any
+      ): Seq.Keyed<K, F>;
+      filter(
+        predicate: (value: V, key: K, iter: this) => any,
+        context?: any
+      ): this;
     }
 
 
@@ -2359,6 +2471,22 @@ declare module Immutable {
         mapper: (value: T, key: number, iter: this) => Iterable<M>,
         context?: any
       ): Seq.Indexed<M>;
+
+      /**
+       * Returns a new Seq with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends T>(
+        predicate: (value: T, index: number, iter: this) => value is F,
+        context?: any
+      ): Seq.Indexed<F>;
+      filter(
+        predicate: (value: T, index: number, iter: this) => any,
+        context?: any
+      ): this;
     }
 
 
@@ -2433,6 +2561,22 @@ declare module Immutable {
         mapper: (value: T, key: T, iter: this) => Iterable<M>,
         context?: any
       ): Seq.Set<M>;
+
+      /**
+       * Returns a new Seq with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends T>(
+        predicate: (value: T, key: T, iter: this) => value is F,
+        context?: any
+      ): Seq.Set<F>;
+      filter(
+        predicate: (value: T, key: T, iter: this) => any,
+        context?: any
+      ): this;
     }
 
   }
@@ -2526,6 +2670,22 @@ declare module Immutable {
       mapper: (value: V, key: K, iter: this) => Iterable<M>,
       context?: any
     ): Seq<K, M>;
+
+    /**
+     * Returns a new Seq with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends V>(
+      predicate: (value: V, key: K, iter: this) => value is F,
+      context?: any
+    ): Seq<K, F>;
+    filter(
+      predicate: (value: V, key: K, iter: this) => any,
+      context?: any
+    ): this;
   }
 
   /**
@@ -2689,6 +2849,22 @@ declare module Immutable {
         mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
         context?: any
       ): Collection.Keyed<KM, VM>;
+
+      /**
+       * Returns a new Collection with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends V>(
+        predicate: (value: V, key: K, iter: this) => value is F,
+        context?: any
+      ): Collection.Keyed<K, F>;
+      filter(
+        predicate: (value: V, key: K, iter: this) => any,
+        context?: any
+      ): this;
 
       [Symbol.iterator](): IterableIterator<[K, V]>;
     }
@@ -2915,6 +3091,22 @@ declare module Immutable {
         context?: any
       ): Collection.Indexed<M>;
 
+      /**
+       * Returns a new Collection with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends T>(
+        predicate: (value: T, index: number, iter: this) => value is F,
+        context?: any
+      ): Collection.Indexed<F>;
+      filter(
+        predicate: (value: T, index: number, iter: this) => any,
+        context?: any
+      ): this;
+
       [Symbol.iterator](): IterableIterator<T>;
     }
 
@@ -2993,6 +3185,22 @@ declare module Immutable {
         mapper: (value: T, key: T, iter: this) => Iterable<M>,
         context?: any
       ): Collection.Set<M>;
+
+      /**
+       * Returns a new Collection with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends T>(
+        predicate: (value: T, key: T, iter: this) => value is F,
+        context?: any
+      ): Collection.Set<F>;
+      filter(
+        predicate: (value: T, key: T, iter: this) => any,
+        context?: any
+      ): this;
 
       [Symbol.iterator](): IterableIterator<T>;
     }
@@ -3349,8 +3557,12 @@ declare module Immutable {
      * Note: `filter()` always returns a new instance, even if it results in
      * not filtering out any values.
      */
+    filter<F extends V>(
+      predicate: (value: V, key: K, iter: this) => value is F,
+      context?: any
+    ): Collection<K, F>;
     filter(
-      predicate: (value: V, key: K, iter: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => any,
       context?: any
     ): this;
 

--- a/tslint.json
+++ b/tslint.json
@@ -11,6 +11,7 @@
     "object-literal-sort-keys": false,
     "no-conditional-assignment": false,
     "one-variable-per-declaration": false,
+    "max-classes-per-file": false,
     "arrow-parens": [
       true,
       "ban-single-arg-parens"

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -767,6 +767,22 @@ declare module Immutable {
       mapper: (value: T, key: number, iter: this) => Iterable<M>,
       context?: any
     ): List<M>;
+
+    /**
+     * Returns a new List with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends T>(
+      predicate: (value: T, index: number, iter: this) => value is F,
+      context?: any
+    ): List<F>;
+    filter(
+      predicate: (value: T, index: number, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -1359,6 +1375,22 @@ declare module Immutable {
       mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
       context?: any
     ): Map<KM, VM>;
+
+    /**
+     * Returns a new Map with only the entries for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends V>(
+      predicate: (value: V, key: K, iter: this) => value is F,
+      context?: any
+    ): Map<K, F>;
+    filter(
+      predicate: (value: V, key: K, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -1451,6 +1483,22 @@ declare module Immutable {
       mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
       context?: any
     ): OrderedMap<KM, VM>;
+
+    /**
+     * Returns a new OrderedMap with only the entries for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends V>(
+      predicate: (value: V, key: K, iter: this) => value is F,
+      context?: any
+    ): OrderedMap<K, F>;
+    filter(
+      predicate: (value: V, key: K, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -1636,6 +1684,22 @@ declare module Immutable {
       mapper: (value: T, key: T, iter: this) => Iterable<M>,
       context?: any
     ): Set<M>;
+
+    /**
+     * Returns a new Set with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends T>(
+      predicate: (value: T, key: T, iter: this) => value is F,
+      context?: any
+    ): Set<F>;
+    filter(
+      predicate: (value: T, key: T, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -1710,6 +1774,22 @@ declare module Immutable {
       mapper: (value: T, key: T, iter: this) => Iterable<M>,
       context?: any
     ): OrderedSet<M>;
+
+    /**
+     * Returns a new OrderedSet with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends T>(
+      predicate: (value: T, key: T, iter: this) => value is F,
+      context?: any
+    ): OrderedSet<F>;
+    filter(
+      predicate: (value: T, key: T, iter: this) => any,
+      context?: any
+    ): this;
 
     /**
      * Returns an OrderedSet of the same type "zipped" with the provided
@@ -1908,6 +1988,22 @@ declare module Immutable {
       mapper: (value: T, key: number, iter: this) => M,
       context?: any
     ): Stack<M>;
+
+    /**
+     * Returns a new Set with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends T>(
+      predicate: (value: T, index: number, iter: this) => value is F,
+      context?: any
+    ): Set<F>;
+    filter(
+      predicate: (value: T, index: number, iter: this) => any,
+      context?: any
+    ): this;
   }
 
 
@@ -2289,6 +2385,22 @@ declare module Immutable {
         mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
         context?: any
       ): Seq.Keyed<KM, VM>;
+
+      /**
+       * Returns a new Seq with only the entries for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends V>(
+        predicate: (value: V, key: K, iter: this) => value is F,
+        context?: any
+      ): Seq.Keyed<K, F>;
+      filter(
+        predicate: (value: V, key: K, iter: this) => any,
+        context?: any
+      ): this;
     }
 
 
@@ -2359,6 +2471,22 @@ declare module Immutable {
         mapper: (value: T, key: number, iter: this) => Iterable<M>,
         context?: any
       ): Seq.Indexed<M>;
+
+      /**
+       * Returns a new Seq with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends T>(
+        predicate: (value: T, index: number, iter: this) => value is F,
+        context?: any
+      ): Seq.Indexed<F>;
+      filter(
+        predicate: (value: T, index: number, iter: this) => any,
+        context?: any
+      ): this;
     }
 
 
@@ -2433,6 +2561,22 @@ declare module Immutable {
         mapper: (value: T, key: T, iter: this) => Iterable<M>,
         context?: any
       ): Seq.Set<M>;
+
+      /**
+       * Returns a new Seq with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends T>(
+        predicate: (value: T, key: T, iter: this) => value is F,
+        context?: any
+      ): Seq.Set<F>;
+      filter(
+        predicate: (value: T, key: T, iter: this) => any,
+        context?: any
+      ): this;
     }
 
   }
@@ -2526,6 +2670,22 @@ declare module Immutable {
       mapper: (value: V, key: K, iter: this) => Iterable<M>,
       context?: any
     ): Seq<K, M>;
+
+    /**
+     * Returns a new Seq with only the values for which the `predicate`
+     * function returns true.
+     *
+     * Note: `filter()` always returns a new instance, even if it results in
+     * not filtering out any values.
+     */
+    filter<F extends V>(
+      predicate: (value: V, key: K, iter: this) => value is F,
+      context?: any
+    ): Seq<K, F>;
+    filter(
+      predicate: (value: V, key: K, iter: this) => any,
+      context?: any
+    ): this;
   }
 
   /**
@@ -2689,6 +2849,22 @@ declare module Immutable {
         mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
         context?: any
       ): Collection.Keyed<KM, VM>;
+
+      /**
+       * Returns a new Collection with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends V>(
+        predicate: (value: V, key: K, iter: this) => value is F,
+        context?: any
+      ): Collection.Keyed<K, F>;
+      filter(
+        predicate: (value: V, key: K, iter: this) => any,
+        context?: any
+      ): this;
 
       [Symbol.iterator](): IterableIterator<[K, V]>;
     }
@@ -2915,6 +3091,22 @@ declare module Immutable {
         context?: any
       ): Collection.Indexed<M>;
 
+      /**
+       * Returns a new Collection with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends T>(
+        predicate: (value: T, index: number, iter: this) => value is F,
+        context?: any
+      ): Collection.Indexed<F>;
+      filter(
+        predicate: (value: T, index: number, iter: this) => any,
+        context?: any
+      ): this;
+
       [Symbol.iterator](): IterableIterator<T>;
     }
 
@@ -2993,6 +3185,22 @@ declare module Immutable {
         mapper: (value: T, key: T, iter: this) => Iterable<M>,
         context?: any
       ): Collection.Set<M>;
+
+      /**
+       * Returns a new Collection with only the values for which the `predicate`
+       * function returns true.
+       *
+       * Note: `filter()` always returns a new instance, even if it results in
+       * not filtering out any values.
+       */
+      filter<F extends T>(
+        predicate: (value: T, key: T, iter: this) => value is F,
+        context?: any
+      ): Collection.Set<F>;
+      filter(
+        predicate: (value: T, key: T, iter: this) => any,
+        context?: any
+      ): this;
 
       [Symbol.iterator](): IterableIterator<T>;
     }
@@ -3349,8 +3557,12 @@ declare module Immutable {
      * Note: `filter()` always returns a new instance, even if it results in
      * not filtering out any values.
      */
+    filter<F extends V>(
+      predicate: (value: V, key: K, iter: this) => value is F,
+      context?: any
+    ): Collection<K, F>;
     filter(
-      predicate: (value: V, key: K, iter: this) => boolean,
+      predicate: (value: V, key: K, iter: this) => any,
       context?: any
     ): this;
 


### PR DESCRIPTION
This expands the type def of filter() to return a type-limited version of the original type.

Fixes #1152