### PR TITLE
Support typescript strictNullChecks

### DIFF
--- a/__tests__/Conversion.ts
+++ b/__tests__/Conversion.ts
@@ -128,7 +128,7 @@ describe('Conversion', () => {
   });
 
   it('Throws when provided circular reference', () => {
-    let o = {a: {b: {c: null}}};
+    let o = {a: {b: {c: null as any}}};
     o.a.b.c = o;
     expect(() => fromJS(o)).toThrow(
       'Cannot convert circular structure to Immutable',
@@ -147,7 +147,7 @@ describe('Conversion', () => {
   });
 
   it('Converts deep JSON with custom conversion including keypath if requested', () => {
-    let paths = [];
+    let paths: Array<any> = [];
     let seq1 = fromJS(js, function (key, sequence, keypath) {
       expect(arguments.length).toBe(3);
       paths.push(keypath);

--- a/__tests__/Equality.ts
+++ b/__tests__/Equality.ts
@@ -68,11 +68,11 @@ describe('Equality', () => {
     };
     expectIs(ptrA, ptrB);
     ptrA.valueOf = ptrB.valueOf = function() {
-      return null;
+      return null as any;
     };
     expectIs(ptrA, ptrB);
     ptrA.valueOf = ptrB.valueOf = function() {
-      return void 0;
+      return void 0 as any;
     };
     expectIs(ptrA, ptrB);
     ptrA.valueOf = function() {

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -129,10 +129,10 @@ describe('List', () => {
 
   it('returns undefined when getting a null value', () => {
     let v = List([1, 2, 3]);
-    expect(v.get(null)).toBe(undefined);
+    expect(v.get(null as any)).toBe(undefined);
 
     let o = List([{ a: 1 }, { b: 2 }, { c: 3 }]);
-    expect(o.get(null)).toBe(undefined);
+    expect(o.get(null as any)).toBe(undefined);
   });
 
   it('counts from the end of the list on negative index', () => {
@@ -261,7 +261,7 @@ describe('List', () => {
   });
 
   it('describes a dense list', () => {
-    let v = List.of('a', 'b', 'c').push('d').set(14, 'o').set(6, undefined).remove(1);
+    let v = List.of<string | undefined>('a', 'b', 'c').push('d').set(14, 'o').set(6, undefined).remove(1);
     expect(v.size).toBe(14);
     expect(v.toJS()).toEqual(
       ['a', 'c', 'd', , , , , , , , , , , 'o'],
@@ -272,7 +272,7 @@ describe('List', () => {
     let v = List().setSize(11).set(1, 1).set(3, 3).set(5, 5).set(7, 7).set(9, 9);
     expect(v.size).toBe(11);
 
-    let forEachResults = [];
+    let forEachResults: Array<any> = [];
     v.forEach((val, i) => forEachResults.push([i, val]));
     expect(forEachResults).toEqual([
       [0, undefined],
@@ -303,7 +303,7 @@ describe('List', () => {
       undefined,
     ]);
 
-    let iteratorResults = [];
+    let iteratorResults: Array<any> = [];
     let iterator = v.entries();
     let step;
     while (!(step = iterator.next()).done) {
@@ -381,7 +381,7 @@ describe('List', () => {
 
   check.it('push adds the next highest index, just like array', {maxSize: 2000},
     [gen.posInt], len => {
-      let a = [];
+      let a: Array<any> = [];
       let v = List();
 
       for (let ii = 0; ii < len; ii++) {
@@ -602,7 +602,7 @@ describe('List', () => {
 
   it('forEach iterates in the correct order', () => {
     let n = 0;
-    let a = [];
+    let a: Array<any> = [];
     let v = List.of(0, 1, 2, 3, 4);
     v.forEach(x => {
       a.push(x);
@@ -614,7 +614,7 @@ describe('List', () => {
   });
 
   it('forEach iteration terminates when callback returns false', () => {
-    let a = [];
+    let a: Array<any> = [];
     function count(x) {
       if (x > 2) {
         return false;
@@ -628,7 +628,7 @@ describe('List', () => {
 
   it('concat works like Array.prototype.concat', () => {
     let v1 = List.of(1, 2, 3);
-    let v2 = v1.concat(4, List([ 5, 6 ]), [7, 8], Seq([ 9, 10 ]), Set.of(11, 12), null);
+    let v2 = v1.concat(4, List([ 5, 6 ]), [7, 8], Seq([ 9, 10 ]), Set.of(11, 12), null as any);
     expect(v1.toArray()).toEqual([1, 2, 3]);
     expect(v2.toArray()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, null]);
   });
@@ -689,7 +689,7 @@ describe('List', () => {
 
     expect(v2.toArray()).toEqual(list.slice(0, 3));
     expect(v3.toArray()).toEqual(
-      list.slice(0, 3).concat([undefined, undefined, undefined]),
+      list.slice(0, 3).concat([undefined, undefined, undefined] as any),
     );
   });
 
@@ -701,7 +701,7 @@ describe('List', () => {
 
     expect(v2.toArray()).toEqual(list.slice(0, 3));
     expect(v3.toArray()).toEqual(
-      list.slice(0, 3).concat([undefined, undefined, undefined]),
+      list.slice(0, 3).concat([undefined, undefined, undefined] as any),
     );
   });
 

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -123,7 +123,7 @@ describe('Map', () => {
   });
 
   it('accepts null as a key', () => {
-    let m1 = Map();
+    let m1 = Map<any, any>();
     let m2 = m1.set(null, 'null');
     let m3 = m2.remove(null);
     expect(m1.size).toBe(0);
@@ -366,7 +366,7 @@ describe('Map', () => {
   });
 
   it('uses toString on keys and values', () => {
-    class A extends Record({x: null}) {
+    class A extends Record({x: null as number | null}) {
       toString() {
         return this.x;
       }

--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -21,7 +21,7 @@ describe('Record', () => {
   });
 
   it('allows for a descriptive name', () => {
-    let Person = Record({name: null}, 'Person');
+    let Person = Record({name: null as string | null}, 'Person');
 
     let me = Person({ name: 'My Name' });
     expect(me.toString()).toEqual('Person { name: "My Name" }');
@@ -162,7 +162,7 @@ describe('Record', () => {
     let realWarn = console.warn;
 
     try {
-      let warnings = [];
+      let warnings: Array<any> = [];
       console.warn = w => warnings.push(w);
 
       // size is a safe key to use
@@ -208,7 +208,7 @@ describe('Record', () => {
     let MyType = Record({a: 0, b: 0});
     let t1 = MyType({a: 10, b: 20});
 
-    let entries = [];
+    let entries: Array<any> = [];
     for (let entry of t1) {
       entries.push(entry);
     }

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -34,7 +34,7 @@ describe('Set', () => {
   });
 
   it('accepts array-like of values', () => {
-    let s = Set({ length: 3, 1: 2 } as any);
+    let s = Set<any>({ length: 3, 1: 2 } as any);
     expect(s.size).toBe(2);
     expect(s.has(undefined)).toBe(true);
     expect(s.has(2)).toBe(true);

--- a/__tests__/Stack.ts
+++ b/__tests__/Stack.ts
@@ -73,7 +73,7 @@ describe('Stack', () => {
     let s = Stack.of('a', 'b', 'c');
     expect(s.size).toBe(3);
 
-    let forEachResults = [];
+    let forEachResults: Array<any> = [];
     s.forEach((val, i) => forEachResults.push([i, val, s.get(i)]));
     expect(forEachResults).toEqual([
       [0, 'a', 'a'],
@@ -88,7 +88,7 @@ describe('Stack', () => {
       'cc',
     ]);
 
-    let iteratorResults = [];
+    let iteratorResults: Array<any> = [];
     let iterator = s.entries();
     let step;
     while (!(step = iterator.next()).done) {
@@ -154,7 +154,7 @@ describe('Stack', () => {
 
   check.it('unshift adds the next lowest index, just like array', {maxSize: 2000},
     [gen.posInt], len => {
-      let a = [];
+      let a: Array<any> = [];
       let s = Stack();
 
       for (let ii = 0; ii < len; ii++) {

--- a/__tests__/flatten.ts
+++ b/__tests__/flatten.ts
@@ -5,8 +5,6 @@ jasmineCheck.install();
 
 import { Collection, fromJS, List, Range, Seq } from '../';
 
-type SeqType = number | number[] | Collection<number, number>;
-
 describe('flatten', () => {
 
   it('flattens sequences one level deep', () => {
@@ -26,6 +24,8 @@ describe('flatten', () => {
     let flat = nested.flatten();
     expect(flat.forEach(x => x < 4)).toEqual(4);
   });
+
+  type SeqType = number | Array<number> | Collection<number, number>;
 
   it('flattens only Sequences (not sequenceables)', () => {
     let nested = Seq.of<SeqType>(Range(1, 3), [3, 4], List.of(5, 6, 7), 8);

--- a/__tests__/groupBy.ts
+++ b/__tests__/groupBy.ts
@@ -9,7 +9,8 @@ describe('groupBy', () => {
     expect(grouped.toJS()).toEqual({1: {a: 1, c: 3}, 0: {b: 2, d: 4}});
 
     // Each group should be a keyed sequence, not an indexed sequence
-    expect(grouped.get(1).toArray()).toEqual([1, 3]);
+    const firstGroup = grouped.get(1);
+    expect(firstGroup && firstGroup.toArray()).toEqual([1, 3]);
   });
 
   it('groups indexed sequence', () => {

--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -32,7 +32,7 @@ describe('merge', () => {
 
   it('can merge in an explicitly undefined value', () => {
     let m1 = Map({a: 1, b: 2});
-    let m2 = Map({a: undefined});
+    let m2 = Map({a: undefined as any});
     expect(m1.merge(m2)).is(Map({a: undefined, b: 2}));
   });
 

--- a/__tests__/minmax.ts
+++ b/__tests__/minmax.ts
@@ -27,7 +27,7 @@ describe('max', () => {
       { name: 'Casey', age: 34 },
       { name: 'Avery', age: 34 },
     ]);
-    expect(family.maxBy(p => p.age).name).toBe('Casey');
+    expect(family.maxBy(p => p.age)).toBe(family.get(2));
   });
 
   it('by a mapper and a comparator', () => {
@@ -37,7 +37,7 @@ describe('max', () => {
       { name: 'Casey', age: 34 },
       { name: 'Avery', age: 34 },
     ]);
-    expect(family.maxBy<number>(p => p.age, (a, b) => b - a).name).toBe('Oakley');
+    expect(family.maxBy<number>(p => p.age, (a, b) => b - a)).toBe(family.get(0));
   });
 
   it('surfaces NaN, null, and undefined', () => {
@@ -89,7 +89,7 @@ describe('min', () => {
       { name: 'Casey', age: 34 },
       { name: 'Avery', age: 34 },
     ]);
-    expect(family.minBy(p => p.age).name).toBe('Oakley');
+    expect(family.minBy(p => p.age)).toBe(family.get(0));
   });
 
   it('by a mapper and a comparator', () => {
@@ -99,7 +99,7 @@ describe('min', () => {
       { name: 'Casey', age: 34 },
       { name: 'Avery', age: 34 },
     ]);
-    expect(family.minBy<number>(p => p.age, (a, b) => b - a).name).toBe('Casey');
+    expect(family.minBy<number>(p => p.age, (a, b) => b - a)).toBe(family.get(2));
   });
 
   check.it('is not dependent on order', [genHeterogeneousishArray], vals => {

--- a/__tests__/slice.ts
+++ b/__tests__/slice.ts
@@ -133,7 +133,7 @@ describe('slice', () => {
     [gen.array(gen.array([gen.posInt, gen.int])),
       gen.array(gen.oneOf([gen.int, gen.undefined]), 0, 3)],
     (entries, args) => {
-      let a = [];
+      let a: Array<any> = [];
       entries.forEach(entry => a[entry[0]] = entry[1]);
       let s = Seq(a);
       let slicedS = s.slice.apply(s, args);

--- a/__tests__/zip.ts
+++ b/__tests__/zip.ts
@@ -91,7 +91,7 @@ describe('zip', () => {
     });
 
     it('with infinite lists', () => {
-      let r: Collection.Indexed<any> = Range();
+      let r: Seq.Indexed<any> = Range();
       let i = r.interleave(Seq.of('A', 'B', 'C'));
       expect(i.size).toBe(6);
       expect(i.toArray()).toEqual(

--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -421,6 +421,11 @@
 
   export interface List<T> extends Collection.Indexed<T> {
 
+    /**
+     * The number of items in this List.
+     */
+    readonly size: number;
+
     // Persistent changes
 
     /**
@@ -784,6 +789,44 @@
       predicate: (value: T, index: number, iter: this) => any,
       context?: any
     ): this;
+
+    /**
+     * Returns a List "zipped" with the provided collections.
+     *
+     * Like `zipWith`, but using the default `zipper`: creating an `Array`.
+     *
+     * ```js
+     * const a = List([ 1, 2, 3 ]);
+     * const b = List([ 4, 5, 6 ]);
+     * const c = a.zip(b); // List [ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
+     * ```
+     */
+    zip(...collections: Array<Collection<any, any>>): List<any>;
+
+    /**
+     * Returns a List "zipped" with the provided collections by using a
+     * custom `zipper` function.
+     *
+     * ```js
+     * const a = List([ 1, 2, 3 ]);
+     * const b = List([ 4, 5, 6 ]);
+     * const c = a.zipWith((a, b) => a + b, b);
+     * // List [ 5, 7, 9 ]
+     * ```
+     */
+    zipWith<U, Z>(
+      zipper: (value: T, otherValue: U) => Z,
+      otherCollection: Collection<any, U>
+    ): List<Z>;
+    zipWith<U, V, Z>(
+      zipper: (value: T, otherValue: U, thirdValue: V) => Z,
+      otherCollection: Collection<any, U>,
+      thirdCollection: Collection<any, V>
+    ): List<Z>;
+    zipWith<Z>(
+      zipper: (...any: Array<any>) => Z,
+      ...collections: Array<Collection<any, any>>
+    ): List<Z>;
   }
 
 
@@ -882,6 +925,11 @@
   export function Map(): Map<any, any>;
 
   export interface Map<K, V> extends Collection.Keyed<K, V> {
+
+    /**
+     * The number of entries in this Map.
+     */
+    readonly size: number;
 
     // Persistent changes
 
@@ -1436,6 +1484,11 @@
 
   export interface OrderedMap<K, V> extends Map<K, V> {
 
+    /**
+     * The number of entries in this OrderedMap.
+     */
+    readonly size: number;
+
     // Sequence algorithms
 
     /**
@@ -1573,6 +1626,11 @@
   export function Set<T>(collection: Iterable<T>): Set<T>;
 
   export interface Set<T> extends Collection.Set<T> {
+
+    /**
+     * The number of items in this Set.
+     */
+    readonly size: number;
 
     // Persistent changes
 
@@ -1744,6 +1802,11 @@
 
   export interface OrderedSet<T> extends Set<T> {
 
+    /**
+     * The number of items in this OrderedSet.
+     */
+    readonly size: number;
+
     // Sequence algorithms
 
     /**
@@ -1870,6 +1933,11 @@
   export function Stack<T>(collection: Iterable<T>): Stack<T>;
 
   export interface Stack<T> extends Collection.Indexed<T> {
+
+    /**
+     * The number of items in this Stack.
+     */
+    readonly size: number;
 
     // Reading values
 
@@ -2005,6 +2073,44 @@
       predicate: (value: T, index: number, iter: this) => any,
       context?: any
     ): this;
+
+    /**
+     * Returns a Stack "zipped" with the provided collections.
+     *
+     * Like `zipWith`, but using the default `zipper`: creating an `Array`.
+     *
+     * ```js
+     * const a = Stack([ 1, 2, 3 ]);
+     * const b = Stack([ 4, 5, 6 ]);
+     * const c = a.zip(b); // Stack [ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
+     * ```
+     */
+    zip(...collections: Array<Collection<any, any>>): Stack<any>;
+
+    /**
+     * Returns a Stack "zipped" with the provided collections by using a
+     * custom `zipper` function.
+     *
+     * ```js
+     * const a = Stack([ 1, 2, 3 ]);
+     * const b = Stack([ 4, 5, 6 ]);
+     * const c = a.zipWith((a, b) => a + b, b);
+     * // Stack [ 5, 7, 9 ]
+     * ```
+     */
+    zipWith<U, Z>(
+      zipper: (value: T, otherValue: U) => Z,
+      otherCollection: Collection<any, U>
+    ): Stack<Z>;
+    zipWith<U, V, Z>(
+      zipper: (value: T, otherValue: U, thirdValue: V) => Z,
+      otherCollection: Collection<any, U>,
+      thirdCollection: Collection<any, V>
+    ): Stack<Z>;
+    zipWith<Z>(
+      zipper: (...any: Array<any>) => Z,
+      ...collections: Array<Collection<any, any>>
+    ): Stack<Z>;
   }
 
 
@@ -2130,7 +2236,6 @@
     }
 
     export interface Instance<T extends Object> {
-      readonly size: number;
 
       // Reading values
 
@@ -2503,6 +2608,44 @@
         predicate: (value: T, index: number, iter: this) => any,
         context?: any
       ): this;
+
+      /**
+       * Returns a Seq "zipped" with the provided collections.
+       *
+       * Like `zipWith`, but using the default `zipper`: creating an `Array`.
+       *
+       * ```js
+       * const a = Seq([ 1, 2, 3 ]);
+       * const b = Seq([ 4, 5, 6 ]);
+       * const c = a.zip(b); // Seq [ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
+       * ```
+       */
+      zip(...collections: Array<Collection<any, any>>): Seq.Indexed<any>;
+
+      /**
+       * Returns a Seq "zipped" with the provided collections by using a
+       * custom `zipper` function.
+       *
+       * ```js
+       * const a = Seq([ 1, 2, 3 ]);
+       * const b = Seq([ 4, 5, 6 ]);
+       * const c = a.zipWith((a, b) => a + b, b);
+       * // Seq [ 5, 7, 9 ]
+       * ```
+       */
+      zipWith<U, Z>(
+        zipper: (value: T, otherValue: U) => Z,
+        otherCollection: Collection<any, U>
+      ): Seq.Indexed<Z>;
+      zipWith<U, V, Z>(
+        zipper: (value: T, otherValue: U, thirdValue: V) => Z,
+        otherCollection: Collection<any, U>,
+        thirdCollection: Collection<any, V>
+      ): Seq.Indexed<Z>;
+      zipWith<Z>(
+        zipper: (...any: Array<any>) => Z,
+        ...collections: Array<Collection<any, any>>
+      ): Seq.Indexed<Z>;
     }
 
 
@@ -4087,16 +4230,5 @@
      * True if this Collection includes every value in `iter`.
      */
     isSuperset(iter: Iterable<V>): boolean;
-
-
-    /**
-     * Note: this is here as a convenience to work around an issue with
-     * TypeScript https://github.com/Microsoft/TypeScript/issues/285, but
-     * Collection does not define `size`, instead `Seq` defines `size` as
-     * nullable number, and `Collection` defines `size` as always a number.
-     *
-     * @ignore
-     */
-    readonly size: number;
   }
 

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -421,6 +421,11 @@ declare module Immutable {
 
   export interface List<T> extends Collection.Indexed<T> {
 
+    /**
+     * The number of items in this List.
+     */
+    readonly size: number;
+
     // Persistent changes
 
     /**
@@ -784,6 +789,44 @@ declare module Immutable {
       predicate: (value: T, index: number, iter: this) => any,
       context?: any
     ): this;
+
+    /**
+     * Returns a List "zipped" with the provided collections.
+     *
+     * Like `zipWith`, but using the default `zipper`: creating an `Array`.
+     *
+     * ```js
+     * const a = List([ 1, 2, 3 ]);
+     * const b = List([ 4, 5, 6 ]);
+     * const c = a.zip(b); // List [ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
+     * ```
+     */
+    zip(...collections: Array<Collection<any, any>>): List<any>;
+
+    /**
+     * Returns a List "zipped" with the provided collections by using a
+     * custom `zipper` function.
+     *
+     * ```js
+     * const a = List([ 1, 2, 3 ]);
+     * const b = List([ 4, 5, 6 ]);
+     * const c = a.zipWith((a, b) => a + b, b);
+     * // List [ 5, 7, 9 ]
+     * ```
+     */
+    zipWith<U, Z>(
+      zipper: (value: T, otherValue: U) => Z,
+      otherCollection: Collection<any, U>
+    ): List<Z>;
+    zipWith<U, V, Z>(
+      zipper: (value: T, otherValue: U, thirdValue: V) => Z,
+      otherCollection: Collection<any, U>,
+      thirdCollection: Collection<any, V>
+    ): List<Z>;
+    zipWith<Z>(
+      zipper: (...any: Array<any>) => Z,
+      ...collections: Array<Collection<any, any>>
+    ): List<Z>;
   }
 
 
@@ -882,6 +925,11 @@ declare module Immutable {
   export function Map(): Map<any, any>;
 
   export interface Map<K, V> extends Collection.Keyed<K, V> {
+
+    /**
+     * The number of entries in this Map.
+     */
+    readonly size: number;
 
     // Persistent changes
 
@@ -1436,6 +1484,11 @@ declare module Immutable {
 
   export interface OrderedMap<K, V> extends Map<K, V> {
 
+    /**
+     * The number of entries in this OrderedMap.
+     */
+    readonly size: number;
+
     // Sequence algorithms
 
     /**
@@ -1573,6 +1626,11 @@ declare module Immutable {
   export function Set<T>(collection: Iterable<T>): Set<T>;
 
   export interface Set<T> extends Collection.Set<T> {
+
+    /**
+     * The number of items in this Set.
+     */
+    readonly size: number;
 
     // Persistent changes
 
@@ -1744,6 +1802,11 @@ declare module Immutable {
 
   export interface OrderedSet<T> extends Set<T> {
 
+    /**
+     * The number of items in this OrderedSet.
+     */
+    readonly size: number;
+
     // Sequence algorithms
 
     /**
@@ -1870,6 +1933,11 @@ declare module Immutable {
   export function Stack<T>(collection: Iterable<T>): Stack<T>;
 
   export interface Stack<T> extends Collection.Indexed<T> {
+
+    /**
+     * The number of items in this Stack.
+     */
+    readonly size: number;
 
     // Reading values
 
@@ -2005,6 +2073,44 @@ declare module Immutable {
       predicate: (value: T, index: number, iter: this) => any,
       context?: any
     ): this;
+
+    /**
+     * Returns a Stack "zipped" with the provided collections.
+     *
+     * Like `zipWith`, but using the default `zipper`: creating an `Array`.
+     *
+     * ```js
+     * const a = Stack([ 1, 2, 3 ]);
+     * const b = Stack([ 4, 5, 6 ]);
+     * const c = a.zip(b); // Stack [ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
+     * ```
+     */
+    zip(...collections: Array<Collection<any, any>>): Stack<any>;
+
+    /**
+     * Returns a Stack "zipped" with the provided collections by using a
+     * custom `zipper` function.
+     *
+     * ```js
+     * const a = Stack([ 1, 2, 3 ]);
+     * const b = Stack([ 4, 5, 6 ]);
+     * const c = a.zipWith((a, b) => a + b, b);
+     * // Stack [ 5, 7, 9 ]
+     * ```
+     */
+    zipWith<U, Z>(
+      zipper: (value: T, otherValue: U) => Z,
+      otherCollection: Collection<any, U>
+    ): Stack<Z>;
+    zipWith<U, V, Z>(
+      zipper: (value: T, otherValue: U, thirdValue: V) => Z,
+      otherCollection: Collection<any, U>,
+      thirdCollection: Collection<any, V>
+    ): Stack<Z>;
+    zipWith<Z>(
+      zipper: (...any: Array<any>) => Z,
+      ...collections: Array<Collection<any, any>>
+    ): Stack<Z>;
   }
 
 
@@ -2130,7 +2236,6 @@ declare module Immutable {
     }
 
     export interface Instance<T extends Object> {
-      readonly size: number;
 
       // Reading values
 
@@ -2503,6 +2608,44 @@ declare module Immutable {
         predicate: (value: T, index: number, iter: this) => any,
         context?: any
       ): this;
+
+      /**
+       * Returns a Seq "zipped" with the provided collections.
+       *
+       * Like `zipWith`, but using the default `zipper`: creating an `Array`.
+       *
+       * ```js
+       * const a = Seq([ 1, 2, 3 ]);
+       * const b = Seq([ 4, 5, 6 ]);
+       * const c = a.zip(b); // Seq [ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
+       * ```
+       */
+      zip(...collections: Array<Collection<any, any>>): Seq.Indexed<any>;
+
+      /**
+       * Returns a Seq "zipped" with the provided collections by using a
+       * custom `zipper` function.
+       *
+       * ```js
+       * const a = Seq([ 1, 2, 3 ]);
+       * const b = Seq([ 4, 5, 6 ]);
+       * const c = a.zipWith((a, b) => a + b, b);
+       * // Seq [ 5, 7, 9 ]
+       * ```
+       */
+      zipWith<U, Z>(
+        zipper: (value: T, otherValue: U) => Z,
+        otherCollection: Collection<any, U>
+      ): Seq.Indexed<Z>;
+      zipWith<U, V, Z>(
+        zipper: (value: T, otherValue: U, thirdValue: V) => Z,
+        otherCollection: Collection<any, U>,
+        thirdCollection: Collection<any, V>
+      ): Seq.Indexed<Z>;
+      zipWith<Z>(
+        zipper: (...any: Array<any>) => Z,
+        ...collections: Array<Collection<any, any>>
+      ): Seq.Indexed<Z>;
     }
 
 
@@ -4087,17 +4230,6 @@ declare module Immutable {
      * True if this Collection includes every value in `iter`.
      */
     isSuperset(iter: Iterable<V>): boolean;
-
-
-    /**
-     * Note: this is here as a convenience to work around an issue with
-     * TypeScript https://github.com/Microsoft/TypeScript/issues/285, but
-     * Collection does not define `size`, instead `Seq` defines `size` as
-     * nullable number, and `Collection` defines `size` as always a number.
-     *
-     * @ignore
-     */
-    readonly size: number;
   }
 }
 

--- a/dist/immutable.js.flow
+++ b/dist/immutable.js.flow
@@ -1048,6 +1048,73 @@ declare class Stack<+T> extends IndexedCollection<T> {
 
   flatten(depth?: number): Stack<any>;
   flatten(shallow?: boolean): Stack<any>;
+
+  zip<A>(
+    a: Iterable<A>,
+    ..._: []
+  ): Stack<[T, A]>;
+  zip<A, B>(
+    a: Iterable<A>,
+    b: Iterable<B>,
+    ..._: []
+  ): Stack<[T, A, B]>;
+  zip<A, B, C>(
+    a: Iterable<A>,
+    b: Iterable<B>,
+    c: Iterable<C>,
+    ..._: []
+  ): Stack<[T, A, B, C]>;
+  zip<A, B, C, D>(
+    a: Iterable<A>,
+    b: Iterable<B>,
+    c: Iterable<C>,
+    d: Iterable<D>,
+    ..._: []
+  ): Stack<[T, A, B, C, D]>;
+  zip<A, B, C, D, E>(
+    a: Iterable<A>,
+    b: Iterable<B>,
+    c: Iterable<C>,
+    d: Iterable<D>,
+    e: Iterable<E>,
+    ..._: []
+  ): Stack<[T, A, B, C, D, E]>;
+
+  zipWith<A, R>(
+    zipper: (value: T, a: A) => R,
+    a: Iterable<A>,
+    ..._: []
+  ): Stack<R>;
+  zipWith<A, B, R>(
+    zipper: (value: T, a: A, b: B) => R,
+    a: Iterable<A>,
+    b: Iterable<B>,
+    ..._: []
+  ): Stack<R>;
+  zipWith<A, B, C, R>(
+    zipper: (value: T, a: A, b: B, c: C) => R,
+    a: Iterable<A>,
+    b: Iterable<B>,
+    c: Iterable<C>,
+    ..._: []
+  ): Stack<R>;
+  zipWith<A, B, C, D, R>(
+    zipper: (value: T, a: A, b: B, c: C, d: D) => R,
+    a: Iterable<A>,
+    b: Iterable<B>,
+    c: Iterable<C>,
+    d: Iterable<D>,
+    ..._: []
+  ): Stack<R>;
+  zipWith<A, B, C, D, E, R>(
+    zipper: (value: T, a: A, b: B, c: C, d: D, e: E) => R,
+    a: Iterable<A>,
+    b: Iterable<B>,
+    c: Iterable<C>,
+    d: Iterable<D>,
+    e: Iterable<E>,
+    ..._: []
+  ): Stack<R>;
 }
 
 declare function Range(start?: number, end?: number, step?: number): IndexedSeq<number>;

--- a/resources/jestPreprocessor.js
+++ b/resources/jestPreprocessor.js
@@ -7,7 +7,8 @@ module.exports = {
     var options = {
       noEmitOnError: true,
       target: typescript.ScriptTarget.ES2015,
-      module: typescript.ModuleKind.CommonJS
+      module: typescript.ModuleKind.CommonJS,
+      strictNullChecks: true,
     };
 
     var host = typescript.createCompilerHost(options);

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": "tslint:recommended",
   "rules": {
+    "array-type": [true, "generic"],
     "quotemark": false,
     "no-reference": false,
     "no-namespace": false,

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -421,6 +421,11 @@ declare module Immutable {
 
   export interface List<T> extends Collection.Indexed<T> {
 
+    /**
+     * The number of items in this List.
+     */
+    readonly size: number;
+
     // Persistent changes
 
     /**
@@ -784,6 +789,44 @@ declare module Immutable {
       predicate: (value: T, index: number, iter: this) => any,
       context?: any
     ): this;
+
+    /**
+     * Returns a List "zipped" with the provided collections.
+     *
+     * Like `zipWith`, but using the default `zipper`: creating an `Array`.
+     *
+     * ```js
+     * const a = List([ 1, 2, 3 ]);
+     * const b = List([ 4, 5, 6 ]);
+     * const c = a.zip(b); // List [ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
+     * ```
+     */
+    zip(...collections: Array<Collection<any, any>>): List<any>;
+
+    /**
+     * Returns a List "zipped" with the provided collections by using a
+     * custom `zipper` function.
+     *
+     * ```js
+     * const a = List([ 1, 2, 3 ]);
+     * const b = List([ 4, 5, 6 ]);
+     * const c = a.zipWith((a, b) => a + b, b);
+     * // List [ 5, 7, 9 ]
+     * ```
+     */
+    zipWith<U, Z>(
+      zipper: (value: T, otherValue: U) => Z,
+      otherCollection: Collection<any, U>
+    ): List<Z>;
+    zipWith<U, V, Z>(
+      zipper: (value: T, otherValue: U, thirdValue: V) => Z,
+      otherCollection: Collection<any, U>,
+      thirdCollection: Collection<any, V>
+    ): List<Z>;
+    zipWith<Z>(
+      zipper: (...any: Array<any>) => Z,
+      ...collections: Array<Collection<any, any>>
+    ): List<Z>;
   }
 
 
@@ -882,6 +925,11 @@ declare module Immutable {
   export function Map(): Map<any, any>;
 
   export interface Map<K, V> extends Collection.Keyed<K, V> {
+
+    /**
+     * The number of entries in this Map.
+     */
+    readonly size: number;
 
     // Persistent changes
 
@@ -1436,6 +1484,11 @@ declare module Immutable {
 
   export interface OrderedMap<K, V> extends Map<K, V> {
 
+    /**
+     * The number of entries in this OrderedMap.
+     */
+    readonly size: number;
+
     // Sequence algorithms
 
     /**
@@ -1573,6 +1626,11 @@ declare module Immutable {
   export function Set<T>(collection: Iterable<T>): Set<T>;
 
   export interface Set<T> extends Collection.Set<T> {
+
+    /**
+     * The number of items in this Set.
+     */
+    readonly size: number;
 
     // Persistent changes
 
@@ -1744,6 +1802,11 @@ declare module Immutable {
 
   export interface OrderedSet<T> extends Set<T> {
 
+    /**
+     * The number of items in this OrderedSet.
+     */
+    readonly size: number;
+
     // Sequence algorithms
 
     /**
@@ -1870,6 +1933,11 @@ declare module Immutable {
   export function Stack<T>(collection: Iterable<T>): Stack<T>;
 
   export interface Stack<T> extends Collection.Indexed<T> {
+
+    /**
+     * The number of items in this Stack.
+     */
+    readonly size: number;
 
     // Reading values
 
@@ -2005,6 +2073,44 @@ declare module Immutable {
       predicate: (value: T, index: number, iter: this) => any,
       context?: any
     ): this;
+
+    /**
+     * Returns a Stack "zipped" with the provided collections.
+     *
+     * Like `zipWith`, but using the default `zipper`: creating an `Array`.
+     *
+     * ```js
+     * const a = Stack([ 1, 2, 3 ]);
+     * const b = Stack([ 4, 5, 6 ]);
+     * const c = a.zip(b); // Stack [ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
+     * ```
+     */
+    zip(...collections: Array<Collection<any, any>>): Stack<any>;
+
+    /**
+     * Returns a Stack "zipped" with the provided collections by using a
+     * custom `zipper` function.
+     *
+     * ```js
+     * const a = Stack([ 1, 2, 3 ]);
+     * const b = Stack([ 4, 5, 6 ]);
+     * const c = a.zipWith((a, b) => a + b, b);
+     * // Stack [ 5, 7, 9 ]
+     * ```
+     */
+    zipWith<U, Z>(
+      zipper: (value: T, otherValue: U) => Z,
+      otherCollection: Collection<any, U>
+    ): Stack<Z>;
+    zipWith<U, V, Z>(
+      zipper: (value: T, otherValue: U, thirdValue: V) => Z,
+      otherCollection: Collection<any, U>,
+      thirdCollection: Collection<any, V>
+    ): Stack<Z>;
+    zipWith<Z>(
+      zipper: (...any: Array<any>) => Z,
+      ...collections: Array<Collection<any, any>>
+    ): Stack<Z>;
   }
 
 
@@ -2130,7 +2236,6 @@ declare module Immutable {
     }
 
     export interface Instance<T extends Object> {
-      readonly size: number;
 
       // Reading values
 
@@ -2503,6 +2608,44 @@ declare module Immutable {
         predicate: (value: T, index: number, iter: this) => any,
         context?: any
       ): this;
+
+      /**
+       * Returns a Seq "zipped" with the provided collections.
+       *
+       * Like `zipWith`, but using the default `zipper`: creating an `Array`.
+       *
+       * ```js
+       * const a = Seq([ 1, 2, 3 ]);
+       * const b = Seq([ 4, 5, 6 ]);
+       * const c = a.zip(b); // Seq [ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
+       * ```
+       */
+      zip(...collections: Array<Collection<any, any>>): Seq.Indexed<any>;
+
+      /**
+       * Returns a Seq "zipped" with the provided collections by using a
+       * custom `zipper` function.
+       *
+       * ```js
+       * const a = Seq([ 1, 2, 3 ]);
+       * const b = Seq([ 4, 5, 6 ]);
+       * const c = a.zipWith((a, b) => a + b, b);
+       * // Seq [ 5, 7, 9 ]
+       * ```
+       */
+      zipWith<U, Z>(
+        zipper: (value: T, otherValue: U) => Z,
+        otherCollection: Collection<any, U>
+      ): Seq.Indexed<Z>;
+      zipWith<U, V, Z>(
+        zipper: (value: T, otherValue: U, thirdValue: V) => Z,
+        otherCollection: Collection<any, U>,
+        thirdCollection: Collection<any, V>
+      ): Seq.Indexed<Z>;
+      zipWith<Z>(
+        zipper: (...any: Array<any>) => Z,
+        ...collections: Array<Collection<any, any>>
+      ): Seq.Indexed<Z>;
     }
 
 
@@ -4087,17 +4230,6 @@ declare module Immutable {
      * True if this Collection includes every value in `iter`.
      */
     isSuperset(iter: Iterable<V>): boolean;
-
-
-    /**
-     * Note: this is here as a convenience to work around an issue with
-     * TypeScript https://github.com/Microsoft/TypeScript/issues/285, but
-     * Collection does not define `size`, instead `Seq` defines `size` as
-     * nullable number, and `Collection` defines `size` as always a number.
-     *
-     * @ignore
-     */
-    readonly size: number;
   }
 }
 

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1048,6 +1048,73 @@ declare class Stack<+T> extends IndexedCollection<T> {
 
   flatten(depth?: number): Stack<any>;
   flatten(shallow?: boolean): Stack<any>;
+
+  zip<A>(
+    a: Iterable<A>,
+    ..._: []
+  ): Stack<[T, A]>;
+  zip<A, B>(
+    a: Iterable<A>,
+    b: Iterable<B>,
+    ..._: []
+  ): Stack<[T, A, B]>;
+  zip<A, B, C>(
+    a: Iterable<A>,
+    b: Iterable<B>,
+    c: Iterable<C>,
+    ..._: []
+  ): Stack<[T, A, B, C]>;
+  zip<A, B, C, D>(
+    a: Iterable<A>,
+    b: Iterable<B>,
+    c: Iterable<C>,
+    d: Iterable<D>,
+    ..._: []
+  ): Stack<[T, A, B, C, D]>;
+  zip<A, B, C, D, E>(
+    a: Iterable<A>,
+    b: Iterable<B>,
+    c: Iterable<C>,
+    d: Iterable<D>,
+    e: Iterable<E>,
+    ..._: []
+  ): Stack<[T, A, B, C, D, E]>;
+
+  zipWith<A, R>(
+    zipper: (value: T, a: A) => R,
+    a: Iterable<A>,
+    ..._: []
+  ): Stack<R>;
+  zipWith<A, B, R>(
+    zipper: (value: T, a: A, b: B) => R,
+    a: Iterable<A>,
+    b: Iterable<B>,
+    ..._: []
+  ): Stack<R>;
+  zipWith<A, B, C, R>(
+    zipper: (value: T, a: A, b: B, c: C) => R,
+    a: Iterable<A>,
+    b: Iterable<B>,
+    c: Iterable<C>,
+    ..._: []
+  ): Stack<R>;
+  zipWith<A, B, C, D, R>(
+    zipper: (value: T, a: A, b: B, c: C, d: D) => R,
+    a: Iterable<A>,
+    b: Iterable<B>,
+    c: Iterable<C>,
+    d: Iterable<D>,
+    ..._: []
+  ): Stack<R>;
+  zipWith<A, B, C, D, E, R>(
+    zipper: (value: T, a: A, b: B, c: C, d: D, e: E) => R,
+    a: Iterable<A>,
+    b: Iterable<B>,
+    c: Iterable<C>,
+    d: Iterable<D>,
+    e: Iterable<E>,
+    ..._: []
+  ): Stack<R>;
 }
 
 declare function Range(start?: number, end?: number, step?: number): IndexedSeq<number>;


### PR DESCRIPTION
This adds strictNullChecks to the ts tests, and improves type definitions such that all tests pass. Specifically this adds two significant changes to typescript defs:

* `size` is now correctly typed to not belong on Collection, exist in a nullable way on `Seq`, and exist in a non-nullable way on all concrete collection types (List, Map, etc)
* `zip` and `zipWith` is overridden in all subtypes such that the return type is more correct.

Fixes #1158