### PR TITLE
Add failing test for power-of-2 hashes

### DIFF
--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -299,7 +299,7 @@ describe('Set', () => {
     expect(set.count(x => true)).toEqual(5);
   });
 
-  it('does not stack overflow on certain hash collisions', () => {
+  it('does not infinitely recurse for large power-of-2 hashes', () => {
     class A {
       equals() {
         return false;

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -299,4 +299,27 @@ describe('Set', () => {
     expect(set.count(x => true)).toEqual(5);
   });
 
+  it('does not stack overflow on certain hash collisions', () => {
+    class A {
+      equals() {
+        return false;
+      }
+      hashCode() {
+        return 0;
+      }
+    }
+
+    class B {
+      equals() {
+        return false;
+      }
+      hashCode() {
+        return 2 ** 32;
+      }
+    }
+
+    let set = Set([1, 2, 3, 4, 5, 6, 7, 8, new A(), new B()]);
+    expect(set.size).toEqual(10);
+  });
+
 });


### PR DESCRIPTION
It seems there is an issue with hash codes that are powers of 2 above 2**32--they cause infinite recursion.

Associated issue: https://github.com/facebook/immutable-js/issues/1176