### PR TITLE
Fix typo: change 'hiearchy' to 'hierarchy'

### DIFF
--- a/dist/immutable.js.flow
+++ b/dist/immutable.js.flow
@@ -351,7 +351,7 @@ declare class SetCollection<+T> extends Collection<T, T> {
 
   concat<C>(...iters: Array<Iterable<C> | C>): SetCollection<T | C>;
 
-  // `map` and `flatMap` cannot be defined further up the hiearchy, because the
+  // `map` and `flatMap` cannot be defined further up the hierarchy, because the
   // implementation for `KeyedCollection` allows the value type to change without
   // constraining the key type. That does not work for `SetCollection` - the value
   // and key types *must* match.

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -351,7 +351,7 @@ declare class SetCollection<+T> extends Collection<T, T> {
 
   concat<C>(...iters: Array<Iterable<C> | C>): SetCollection<T | C>;
 
-  // `map` and `flatMap` cannot be defined further up the hiearchy, because the
+  // `map` and `flatMap` cannot be defined further up the hierarchy, because the
   // implementation for `KeyedCollection` allows the value type to change without
   // constraining the key type. That does not work for `SetCollection` - the value
   // and key types *must* match.


### PR DESCRIPTION
Noticed this when I was reading over the flow type definitions.