### PR TITLE
Fix genTypeDef for MappedType to make Record documentation work

### DIFF
--- a/pages/lib/genTypeDefData.js
+++ b/pages/lib/genTypeDefData.js
@@ -384,10 +384,10 @@ function DocVisitor(source) {
           members: [
             {
               index: true,
-              params: {
+              params: [{
                 name: 'key',
-                type: TypeKind.String
-              },
+                type: { k: TypeKind.String }
+              }],
               type: parseType(node.type)
             }
           ]

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2301,7 +2301,7 @@ declare module Immutable {
       /**
        * Deeply converts this Record to equivalent native JavaScript Object.
        */
-      toJS(): { [K in keyof T]: any };
+      toJS(): Object;
 
       /**
        * Shallowly converts this Record to equivalent native JavaScript Object.

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2301,7 +2301,7 @@ declare module Immutable {
       /**
        * Deeply converts this Record to equivalent native JavaScript Object.
        */
-      toJS(): Object;
+      toJS(): { [K in keyof T]: any };
 
       /**
        * Shallowly converts this Record to equivalent native JavaScript Object.


### PR DESCRIPTION
While reading the type def I noticed how the module Collection exported module Keyed etc... and I figured That we could do the same to make the Record.Instance documentation generate correctly. 

This is certainly not a definitive solution but might still be better than no documentation.