### PR TITLE
Change the has method of Record to be a type guard

### DIFF
--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -2239,7 +2239,7 @@
 
       // Reading values
 
-      has(key: string): boolean;
+      has(key: string): key is keyof T;
       get<K extends keyof T>(key: K): T[K];
 
       // Reading deep values

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -2239,7 +2239,7 @@ declare module Immutable {
 
       // Reading values
 
-      has(key: string): boolean;
+      has(key: string): key is keyof T;
       get<K extends keyof T>(key: K): T[K];
 
       // Reading deep values

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2239,7 +2239,7 @@ declare module Immutable {
 
       // Reading values
 
-      has(key: string): boolean;
+      has(key: string): key is keyof T;
       get<K extends keyof T>(key: K): T[K];
 
       // Reading deep values


### PR DESCRIPTION
This allows use of the `has` method as a type guard, while still otherwise acting as a boolean. Resolves #1230.