### PR TITLE
Inline runnable examples with RunKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ const { Map } = require('immutable')
 const map1 = Map( {a: 1, b: 2, c: 3 })
 const map2 = map1.set('b', 2)
 assert.equal(map1, map2) // uses map1.equals
-assert.identical(map1, map2) // uses ===
+assert.strictEqual(map1, map2) // uses ===
 const map3 = map1.set('b', 50)
-assert.not_equal(map1, map3) // uses map1.equals
+assert.notEqual(map1, map3) // uses map1.equals
 ```
 
 Note: As a performance optimization Immutable.js attempts to return the existing
@@ -274,7 +274,7 @@ Object.keys(obj) // [ "1" ]
 assert.equal(obj["1"], obj[1])   // "one" === "one"
 
 const map = fromJS(obj)
-assert.not_equal(map.get("1"), map.get(1)) // "one" !== undefined
+assert.notEqual(map.get("1"), map.get(1)) // "one" !== undefined
 ```
 
 Property access for JavaScript Objects first converts the key to a string, but

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ npm install immutable
 
 Then require it into any module.
 
+<!-- runkit:activate -->
 ```js
 const { Map } = require('immutable')
 const map1 = Map({ a: 1, b: 2, c: 3 })
 const map2 = map1.set('b', 50)
-map1.get('b') // 2
-map2.get('b') // 50
+map1.get('b') + " vs. " + map2.get('b') // 2 vs. 50
 ```
 
 ### Browser
@@ -99,12 +99,12 @@ lib. Include either `"target": "es2015"` or `"lib": "es2015"` in your
 `tsconfig.json`, or provide `--target es2015` or `--lib es2015` to the
 `tsc` command.
 
+<!-- runkit:activate -->
 ```js
-import { Map } from "immutable";
+const { Map } = require("immutable");
 const map1 = Map({ a: 1, b: 2, c: 3 });
 const map2 = map1.set('b', 50);
-map1.get('b'); // 2
-map2.get('b'); // 50
+map1.get('b') + " vs. " + map2.get('b') // 2 vs. 50
 ```
 
 #### Using TypeScript with Immutable.js v3 and earlier:
@@ -114,7 +114,7 @@ via relative path to the type definitions at the top of your file.
 
 ```js
 ///<reference path='./node_modules/immutable/dist/immutable.d.ts'/>
-import Immutable = require('immutable');
+import Immutable from require('immutable');
 var map1: Immutable.Map<string, number>;
 map1 = Immutable.Map({a:1, b:2, c:3});
 var map2 = map1.set('b', 50);
@@ -151,13 +151,15 @@ treat Immutable.js collections as values, it's important to use the
 `Immutable.is()` function or `.equals()` method to determine value equality
 instead of the `===` operator which determines object reference identity.
 
+<!-- runkit:activate -->
 ```js
 const { Map } = require('immutable')
 const map1 = Map( {a: 1, b: 2, c: 3 })
 const map2 = map1.set('b', 2)
-assert(map1.equals(map2) === true)
+assert.equal(map1, map2) // uses map1.equals
+assert.identical(map1, map2) // uses ===
 const map3 = map1.set('b', 50)
-assert(map1.equals(map3) === false)
+assert.not_equal(map1, map3) // uses map1.equals
 ```
 
 Note: As a performance optimization Immutable.js attempts to return the existing
@@ -173,6 +175,7 @@ to it instead of copying the entire object. Because a reference is much smaller
 than the object itself, this results in memory savings and a potential boost in
 execution speed for programs which rely on copies (such as an undo-stack).
 
+<!-- runkit:activate -->
 ```js
 const { Map } = require('immutable')
 const map1 = Map({ a: 1, b: 2, c: 3 })
@@ -201,17 +204,18 @@ the collection, like `push`, `set`, `unshift` or `splice` instead return a new
 immutable collection. Methods which return new arrays like `slice` or `concat`
 instead return new immutable collections.
 
+<!-- runkit:activate -->
 ```js
 const { List } = require('immutable')
 const list1 = List([ 1, 2 ]);
 const list2 = list1.push(3, 4, 5);
 const list3 = list2.unshift(0);
 const list4 = list1.concat(list2, list3);
-assert(list1.size === 2);
-assert(list2.size === 5);
-assert(list3.size === 6);
-assert(list4.size === 13);
-assert(list4.get(0) === 1);
+assert.equal(list1.size, 2);
+assert.equal(list2.size, 5);
+assert.equal(list3.size, 6);
+assert.equal(list4.size, 13);
+assert.equal(list4.get(0), 1);
 ```
 
 Almost all of the methods on [Array][] will be found in similar form on
@@ -219,6 +223,7 @@ Almost all of the methods on [Array][] will be found in similar form on
 found on `Immutable.Set`, including collection operations like `forEach()`
 and `map()`.
 
+<!-- runkit:activate -->
 ```js
 const { Map } = require('immutable')
 const alpha = Map({ a: 1, b: 2, c: 3, d: 4 });
@@ -232,6 +237,7 @@ Designed to inter-operate with your existing JavaScript, Immutable.js
 accepts plain JavaScript Arrays and Objects anywhere a method expects an
 `Collection`.
 
+<!-- runkit:activate -->
 ```js
 const { Map } = require('immutable')
 const map1 = Map({ a: 1, b: 2, c: 3, d: 4 })
@@ -247,6 +253,7 @@ collection methods on JavaScript Objects, which otherwise have a very sparse
 native API. Because Seq evaluates lazily and does not cache intermediate
 results, these operations can be extremely efficient.
 
+<!-- runkit:activate -->
 ```js
 const { Seq } = require('immutable')
 const myObject = { a: 1, b: 2, c: 3 }
@@ -258,17 +265,16 @@ Keep in mind, when using JS objects to construct Immutable Maps, that
 JavaScript Object properties are always strings, even if written in a quote-less
 shorthand, while Immutable Maps accept keys of any type.
 
+<!-- runkit:activate -->
 ```js
 const { fromJS } = require('immutable')
 
 const obj = { 1: "one" }
 Object.keys(obj) // [ "1" ]
-obj["1"] // "one"
-obj[1]   // "one"
+assert.equal(obj["1"], obj[1])   // "one" === "one"
 
 const map = fromJS(obj)
-map.get("1") // "one"
-map.get(1)   // undefined
+assert.not_equal(map.get("1"), map.get(1)) // "one" !== undefined
 ```
 
 Property access for JavaScript Objects first converts the key to a string, but
@@ -283,12 +289,13 @@ Objects shallowly with `toArray()` and `toObject()` or deeply with `toJS()`.
 All Immutable Collections also implement `toJSON()` allowing them to be passed
 to `JSON.stringify` directly.
 
+<!-- runkit:activate -->
 ```js
 const { Map, List } = require('immutable')
 const deep = Map({ a: 1, b: 2, c: List([ 3, 4, 5 ]) })
-deep.toObject() // { a: 1, b: 2, c: List [ 3, 4, 5 ] }
-deep.toArray() // [ 1, 2, List [ 3, 4, 5 ] ]
-deep.toJS() // { a: 1, b: 2, c: [ 3, 4, 5 ] }
+console.log(deep.toObject()) // { a: 1, b: 2, c: List [ 3, 4, 5 ] }
+console.log(deep.toArray()) // [ 1, 2, List [ 3, 4, 5 ] ]
+console.log(deep.toJS()) // { a: 1, b: 2, c: [ 3, 4, 5 ] }
 JSON.stringify(deep) // '{"a":1,"b":2,"c":[3,4,5]}'
 ```
 
@@ -322,6 +329,7 @@ Nested Structures
 The collections in Immutable.js are intended to be nested, allowing for deep
 trees of data, similar to JSON.
 
+<!-- runkit:activate -->
 ```js
 const { fromJS } = require('immutable')
 const nested = fromJS({ a: { b: { c: [ 3, 4, 5 ] } } })
@@ -332,13 +340,18 @@ A few power-tools allow for reading and operating on nested data. The
 most useful are `mergeDeep`, `getIn`, `setIn`, and `updateIn`, found on `List`,
 `Map` and `OrderedMap`.
 
+<!-- runkit:activate -->
 ```js
+const { fromJS } = require('immutable')
+const nested = fromJS({ a: { b: { c: [ 3, 4, 5 ] } } })
+
 const nested2 = nested.mergeDeep({ a: { b: { d: 6 } } })
 // Map { a: Map { b: Map { c: List [ 3, 4, 5 ], d: 6 } } }
 
-nested2.getIn([ 'a', 'b', 'd' ]) // 6
+console.log(nested2.getIn([ 'a', 'b', 'd' ])) // 6
 
 const nested3 = nested2.updateIn([ 'a', 'b', 'd' ], value => value + 1)
+console.log(nested3);
 // Map { a: Map { b: Map { c: List [ 3, 4, 5 ], d: 7 } } }
 
 const nested4 = nested3.updateIn([ 'a', 'b', 'c' ], list => list.push(6))
@@ -379,6 +392,7 @@ console.log(oddSquares.get(1)); // 9
 
 Any collection can be converted to a lazy Seq with `.toSeq()`.
 
+<!-- runkit:activate -->
 ```js
 const { Map } = require('immutable')
 const seq = Map({ a: 1, b: 2, c: 3 }).toSeq()
@@ -394,6 +408,7 @@ seq.flip().map(key => key.toUpperCase()).flip().toObject();
 
 As well as expressing logic that would otherwise seem memory-limited:
 
+<!-- runkit:activate -->
 ```js
 const { Range } = require('immutable')
 Range(1, Infinity)
@@ -415,13 +430,14 @@ Equality treats Collections as Data
 Immutable.js provides equality which treats immutable data structures as pure
 data, performing a deep equality check if necessary.
 
+<!-- runkit:activate -->
 ```js
 const { Map, is } = require('immutable')
 const map1 = Map({ a: 1, b: 2, c: 3 })
 const map2 = Map({ a: 1, b: 2, c: 3 })
-assert(map1 !== map2) // two different instances
-assert(is(map1, map2)) // have equivalent values
-assert(map1.equals(map2)) // alternatively use the equals method
+assert.equal(map1 !== map2, true) // two different instances
+assert.equal(is(map1, map2), true) // have equivalent values
+assert.equal(map1.equals(map2), true) // alternatively use the equals method
 ```
 
 `Immutable.is()` uses the same measure of equality as [Object.is][]
@@ -451,14 +467,15 @@ exactly how  Immutable.js applies complex mutations itself.
 As an example, building `list2` results in the creation of 1, not 3, new
 immutable Lists.
 
+<!-- runkit:activate -->
 ```js
 const { List } = require('immutable')
 const list1 = List([ 1, 2, 3 ]);
 const list2 = list1.withMutations(function (list) {
   list.push(4).push(5).push(6);
 });
-assert(list1.size === 3);
-assert(list2.size === 6);
+assert.equal(list1.size, 3);
+assert.equal(list2.size, 6);
 ```
 
 Note: Immutable.js also provides `asMutable` and `asImmutable`, but only

--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -116,10 +116,10 @@
    * This example converts native JS data to List and OrderedMap:
    *
    * ```js
-   * const { fromJS, Iterable } = require('immutable')
+   * const { fromJS, isIndexed } = require('immutable')
    * fromJS({ a: {b: [10, 20, 30]}, c: 40}, function (key, value, path) {
    *   console.log(key, value, path)
-   *   return Iterable.isIndexed(value) ? value.toList() : value.toOrderedMap()
+   *   return isIndexed(value) ? value.toList() : value.toOrderedMap()
    * })
    *
    * > "b", [ 10, 20, 30 ], [ "a", "b" ]
@@ -1407,7 +1407,7 @@
      * performing the deep merge at a point arrived at by following the keyPath.
      * In other words, these two lines are equivalent:
      *
-     * ```javascript
+     * ```js
      * map.updateIn(['a', 'b', 'c'], abc => abc.mergeDeep(y))
      * map.mergeDeepIn(['a', 'b', 'c'], y)
      * ```

--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -116,10 +116,10 @@
    * This example converts native JS data to List and OrderedMap:
    *
    * ```js
-   * const { fromJS, isIndexed } = require('immutable')
+   * const { fromJS, Iterable } = require('immutable')
    * fromJS({ a: {b: [10, 20, 30]}, c: 40}, function (key, value, path) {
    *   console.log(key, value, path)
-   *   return isIndexed(value) ? value.toList() : value.toOrderedMap()
+   *   return Iterable.isIndexed(value) ? value.toList() : value.toOrderedMap()
    * })
    *
    * > "b", [ 10, 20, 30 ], [ "a", "b" ]
@@ -140,15 +140,16 @@
    * JavaScript Object properties are always strings, even if written in a
    * quote-less shorthand, while Immutable Maps accept keys of any type.
    *
+   * <!-- runkit:activate
+   *      { "preamble": "const { Map } = require(\"immutable\");" }
+   * -->
    * ```js
    * let obj = { 1: "one" };
    * Object.keys(obj); // [ "1" ]
-   * obj["1"]; // "one"
-   * obj[1];   // "one"
+   * assert.equal(obj["1"], obj[1]); // "one" === "one"
    *
    * let map = Map(obj);
-   * map.get("1"); // "one"
-   * map.get(1);   // undefined
+   * assert.notEqual(map.get("1"), map.get(1)); // "one" !== undefined
    * ```
    *
    * Property access for JavaScript Objects first converts the key to a string,
@@ -176,13 +177,14 @@
    * It's used throughout Immutable when checking for equality, including `Map`
    * key equality and `Set` membership.
    *
+   * <!-- runkit:activate -->
    * ```js
-   * import { Map, is } from 'immutable'
+   * const { Map, is } = require('immutable')
    * const map1 = Map({ a: 1, b: 1, c: 1 })
    * const map2 = Map({ a: 1, b: 1, c: 1 })
-   * assert(map1 !== map2)
-   * assert(Object.is(map1, map2) === false)
-   * assert(is(map1, map2) === true)
+   * assert.equal(map1 !== map2, true)
+   * assert.equal(Object.is(map1, map2), false)
+   * assert.equal(is(map1, map2), true)
    * ```
    *
    * `is()` compares primitive types like strings and numbers, Immutable.js
@@ -327,12 +329,15 @@
      * and is used when adding this to a `Set` or as a key in a `Map`, enabling
      * lookup via a different instance.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List, Set } = require(\"immutable\")" }
+     * -->
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 1, 2, 3 ]);
-     * assert(a !== b); // different instances
+     * assert.notStrictEqual(a, b); // different instances
      * const set = Set([ a ]);
-     * assert(set.has(b) === true);
+     * assert.equal(set.has(b), true);
      * ```
      *
      * If two values have the same `hashCode`, they are [not guaranteed
@@ -363,6 +368,9 @@
     /**
      * True if the provided value is a List
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List.isList([]); // false
      * List.isList(List()); // true
@@ -373,6 +381,9 @@
     /**
      * Creates a new List containing `values`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List.of(1, 2, 3, 4)
      * // List [ 1, 2, 3, 4 ]
@@ -380,6 +391,9 @@
      *
      * Note: Values are not altered or converted in any way.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List.of({x:1}, 2, [3], 4)
      * // List [ { x: 1 }, 2, [ 3 ], 4 ]
@@ -392,6 +406,7 @@
    * Create a new immutable List containing the values of the provided
    * collection-like.
    *
+   * <!-- runkit:activate -->
    * ```js
    * const { List, Set } = require('immutable')
    *
@@ -438,6 +453,9 @@
      * If `index` larger than `size`, the returned List's `size` will be large
      * enough to include the `index`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const originalList = List([ 0 ]);
      * // List [ 0 ]
@@ -468,6 +486,9 @@
      *
      * Note: `delete` cannot be safely used in IE8
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 0, 1, 2, 3, 4 ]).delete(0);
      * // List [ 1, 2, 3, 4 ]
@@ -486,6 +507,9 @@
      *
      * This is synonymous with `list.splice(index, 0, value)`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 0, 1, 2, 3, 4 ]).insert(6, 5)
      * // List [ 0, 1, 2, 3, 4, 5 ]
@@ -498,6 +522,9 @@
     /**
      * Returns a new List with 0 size and no values.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 1, 2, 3, 4 ]).clear()
      * // List []
@@ -511,6 +538,9 @@
      * Returns a new List with the provided `values` appended, starting at this
      * List's `size`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 1, 2, 3, 4 ]).push(5)
      * // List [ 1, 2, 3, 4, 5 ]
@@ -541,6 +571,9 @@
      * Returns a new List with the provided `values` prepended, shifting other
      * values ahead to higher indices.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 2, 3, 4]).unshift(1);
      * // List [ 1, 2, 3, 4 ]
@@ -558,6 +591,9 @@
      * List rather than the removed value. Use `first()` to get the first
      * value in this List.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 0, 1, 2, 3, 4 ]).shift();
      * // List [ 1, 2, 3, 4 ]
@@ -576,6 +612,9 @@
      * `index` may be a negative number, which indexes back from the end of the
      * List. `v.update(-1)` updates the last item in the List.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const list = List([ 'a', 'b', 'c' ])
      * const result = list.update(2, val => val.toUpperCase())
@@ -587,6 +626,9 @@
      *
      * For example, to sum a List after mapping and filtering:
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * function sum(collection) {
      *   return collection.reduce((sum, x) => sum + x, 0)
@@ -662,8 +704,9 @@
      * Index numbers are used as keys to determine the path to follow in
      * the List.
      *
+     * <!-- runkit:activate -->
      * ```js
-     * const { List } = require('immutable');
+     * const { List } = require("immutable")
      * const list = List([ 0, 1, 2, List([ 3, 4 ])])
      * list.setIn([3, 0], 999);
      * // List [ 0, 1, 2, List [ 999, 4 ] ]
@@ -677,8 +720,9 @@
      * Returns a new List having removed the value at this `keyPath`. If any
      * keys in `keyPath` do not exist, no change will occur.
      *
+     * <!-- runkit:activate -->
      * ```js
-     * const { List } = require('immutable');
+     * const { List } = require("immutable")
      * const list = List([ 0, 1, 2, List([ 3, 4 ])])
      * list.deleteIn([3, 0]);
      * // List [ 0, 1, 2, List [ 4 ] ]
@@ -751,6 +795,9 @@
      * Returns a new List with values passed through a
      * `mapper` function.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 1, 2 ]).map(x => 10 * x)
      * // List [ 10, 20 ]
@@ -795,6 +842,9 @@
      *
      * Like `zipWith`, but using the default `zipper`: creating an `Array`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 4, 5, 6 ]);
@@ -807,6 +857,9 @@
      * Returns a List "zipped" with the provided collections by using a
      * custom `zipper` function.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 4, 5, 6 ]);
@@ -844,6 +897,7 @@
    * Immutable collections are treated as values, any Immutable collection may
    * be used as a key.
    *
+   * <!-- runkit:activate -->
    * ```js
    * const { Map, List } = require('immutable');
    * Map().set(List([ 1 ]), 'listofone').get(List([ 1 ]));
@@ -872,6 +926,7 @@
     /**
      * Creates a new Map from alternating keys and values
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * Map.of(
@@ -893,6 +948,7 @@
    * Created with the same key value pairs as the provided Collection.Keyed or
    * JavaScript Object or expects a Collection of [K, V] tuple entries.
    *
+   * <!-- runkit:activate -->
    * ```js
    * const { Map } = require('immutable')
    * Map({ key: "value" })
@@ -903,15 +959,16 @@
    * JavaScript Object properties are always strings, even if written in a
    * quote-less shorthand, while Immutable Maps accept keys of any type.
    *
+   * <!-- runkit:activate
+   *      { "preamble": "const { Map } = require(\"immutable\");" }
+   * -->
    * ```js
    * let obj = { 1: "one" }
    * Object.keys(obj) // [ "1" ]
-   * obj["1"] // "one"
-   * obj[1]   // "one"
+   * assert.equal(obj["1"], obj[1]) // "one" === "one"
    *
    * let map = Map(obj)
-   * map.get("1") // "one"
-   * map.get(1)   // undefined
+   * assert.notEqual(map.get("1"), map.get(1)) // "one" !== undefined
    * ```
    *
    * Property access for JavaScript Objects first converts the key to a string,
@@ -937,6 +994,7 @@
      * Returns a new Map also containing the new key, value pair. If an equivalent
      * key already exists in this Map, it will be replaced.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const originalMap = Map()
@@ -961,6 +1019,7 @@
      * Note: `delete` cannot be safely used in IE8, but is provided to mirror
      * the ES6 collection API.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const originalMap = Map({
@@ -999,6 +1058,7 @@
     /**
      * Returns a new Map containing no keys or values.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * Map({ key: 'value' }).clear()
@@ -1015,6 +1075,7 @@
      *
      * Similar to: `map.set(key, updater(map.get(key)))`.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const aMap = Map({ key: 'value' })
@@ -1026,6 +1087,9 @@
      * structure of data. For example, in order to `.push()` onto a nested `List`,
      * `update` and `push` can be used together:
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map, List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ nestedList: List([ 1, 2, 3 ]) })
      * const newMap = aMap.update('nestedList', list => list.push(4))
@@ -1035,6 +1099,9 @@
      * When a `notSetValue` is provided, it is provided to the `updater`
      * function when the value at the key does not exist in the Map.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ key: 'value' })
      * const newMap = aMap.update('noKey', 'no value', value => value + value)
@@ -1045,11 +1112,14 @@
      * with, then no change will occur. This is still true if `notSetValue`
      * is provided.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ apples: 10 })
      * const newMap = aMap.update('oranges', 0, val => val)
      * // Map { "apples": 10 }
-     * assert(newMap === map);
+     * assert.strictEqual(newMap, map);
      * ```
      *
      * For code using ES2015 or later, using `notSetValue` is discourged in
@@ -1058,6 +1128,9 @@
      *
      * The previous example behaves differently when written with default values:
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ apples: 10 })
      * const newMap = aMap.update('oranges', (val = 0) => val)
@@ -1067,6 +1140,9 @@
      * If no key is provided, then the `updater` function return value is
      * returned as well.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ key: 'value' })
      * const result = aMap.update(aMap => aMap.get('key'))
@@ -1078,6 +1154,9 @@
      *
      * For example, to sum the values in a Map
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * function sum(collection) {
      *   return collection.reduce((sum, x) => sum + x, 0)
@@ -1107,6 +1186,7 @@
      * Collection but includes non-collection JS objects or arrays, those nested
      * values will be preserved.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const one = Map({ a: 10, b: 20, c: 30 })
@@ -1124,6 +1204,7 @@
      * the provided Collections (or JS objects) into this Map, but uses the
      * `merger` function for dealing with conflicts.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const one = Map({ a: 10, b: 20, c: 30 })
@@ -1145,6 +1226,7 @@
      * Like `merge()`, but when two Collections conflict, it merges them as well,
      * recursing deeply through the nested data.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const one = Map({ a: Map({ x: 10, y: 10 }), b: Map({ x: 20, y: 50 }) })
@@ -1165,6 +1247,7 @@
      * Like `mergeDeep()`, but when two non-Collections conflict, it uses the
      * `merger` function to determine the resulting value.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const one = Map({ a: Map({ x: 10, y: 10 }), b: Map({ x: 20, y: 50 }) })
@@ -1191,6 +1274,7 @@
      * Returns a new Map having set `value` at this `keyPath`. If any keys in
      * `keyPath` do not exist, a new immutable Map will be created at that key.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const originalMap = Map({
@@ -1248,6 +1332,7 @@
      * structure of data. For example, in order to `.push()` onto a nested `List`,
      * `updateIn` and `push` can be used together:
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map, List } = require('immutable')
      * const map = Map({ inMap: Map({ inList: List([ 1, 2, 3 ]) }) })
@@ -1260,6 +1345,9 @@
      * value, the `updater` function will be called with `notSetValue`, if
      * provided, otherwise `undefined`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\")" }     
+     * -->
      * ```js
      * const map = Map({ a: Map({ b: Map({ c: 10 }) }) })
      * const newMap = map.updateIn(['a', 'b', 'c'], val => val * 2)
@@ -1269,11 +1357,14 @@
      * If the `updater` function returns the same value it was called with, then
      * no change will occur. This is still true if `notSetValue` is provided.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\")" }     
+     * -->
      * ```js
      * const map = Map({ a: Map({ b: Map({ c: 10 }) }) })
      * const newMap = map.updateIn(['a', 'b', 'x'], 100, val => val)
      * // Map { "a": Map { "b": Map { "c": 10 } } }
-     * assert(newMap === map)
+     * assert.strictEqual(newMap, aMap)
      * ```
      *
      * For code using ES2015 or later, using `notSetValue` is discourged in
@@ -1282,6 +1373,9 @@
      *
      * The previous example behaves differently when written with default values:
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\")" }     
+     * -->
      * ```js
      * const map = Map({ a: Map({ b: Map({ c: 10 }) }) })
      * const newMap = map.updateIn(['a', 'b', 'x'], (val = 100) => val)
@@ -1313,7 +1407,7 @@
      * performing the deep merge at a point arrived at by following the keyPath.
      * In other words, these two lines are equivalent:
      *
-     * ```js
+     * ```javascript
      * map.updateIn(['a', 'b', 'c'], abc => abc.mergeDeep(y))
      * map.mergeDeepIn(['a', 'b', 'c'], y)
      * ```
@@ -1337,14 +1431,15 @@
      *
      * As an example, this results in the creation of 2, not 4, new Maps:
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const map1 = Map()
      * const map2 = map1.withMutations(map => {
      *   map.set('a', 1).set('b', 2).set('c', 3)
      * })
-     * assert(map1.size === 0)
-     * assert(map2.size === 3)
+     * assert.equal(map1.size, 0)
+     * assert.equal(map2.size, 3)
      * ```
      *
      * Note: Not all methods can be used on a mutable collection or within
@@ -1606,7 +1701,7 @@
      * collection of other sets.
      *
      * ```js
-     * * const { Set } = require('immutable')
+     * const { Set } = require('immutable')
      * const unioned = Set.union([
      *   Set([ 'a', 'b', 'c' ])
      *   Set([ 'c', 'a', 't' ])
@@ -2930,6 +3025,7 @@
        * Returns a new Collection.Keyed of the same type where the keys and values
        * have been flipped.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { Map } = require('immutable')
        * Map({ a: 'z', b: 'y' }).flip()
@@ -2966,6 +3062,7 @@
        * Returns a new Collection.Keyed of the same type with keys passed through
        * a `mapper` function.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { Map } = require('immutable')
        * Map({ a: 1, b: 2 }).mapKeys(x => x.toUpperCase())
@@ -2984,6 +3081,7 @@
        * Returns a new Collection.Keyed of the same type with entries
        * ([key, value] tuples) passed through a `mapper` function.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { Map } = require('immutable')
        * Map({ a: 1, b: 2 })
@@ -3105,6 +3203,7 @@
        * The resulting Collection includes the first item from each, then the
        * second from each, etc.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { List } = require('immutable')
        * List([ 1, 2, 3 ]).interleave(List([ 'A', 'B', 'C' ]))
@@ -3113,6 +3212,9 @@
        *
        * The shortest Collection stops interleave.
        *
+       * <!-- runkit:activate
+       *      { "preamble": "const { List } = require(\"immutable\")" }
+       * -->
        * ```js
        * List([ 1, 2, 3 ]).interleave(
        *   List([ 'A', 'B' ]),
@@ -3131,6 +3233,7 @@
        * `index` may be a negative number, which indexes back from the end of the
        * Collection. `s.splice(-2)` splices after the second to last item.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { List } = require('immutable')
        * List([ 'a', 'b', 'c', 'd' ]).splice(1, 2, 'q', 'r', 's')
@@ -3149,6 +3252,10 @@
        *
        * Like `zipWith`, but using the default `zipper`: creating an `Array`.
        *
+       *
+       * <!-- runkit:activate
+       *      { "preamble": "const { List } = require(\"immutable\")" }
+       * -->
        * ```js
        * const a = List([ 1, 2, 3 ]);
        * const b = List([ 4, 5, 6 ]);
@@ -3161,6 +3268,9 @@
        * Returns a Collection of the same type "zipped" with the provided
        * collections by using a custom `zipper` function.
        *
+       * <!-- runkit:activate
+       *      { "preamble": "const { List } = require(\"immutable\")" }
+       * -->
        * ```js
        * const a = List([ 1, 2, 3 ]);
        * const b = List([ 4, 5, 6 ]);
@@ -3405,12 +3515,15 @@
      * and is used when adding this to a `Set` or as a key in a `Map`, enabling
      * lookup via a different instance.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Set,  List } = require(\"immutable\")" }
+     * -->
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 1, 2, 3 ]);
-     * assert(a !== b); // different instances
+     * assert.notStrictEqual(a, b); // different instances
      * const set = Set([ a ]);
-     * assert(set.has(b) === true);
+     * assert.equal(set.has(b), true);
      * ```
      *
      * If two values have the same `hashCode`, they are [not guaranteed
@@ -3574,6 +3687,7 @@
      * `collection.toList()` discards the keys and creates a list of only the
      * values, whereas `List(collection)` creates a list of entry tuples.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map, List } = require('immutable')
      * var myMap = Map({ a: 'Apple', b: 'Banana' })
@@ -3708,6 +3822,7 @@
      * Returns a new Collection of the same type with only the entries for which
      * the `predicate` function returns true.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * Map({ a: 1, b: 2, c: 3, d: 4}).filter(x => x % 2 === 0)
@@ -3730,6 +3845,7 @@
      * Returns a new Collection of the same type with only the entries for which
      * the `predicate` function returns false.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * Map({ a: 1, b: 2, c: 3, d: 4}).filterNot(x => x % 2 === 0)
@@ -3887,6 +4003,7 @@
      * Returns a new Collection of the same type which includes entries starting
      * from when `predicate` first returns false.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { List } = require('immutable')
      * List([ 'dog', 'frog', 'cat', 'hat', 'god' ])
@@ -3903,6 +4020,7 @@
      * Returns a new Collection of the same type which includes entries starting
      * from when `predicate` first returns true.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { List } = require('immutable')
      * List([ 'dog', 'frog', 'cat', 'hat', 'god' ])
@@ -3931,6 +4049,7 @@
      * Returns a new Collection of the same type which includes entries from this
      * Collection as long as the `predicate` returns true.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { List } = require('immutable')
      * List([ 'dog', 'frog', 'cat', 'hat', 'god' ])
@@ -3947,6 +4066,7 @@
      * Returns a new Collection of the same type which includes entries from this
      * Collection as long as the `predicate` returns false.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { List } = require('immutable')
      * List([ 'dog', 'frog', 'cat', 'hat', 'god' ])

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -116,10 +116,10 @@ declare module Immutable {
    * This example converts native JS data to List and OrderedMap:
    *
    * ```js
-   * const { fromJS, isIndexed } = require('immutable')
+   * const { fromJS, Iterable } = require('immutable')
    * fromJS({ a: {b: [10, 20, 30]}, c: 40}, function (key, value, path) {
    *   console.log(key, value, path)
-   *   return isIndexed(value) ? value.toList() : value.toOrderedMap()
+   *   return Iterable.isIndexed(value) ? value.toList() : value.toOrderedMap()
    * })
    *
    * > "b", [ 10, 20, 30 ], [ "a", "b" ]
@@ -140,15 +140,16 @@ declare module Immutable {
    * JavaScript Object properties are always strings, even if written in a
    * quote-less shorthand, while Immutable Maps accept keys of any type.
    *
+   * <!-- runkit:activate
+   *      { "preamble": "const { Map } = require(\"immutable\");" }
+   * -->
    * ```js
    * let obj = { 1: "one" };
    * Object.keys(obj); // [ "1" ]
-   * obj["1"]; // "one"
-   * obj[1];   // "one"
+   * assert.equal(obj["1"], obj[1]); // "one" === "one"
    *
    * let map = Map(obj);
-   * map.get("1"); // "one"
-   * map.get(1);   // undefined
+   * assert.notEqual(map.get("1"), map.get(1)); // "one" !== undefined
    * ```
    *
    * Property access for JavaScript Objects first converts the key to a string,
@@ -176,13 +177,14 @@ declare module Immutable {
    * It's used throughout Immutable when checking for equality, including `Map`
    * key equality and `Set` membership.
    *
+   * <!-- runkit:activate -->
    * ```js
-   * import { Map, is } from 'immutable'
+   * const { Map, is } = require('immutable')
    * const map1 = Map({ a: 1, b: 1, c: 1 })
    * const map2 = Map({ a: 1, b: 1, c: 1 })
-   * assert(map1 !== map2)
-   * assert(Object.is(map1, map2) === false)
-   * assert(is(map1, map2) === true)
+   * assert.equal(map1 !== map2, true)
+   * assert.equal(Object.is(map1, map2), false)
+   * assert.equal(is(map1, map2), true)
    * ```
    *
    * `is()` compares primitive types like strings and numbers, Immutable.js
@@ -327,12 +329,15 @@ declare module Immutable {
      * and is used when adding this to a `Set` or as a key in a `Map`, enabling
      * lookup via a different instance.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List, Set } = require(\"immutable\")" }
+     * -->
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 1, 2, 3 ]);
-     * assert(a !== b); // different instances
+     * assert.notStrictEqual(a, b); // different instances
      * const set = Set([ a ]);
-     * assert(set.has(b) === true);
+     * assert.equal(set.has(b), true);
      * ```
      *
      * If two values have the same `hashCode`, they are [not guaranteed
@@ -363,6 +368,9 @@ declare module Immutable {
     /**
      * True if the provided value is a List
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List.isList([]); // false
      * List.isList(List()); // true
@@ -373,6 +381,9 @@ declare module Immutable {
     /**
      * Creates a new List containing `values`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List.of(1, 2, 3, 4)
      * // List [ 1, 2, 3, 4 ]
@@ -380,6 +391,9 @@ declare module Immutable {
      *
      * Note: Values are not altered or converted in any way.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List.of({x:1}, 2, [3], 4)
      * // List [ { x: 1 }, 2, [ 3 ], 4 ]
@@ -392,6 +406,7 @@ declare module Immutable {
    * Create a new immutable List containing the values of the provided
    * collection-like.
    *
+   * <!-- runkit:activate -->
    * ```js
    * const { List, Set } = require('immutable')
    *
@@ -438,6 +453,9 @@ declare module Immutable {
      * If `index` larger than `size`, the returned List's `size` will be large
      * enough to include the `index`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const originalList = List([ 0 ]);
      * // List [ 0 ]
@@ -468,6 +486,9 @@ declare module Immutable {
      *
      * Note: `delete` cannot be safely used in IE8
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 0, 1, 2, 3, 4 ]).delete(0);
      * // List [ 1, 2, 3, 4 ]
@@ -486,6 +507,9 @@ declare module Immutable {
      *
      * This is synonymous with `list.splice(index, 0, value)`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 0, 1, 2, 3, 4 ]).insert(6, 5)
      * // List [ 0, 1, 2, 3, 4, 5 ]
@@ -498,6 +522,9 @@ declare module Immutable {
     /**
      * Returns a new List with 0 size and no values.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 1, 2, 3, 4 ]).clear()
      * // List []
@@ -511,6 +538,9 @@ declare module Immutable {
      * Returns a new List with the provided `values` appended, starting at this
      * List's `size`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 1, 2, 3, 4 ]).push(5)
      * // List [ 1, 2, 3, 4, 5 ]
@@ -541,6 +571,9 @@ declare module Immutable {
      * Returns a new List with the provided `values` prepended, shifting other
      * values ahead to higher indices.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 2, 3, 4]).unshift(1);
      * // List [ 1, 2, 3, 4 ]
@@ -558,6 +591,9 @@ declare module Immutable {
      * List rather than the removed value. Use `first()` to get the first
      * value in this List.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 0, 1, 2, 3, 4 ]).shift();
      * // List [ 1, 2, 3, 4 ]
@@ -576,6 +612,9 @@ declare module Immutable {
      * `index` may be a negative number, which indexes back from the end of the
      * List. `v.update(-1)` updates the last item in the List.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const list = List([ 'a', 'b', 'c' ])
      * const result = list.update(2, val => val.toUpperCase())
@@ -587,6 +626,9 @@ declare module Immutable {
      *
      * For example, to sum a List after mapping and filtering:
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * function sum(collection) {
      *   return collection.reduce((sum, x) => sum + x, 0)
@@ -662,8 +704,9 @@ declare module Immutable {
      * Index numbers are used as keys to determine the path to follow in
      * the List.
      *
+     * <!-- runkit:activate -->
      * ```js
-     * const { List } = require('immutable');
+     * const { List } = require("immutable")
      * const list = List([ 0, 1, 2, List([ 3, 4 ])])
      * list.setIn([3, 0], 999);
      * // List [ 0, 1, 2, List [ 999, 4 ] ]
@@ -677,8 +720,9 @@ declare module Immutable {
      * Returns a new List having removed the value at this `keyPath`. If any
      * keys in `keyPath` do not exist, no change will occur.
      *
+     * <!-- runkit:activate -->
      * ```js
-     * const { List } = require('immutable');
+     * const { List } = require("immutable")
      * const list = List([ 0, 1, 2, List([ 3, 4 ])])
      * list.deleteIn([3, 0]);
      * // List [ 0, 1, 2, List [ 4 ] ]
@@ -751,6 +795,9 @@ declare module Immutable {
      * Returns a new List with values passed through a
      * `mapper` function.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 1, 2 ]).map(x => 10 * x)
      * // List [ 10, 20 ]
@@ -795,6 +842,9 @@ declare module Immutable {
      *
      * Like `zipWith`, but using the default `zipper`: creating an `Array`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 4, 5, 6 ]);
@@ -807,6 +857,9 @@ declare module Immutable {
      * Returns a List "zipped" with the provided collections by using a
      * custom `zipper` function.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 4, 5, 6 ]);
@@ -844,6 +897,7 @@ declare module Immutable {
    * Immutable collections are treated as values, any Immutable collection may
    * be used as a key.
    *
+   * <!-- runkit:activate -->
    * ```js
    * const { Map, List } = require('immutable');
    * Map().set(List([ 1 ]), 'listofone').get(List([ 1 ]));
@@ -872,6 +926,7 @@ declare module Immutable {
     /**
      * Creates a new Map from alternating keys and values
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * Map.of(
@@ -893,6 +948,7 @@ declare module Immutable {
    * Created with the same key value pairs as the provided Collection.Keyed or
    * JavaScript Object or expects a Collection of [K, V] tuple entries.
    *
+   * <!-- runkit:activate -->
    * ```js
    * const { Map } = require('immutable')
    * Map({ key: "value" })
@@ -903,15 +959,16 @@ declare module Immutable {
    * JavaScript Object properties are always strings, even if written in a
    * quote-less shorthand, while Immutable Maps accept keys of any type.
    *
+   * <!-- runkit:activate
+   *      { "preamble": "const { Map } = require(\"immutable\");" }
+   * -->
    * ```js
    * let obj = { 1: "one" }
    * Object.keys(obj) // [ "1" ]
-   * obj["1"] // "one"
-   * obj[1]   // "one"
+   * assert.equal(obj["1"], obj[1]) // "one" === "one"
    *
    * let map = Map(obj)
-   * map.get("1") // "one"
-   * map.get(1)   // undefined
+   * assert.notEqual(map.get("1"), map.get(1)) // "one" !== undefined
    * ```
    *
    * Property access for JavaScript Objects first converts the key to a string,
@@ -937,6 +994,7 @@ declare module Immutable {
      * Returns a new Map also containing the new key, value pair. If an equivalent
      * key already exists in this Map, it will be replaced.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const originalMap = Map()
@@ -961,6 +1019,7 @@ declare module Immutable {
      * Note: `delete` cannot be safely used in IE8, but is provided to mirror
      * the ES6 collection API.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const originalMap = Map({
@@ -999,6 +1058,7 @@ declare module Immutable {
     /**
      * Returns a new Map containing no keys or values.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * Map({ key: 'value' }).clear()
@@ -1015,6 +1075,7 @@ declare module Immutable {
      *
      * Similar to: `map.set(key, updater(map.get(key)))`.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const aMap = Map({ key: 'value' })
@@ -1026,6 +1087,9 @@ declare module Immutable {
      * structure of data. For example, in order to `.push()` onto a nested `List`,
      * `update` and `push` can be used together:
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map, List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ nestedList: List([ 1, 2, 3 ]) })
      * const newMap = aMap.update('nestedList', list => list.push(4))
@@ -1035,6 +1099,9 @@ declare module Immutable {
      * When a `notSetValue` is provided, it is provided to the `updater`
      * function when the value at the key does not exist in the Map.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ key: 'value' })
      * const newMap = aMap.update('noKey', 'no value', value => value + value)
@@ -1045,11 +1112,14 @@ declare module Immutable {
      * with, then no change will occur. This is still true if `notSetValue`
      * is provided.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ apples: 10 })
      * const newMap = aMap.update('oranges', 0, val => val)
      * // Map { "apples": 10 }
-     * assert(newMap === map);
+     * assert.strictEqual(newMap, map);
      * ```
      *
      * For code using ES2015 or later, using `notSetValue` is discourged in
@@ -1058,6 +1128,9 @@ declare module Immutable {
      *
      * The previous example behaves differently when written with default values:
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ apples: 10 })
      * const newMap = aMap.update('oranges', (val = 0) => val)
@@ -1067,6 +1140,9 @@ declare module Immutable {
      * If no key is provided, then the `updater` function return value is
      * returned as well.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ key: 'value' })
      * const result = aMap.update(aMap => aMap.get('key'))
@@ -1078,6 +1154,9 @@ declare module Immutable {
      *
      * For example, to sum the values in a Map
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * function sum(collection) {
      *   return collection.reduce((sum, x) => sum + x, 0)
@@ -1107,6 +1186,7 @@ declare module Immutable {
      * Collection but includes non-collection JS objects or arrays, those nested
      * values will be preserved.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const one = Map({ a: 10, b: 20, c: 30 })
@@ -1124,6 +1204,7 @@ declare module Immutable {
      * the provided Collections (or JS objects) into this Map, but uses the
      * `merger` function for dealing with conflicts.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const one = Map({ a: 10, b: 20, c: 30 })
@@ -1145,6 +1226,7 @@ declare module Immutable {
      * Like `merge()`, but when two Collections conflict, it merges them as well,
      * recursing deeply through the nested data.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const one = Map({ a: Map({ x: 10, y: 10 }), b: Map({ x: 20, y: 50 }) })
@@ -1165,6 +1247,7 @@ declare module Immutable {
      * Like `mergeDeep()`, but when two non-Collections conflict, it uses the
      * `merger` function to determine the resulting value.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const one = Map({ a: Map({ x: 10, y: 10 }), b: Map({ x: 20, y: 50 }) })
@@ -1191,6 +1274,7 @@ declare module Immutable {
      * Returns a new Map having set `value` at this `keyPath`. If any keys in
      * `keyPath` do not exist, a new immutable Map will be created at that key.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const originalMap = Map({
@@ -1248,6 +1332,7 @@ declare module Immutable {
      * structure of data. For example, in order to `.push()` onto a nested `List`,
      * `updateIn` and `push` can be used together:
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map, List } = require('immutable')
      * const map = Map({ inMap: Map({ inList: List([ 1, 2, 3 ]) }) })
@@ -1260,6 +1345,9 @@ declare module Immutable {
      * value, the `updater` function will be called with `notSetValue`, if
      * provided, otherwise `undefined`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\")" }     
+     * -->
      * ```js
      * const map = Map({ a: Map({ b: Map({ c: 10 }) }) })
      * const newMap = map.updateIn(['a', 'b', 'c'], val => val * 2)
@@ -1269,11 +1357,14 @@ declare module Immutable {
      * If the `updater` function returns the same value it was called with, then
      * no change will occur. This is still true if `notSetValue` is provided.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\")" }     
+     * -->
      * ```js
      * const map = Map({ a: Map({ b: Map({ c: 10 }) }) })
      * const newMap = map.updateIn(['a', 'b', 'x'], 100, val => val)
      * // Map { "a": Map { "b": Map { "c": 10 } } }
-     * assert(newMap === map)
+     * assert.strictEqual(newMap, aMap)
      * ```
      *
      * For code using ES2015 or later, using `notSetValue` is discourged in
@@ -1282,6 +1373,9 @@ declare module Immutable {
      *
      * The previous example behaves differently when written with default values:
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\")" }     
+     * -->
      * ```js
      * const map = Map({ a: Map({ b: Map({ c: 10 }) }) })
      * const newMap = map.updateIn(['a', 'b', 'x'], (val = 100) => val)
@@ -1313,7 +1407,7 @@ declare module Immutable {
      * performing the deep merge at a point arrived at by following the keyPath.
      * In other words, these two lines are equivalent:
      *
-     * ```js
+     * ```javascript
      * map.updateIn(['a', 'b', 'c'], abc => abc.mergeDeep(y))
      * map.mergeDeepIn(['a', 'b', 'c'], y)
      * ```
@@ -1337,14 +1431,15 @@ declare module Immutable {
      *
      * As an example, this results in the creation of 2, not 4, new Maps:
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const map1 = Map()
      * const map2 = map1.withMutations(map => {
      *   map.set('a', 1).set('b', 2).set('c', 3)
      * })
-     * assert(map1.size === 0)
-     * assert(map2.size === 3)
+     * assert.equal(map1.size, 0)
+     * assert.equal(map2.size, 3)
      * ```
      *
      * Note: Not all methods can be used on a mutable collection or within
@@ -1606,7 +1701,7 @@ declare module Immutable {
      * collection of other sets.
      *
      * ```js
-     * * const { Set } = require('immutable')
+     * const { Set } = require('immutable')
      * const unioned = Set.union([
      *   Set([ 'a', 'b', 'c' ])
      *   Set([ 'c', 'a', 't' ])
@@ -2930,6 +3025,7 @@ declare module Immutable {
        * Returns a new Collection.Keyed of the same type where the keys and values
        * have been flipped.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { Map } = require('immutable')
        * Map({ a: 'z', b: 'y' }).flip()
@@ -2966,6 +3062,7 @@ declare module Immutable {
        * Returns a new Collection.Keyed of the same type with keys passed through
        * a `mapper` function.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { Map } = require('immutable')
        * Map({ a: 1, b: 2 }).mapKeys(x => x.toUpperCase())
@@ -2984,6 +3081,7 @@ declare module Immutable {
        * Returns a new Collection.Keyed of the same type with entries
        * ([key, value] tuples) passed through a `mapper` function.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { Map } = require('immutable')
        * Map({ a: 1, b: 2 })
@@ -3105,6 +3203,7 @@ declare module Immutable {
        * The resulting Collection includes the first item from each, then the
        * second from each, etc.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { List } = require('immutable')
        * List([ 1, 2, 3 ]).interleave(List([ 'A', 'B', 'C' ]))
@@ -3113,6 +3212,9 @@ declare module Immutable {
        *
        * The shortest Collection stops interleave.
        *
+       * <!-- runkit:activate
+       *      { "preamble": "const { List } = require(\"immutable\")" }
+       * -->
        * ```js
        * List([ 1, 2, 3 ]).interleave(
        *   List([ 'A', 'B' ]),
@@ -3131,6 +3233,7 @@ declare module Immutable {
        * `index` may be a negative number, which indexes back from the end of the
        * Collection. `s.splice(-2)` splices after the second to last item.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { List } = require('immutable')
        * List([ 'a', 'b', 'c', 'd' ]).splice(1, 2, 'q', 'r', 's')
@@ -3149,6 +3252,10 @@ declare module Immutable {
        *
        * Like `zipWith`, but using the default `zipper`: creating an `Array`.
        *
+       *
+       * <!-- runkit:activate
+       *      { "preamble": "const { List } = require(\"immutable\")" }
+       * -->
        * ```js
        * const a = List([ 1, 2, 3 ]);
        * const b = List([ 4, 5, 6 ]);
@@ -3161,6 +3268,9 @@ declare module Immutable {
        * Returns a Collection of the same type "zipped" with the provided
        * collections by using a custom `zipper` function.
        *
+       * <!-- runkit:activate
+       *      { "preamble": "const { List } = require(\"immutable\")" }
+       * -->
        * ```js
        * const a = List([ 1, 2, 3 ]);
        * const b = List([ 4, 5, 6 ]);
@@ -3405,12 +3515,15 @@ declare module Immutable {
      * and is used when adding this to a `Set` or as a key in a `Map`, enabling
      * lookup via a different instance.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Set,  List } = require(\"immutable\")" }
+     * -->
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 1, 2, 3 ]);
-     * assert(a !== b); // different instances
+     * assert.notStrictEqual(a, b); // different instances
      * const set = Set([ a ]);
-     * assert(set.has(b) === true);
+     * assert.equal(set.has(b), true);
      * ```
      *
      * If two values have the same `hashCode`, they are [not guaranteed
@@ -3574,6 +3687,7 @@ declare module Immutable {
      * `collection.toList()` discards the keys and creates a list of only the
      * values, whereas `List(collection)` creates a list of entry tuples.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map, List } = require('immutable')
      * var myMap = Map({ a: 'Apple', b: 'Banana' })
@@ -3708,6 +3822,7 @@ declare module Immutable {
      * Returns a new Collection of the same type with only the entries for which
      * the `predicate` function returns true.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * Map({ a: 1, b: 2, c: 3, d: 4}).filter(x => x % 2 === 0)
@@ -3730,6 +3845,7 @@ declare module Immutable {
      * Returns a new Collection of the same type with only the entries for which
      * the `predicate` function returns false.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * Map({ a: 1, b: 2, c: 3, d: 4}).filterNot(x => x % 2 === 0)
@@ -3887,6 +4003,7 @@ declare module Immutable {
      * Returns a new Collection of the same type which includes entries starting
      * from when `predicate` first returns false.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { List } = require('immutable')
      * List([ 'dog', 'frog', 'cat', 'hat', 'god' ])
@@ -3903,6 +4020,7 @@ declare module Immutable {
      * Returns a new Collection of the same type which includes entries starting
      * from when `predicate` first returns true.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { List } = require('immutable')
      * List([ 'dog', 'frog', 'cat', 'hat', 'god' ])
@@ -3931,6 +4049,7 @@ declare module Immutable {
      * Returns a new Collection of the same type which includes entries from this
      * Collection as long as the `predicate` returns true.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { List } = require('immutable')
      * List([ 'dog', 'frog', 'cat', 'hat', 'god' ])
@@ -3947,6 +4066,7 @@ declare module Immutable {
      * Returns a new Collection of the same type which includes entries from this
      * Collection as long as the `predicate` returns false.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { List } = require('immutable')
      * List([ 'dog', 'frog', 'cat', 'hat', 'god' ])

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -116,10 +116,10 @@ declare module Immutable {
    * This example converts native JS data to List and OrderedMap:
    *
    * ```js
-   * const { fromJS, Iterable } = require('immutable')
+   * const { fromJS, isIndexed } = require('immutable')
    * fromJS({ a: {b: [10, 20, 30]}, c: 40}, function (key, value, path) {
    *   console.log(key, value, path)
-   *   return Iterable.isIndexed(value) ? value.toList() : value.toOrderedMap()
+   *   return isIndexed(value) ? value.toList() : value.toOrderedMap()
    * })
    *
    * > "b", [ 10, 20, 30 ], [ "a", "b" ]
@@ -1407,7 +1407,7 @@ declare module Immutable {
      * performing the deep merge at a point arrived at by following the keyPath.
      * In other words, these two lines are equivalent:
      *
-     * ```javascript
+     * ```js
      * map.updateIn(['a', 'b', 'c'], abc => abc.mergeDeep(y))
      * map.mergeDeepIn(['a', 'b', 'c'], y)
      * ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,9 +102,7 @@ function gulpJS(subDir) {
       .pipe(sourcemaps.init({
         loadMaps: true,
       }))
-      // We need "global" to remain in makeAssert() function that gets stringified
-      // in runkit-embed.js
-      .pipe(uglify({ mangle: { except: ['global'] } }))
+      .pipe(uglify())
       .pipe(sourcemaps.write('./maps'))
       .pipe(gulp.dest(BUILD_DIR+subDir))
       .pipe(filter('**/*.js'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,7 +102,7 @@ function gulpJS(subDir) {
       .pipe(sourcemaps.init({
         loadMaps: true,
       }))
-      .pipe(uglify())
+      .pipe(uglify({ mangle: { except: ['global'] } }))
       .pipe(sourcemaps.write('./maps'))
       .pipe(gulp.dest(BUILD_DIR+subDir))
       .pipe(filter('**/*.js'))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,6 +102,8 @@ function gulpJS(subDir) {
       .pipe(sourcemaps.init({
         loadMaps: true,
       }))
+      // We need "global" to remain in makeAssert() function that gets stringified
+      // in runkit-embed.js
       .pipe(uglify({ mangle: { except: ['global'] } }))
       .pipe(sourcemaps.write('./maps'))
       .pipe(gulp.dest(BUILD_DIR+subDir))

--- a/pages/lib/markdown.js
+++ b/pages/lib/markdown.js
@@ -52,25 +52,21 @@ marked.setOptions({
 var renderer = new marked.Renderer();
 
 const runkitRegExp = /^<!--\s*runkit:activate((.|\n)*)-->(.|\n)*$/;
-const runkitContext = { options: "{}", activated: false };
+const runkitContext = { options: '{}', activated: false };
 
-renderer.html = function (text) {
+renderer.html = function(text) {
   const result = runkitRegExp.exec(text);
 
-  if (!result)
-    return text;
+  if (!result) return text;
 
   runkitContext.activated = true;
-  try
-  {
-    runkitContext.options = result[1] ? JSON.parse(result[1]) : { };
-  }
-  catch (e)
-  {
+  try {
+    runkitContext.options = result[1] ? JSON.parse(result[1]) : {};
+  } catch (e) {
     runkitContext.options = {};
   }
   return text;
-}
+};
 
 renderer.code = function(code, lang, escaped) {
   if (this.options.highlight) {
@@ -81,16 +77,18 @@ renderer.code = function(code, lang, escaped) {
     }
   }
 
-  const runItButton = runkitContext.activated ?
-    '<a class = "try-it" data-options="' +
+  const runItButton = runkitContext.activated
+    ? '<a class = "try-it" data-options="' +
         escape(JSON.stringify(runkitContext.options)) +
-        '" onClick = "runIt(this)">run it</a>' : '';
+        '" onClick = "runIt(this)">run it</a>'
+    : '';
 
   runkitContext.activated = false;
-  runkitContext.options = "{}";
+  runkitContext.options = '{}';
 
   return '<code class="codeBlock">' +
-    (escaped ? code : escapeCode(code, true)) + runItButton +
+    (escaped ? code : escapeCode(code, true)) +
+    runItButton +
     '</code>';
 };
 

--- a/pages/lib/markdown.js
+++ b/pages/lib/markdown.js
@@ -51,7 +51,7 @@ marked.setOptions({
 
 var renderer = new marked.Renderer();
 
-const runkitRegExp = /^<!--\s*runkit\:activate((.|\n)*)-->(.|\n)*$/;
+const runkitRegExp = /^<!--\s*runkit:activate((.|\n)*)-->(.|\n)*$/;
 const runkitContext = { options: "{}", activated: false };
 
 renderer.html = function (text) {

--- a/pages/lib/runkit-embed.js
+++ b/pages/lib/runkit-embed.js
@@ -1,4 +1,7 @@
 global.runIt = function runIt(button) {
+    if (!global.RunKit)
+        return;
+
     var container = document.createElement("div");
     var codeElement = button.parentNode;
     var parent = codeElement.parentNode;
@@ -7,9 +10,9 @@ global.runIt = function runIt(button) {
     parent.removeChild(codeElement);
     codeElement.removeChild(button);
     
-    const options = JSON.parse(unescape(button.dataset["options"]));
+    const options = JSON.parse(unescape(button.dataset.options));
 
-    RunKit.createNotebook({
+    global.RunKit.createNotebook({
          element: container,
          nodeVersion: options.nodeVersion || '*',
          preamble: "const assert = (" + makeAssert + ")(require(\"immutable\"));" + (options.preamble || ""),

--- a/pages/lib/runkit-embed.js
+++ b/pages/lib/runkit-embed.js
@@ -12,7 +12,7 @@ global.runIt = function runIt(button) {
     RunKit.createNotebook({
          element: container,
          nodeVersion: options.nodeVersion || '*',
-         preamble: "(" + makeAssert + ")();" + (options.preamble || ""),
+         preamble: "const assert = (" + makeAssert + ")(require(\"immutable\"));" + (options.preamble || ""),
          source: codeElement.textContent.replace(/\n(>[^\n]*\n?)+$/g, ""),
          minHeight: "52px",
          onLoad: function(notebook) {
@@ -21,11 +21,10 @@ global.runIt = function runIt(button) {
      });
 }
 
-function makeAssert()
+function makeAssert(I)
 {
-    global.assert = (function ()
-    {
-        var html = `
+    var isIterable = I.isIterable || I.Iterable.isIterable;
+    var html = `
         <style>
             *
             {
@@ -79,7 +78,6 @@ function makeAssert()
     
     function compare(lhs, rhs, same, identical)
     {
-        var { Iterable: { isIterable } } = require("immutable");
         var both = !identical && isIterable(lhs) && isIterable(rhs);
     
         if (both)
@@ -91,9 +89,8 @@ function makeAssert()
     function message(lhs, rhs, same, identical)
     {
         var result = compare(lhs, rhs, same, identical);
-        var comparison = result ? (identical ? "identical to" : "does equal") : (identical ? "identical" : "does not equal");
+        var comparison = result ? (identical ? "identical to" : "does equal") : (identical ? "not identical to" : "does not equal");
         var className = result === same ? "success" : "failure";
-        var { Iterable: { isIterable } } = require("immutable");
         var lhsString = isIterable(lhs) ? lhs + "" : JSON.stringify(lhs);
         var rhsString = isIterable(rhs) ? rhs + "" : JSON.stringify(rhs);
     
@@ -126,5 +123,4 @@ function makeAssert()
     }
     
     return { equal, not_equal, identical, not_identical };
-    })();
 }

--- a/pages/lib/runkit-embed.js
+++ b/pages/lib/runkit-embed.js
@@ -122,5 +122,5 @@ function makeAssert(I)
         return message(lhs, rhs, false, true);
     }
     
-    return { equal, not_equal, identical, not_identical };
+    return { equal, notEqual, strictEqual, notStrictEqual };
 }

--- a/pages/lib/runkit-embed.js
+++ b/pages/lib/runkit-embed.js
@@ -1,0 +1,130 @@
+global.runIt = function runIt(button) {
+    var container = document.createElement("div");
+    var codeElement = button.parentNode;
+    var parent = codeElement.parentNode;
+    
+    parent.insertBefore(container, codeElement);
+    parent.removeChild(codeElement);
+    codeElement.removeChild(button);
+    
+    const options = JSON.parse(unescape(button.dataset["options"]));
+
+    RunKit.createNotebook({
+         element: container,
+         nodeVersion: options.nodeVersion || '*',
+         preamble: "(" + makeAssert + ")();" + (options.preamble || ""),
+         source: codeElement.textContent.replace(/\n(>[^\n]*\n?)+$/g, ""),
+         minHeight: "52px",
+         onLoad: function(notebook) {
+           notebook.evaluate()
+         }
+     });
+}
+
+function makeAssert()
+{
+    eval("global").assert = (function ()
+    {
+        var html = `
+        <style>
+            *
+            {
+                font-size: 14px;
+                font-family: monospace;
+            }
+            
+            code
+            {
+                font-family: monospace;
+                color: #4183C4;
+                text-decoration: none;
+                text-decoration: none;
+                background: rgba(65, 131, 196, 0.1);
+                border-radius: 2px;
+                padding: 2px;
+            }
+    
+            .success
+            {
+                color: rgba(84,184,54,1.0);
+            }
+            
+            .success:before
+            {
+                content:  "✅";
+            }
+            /*
+            .success i
+            {
+                color: rgba(72,147,49,1.0);
+            }*/
+            
+            .failure
+            {
+                color: rgba(220,47,33,1.0);
+            }
+            
+            .failure i
+            {
+                color: rgba(210,44,31,1.0);
+            }
+    
+            .failure:before
+            {
+                content: "❌";
+            }
+            
+            
+        </style>`
+    
+    function compare(lhs, rhs, same, identical)
+    {
+        var { Iterable: { isIterable } } = require("immutable");
+        var both = !identical && isIterable(lhs) && isIterable(rhs);
+    
+        if (both)
+            return lhs.equals(rhs);
+    
+        return lhs === rhs;
+    }
+    
+    function message(lhs, rhs, same, identical)
+    {
+        var result = compare(lhs, rhs, same, identical);
+        var comparison = result ? (identical ? "identical to" : "does equal") : (identical ? "identical" : "does not equal");
+        var className = result === same ? "success" : "failure";
+        var { Iterable: { isIterable } } = require("immutable");
+        var lhsString = isIterable(lhs) ? lhs + "" : JSON.stringify(lhs);
+        var rhsString = isIterable(rhs) ? rhs + "" : JSON.stringify(rhs);
+    
+        return html += `
+            <span class = "${className}">
+                <code>${lhsString}</code>
+                ${comparison}
+                <code>${rhsString}</code>    
+            </span><br/>`;
+    }
+    
+    function equal(lhs, rhs)
+    {
+        return message(lhs, rhs, true);
+    }
+    
+    function not_equal(lhs, rhs)
+    {
+        return message(lhs, rhs, false);
+    }
+    
+    function identical(lhs, rhs)
+    {
+        return message(lhs, rhs, true, true);
+    }
+    
+    function not_identical(lhs, rhs)
+    {
+        return message(lhs, rhs, false, true);
+    }
+    
+    return { equal, not_equal, identical, not_identical };
+    })();
+}

--- a/pages/lib/runkit-embed.js
+++ b/pages/lib/runkit-embed.js
@@ -1,33 +1,34 @@
 global.runIt = function runIt(button) {
-    if (!global.RunKit)
-        return;
+  if (!global.RunKit) return;
 
-    var container = document.createElement("div");
-    var codeElement = button.parentNode;
-    var parent = codeElement.parentNode;
-    
-    parent.insertBefore(container, codeElement);
-    parent.removeChild(codeElement);
-    codeElement.removeChild(button);
-    
-    const options = JSON.parse(unescape(button.dataset.options));
+  var container = document.createElement('div');
+  var codeElement = button.parentNode;
+  var parent = codeElement.parentNode;
 
-    global.RunKit.createNotebook({
-         element: container,
-         nodeVersion: options.nodeVersion || '*',
-         preamble: "const assert = (" + makeAssert + ")(require(\"immutable\"));" + (options.preamble || ""),
-         source: codeElement.textContent.replace(/\n(>[^\n]*\n?)+$/g, ""),
-         minHeight: "52px",
-         onLoad: function(notebook) {
-           notebook.evaluate()
-         }
-     });
-}
+  parent.insertBefore(container, codeElement);
+  parent.removeChild(codeElement);
+  codeElement.removeChild(button);
 
-function makeAssert(I)
-{
-    var isIterable = I.isIterable || I.Iterable.isIterable;
-    var html = `
+  const options = JSON.parse(unescape(button.dataset.options));
+
+  global.RunKit.createNotebook({
+    element: container,
+    nodeVersion: options.nodeVersion || '*',
+    preamble: 'const assert = (' +
+      makeAssert +
+      ')(require("immutable"));' +
+      (options.preamble || ''),
+    source: codeElement.textContent.replace(/\n(>[^\n]*\n?)+$/g, ''),
+    minHeight: '52px',
+    onLoad: function(notebook) {
+      notebook.evaluate();
+    }
+  });
+};
+
+function makeAssert(I) {
+  var isIterable = I.isIterable || I.Iterable.isIterable;
+  var html = `
         <style>
             *
             {
@@ -77,53 +78,48 @@ function makeAssert(I)
             }
             
             
-        </style>`
-    
-    function compare(lhs, rhs, same, identical)
-    {
-        var both = !identical && isIterable(lhs) && isIterable(rhs);
-    
-        if (both)
-            return lhs.equals(rhs);
-    
-        return lhs === rhs;
-    }
-    
-    function message(lhs, rhs, same, identical)
-    {
-        var result = compare(lhs, rhs, same, identical);
-        var comparison = result ? (identical ? "strict equal to" : "does equal") : (identical ? "not strict equal to" : "does not equal");
-        var className = result === same ? "success" : "failure";
-        var lhsString = isIterable(lhs) ? lhs + "" : JSON.stringify(lhs);
-        var rhsString = isIterable(rhs) ? rhs + "" : JSON.stringify(rhs);
-    
-        return html += `
+        </style>`;
+
+  function compare(lhs, rhs, same, identical) {
+    var both = !identical && isIterable(lhs) && isIterable(rhs);
+
+    if (both) return lhs.equals(rhs);
+
+    return lhs === rhs;
+  }
+
+  function message(lhs, rhs, same, identical) {
+    var result = compare(lhs, rhs, same, identical);
+    var comparison = result
+      ? identical ? 'strict equal to' : 'does equal'
+      : identical ? 'not strict equal to' : 'does not equal';
+    var className = result === same ? 'success' : 'failure';
+    var lhsString = isIterable(lhs) ? lhs + '' : JSON.stringify(lhs);
+    var rhsString = isIterable(rhs) ? rhs + '' : JSON.stringify(rhs);
+
+    return (html += `
             <span class = "${className}">
                 <code>${lhsString}</code>
                 ${comparison}
                 <code>${rhsString}</code>    
-            </span><br/>`;
-    }
-    
-    function equal(lhs, rhs)
-    {
-        return message(lhs, rhs, true);
-    }
-    
-    function notEqual(lhs, rhs)
-    {
-        return message(lhs, rhs, false);
-    }
-    
-    function strictEqual(lhs, rhs)
-    {
-        return message(lhs, rhs, true, true);
-    }
-    
-    function notStrictEqual(lhs, rhs)
-    {
-        return message(lhs, rhs, false, true);
-    }
-    
-    return { equal, notEqual, strictEqual, notStrictEqual };
+            </span><br/>`);
+  }
+
+  function equal(lhs, rhs) {
+    return message(lhs, rhs, true);
+  }
+
+  function notEqual(lhs, rhs) {
+    return message(lhs, rhs, false);
+  }
+
+  function strictEqual(lhs, rhs) {
+    return message(lhs, rhs, true, true);
+  }
+
+  function notStrictEqual(lhs, rhs) {
+    return message(lhs, rhs, false, true);
+  }
+
+  return { equal, notEqual, strictEqual, notStrictEqual };
 }

--- a/pages/lib/runkit-embed.js
+++ b/pages/lib/runkit-embed.js
@@ -23,7 +23,7 @@ global.runIt = function runIt(button) {
 
 function makeAssert()
 {
-    eval("global").assert = (function ()
+    global.assert = (function ()
     {
         var html = `
         <style>

--- a/pages/lib/runkit-embed.js
+++ b/pages/lib/runkit-embed.js
@@ -89,7 +89,7 @@ function makeAssert(I)
     function message(lhs, rhs, same, identical)
     {
         var result = compare(lhs, rhs, same, identical);
-        var comparison = result ? (identical ? "identical to" : "does equal") : (identical ? "not identical to" : "does not equal");
+        var comparison = result ? (identical ? "strict equal to" : "does equal") : (identical ? "not strict equal to" : "does not equal");
         var className = result === same ? "success" : "failure";
         var lhsString = isIterable(lhs) ? lhs + "" : JSON.stringify(lhs);
         var rhsString = isIterable(rhs) ? rhs + "" : JSON.stringify(rhs);

--- a/pages/lib/runkit-embed.js
+++ b/pages/lib/runkit-embed.js
@@ -107,17 +107,17 @@ function makeAssert(I)
         return message(lhs, rhs, true);
     }
     
-    function not_equal(lhs, rhs)
+    function notEqual(lhs, rhs)
     {
         return message(lhs, rhs, false);
     }
     
-    function identical(lhs, rhs)
+    function strictEqual(lhs, rhs)
     {
         return message(lhs, rhs, true, true);
     }
     
-    function not_identical(lhs, rhs)
+    function notStrictEqual(lhs, rhs)
     {
         return message(lhs, rhs, false, true);
     }

--- a/pages/src/docs/index.html
+++ b/pages/src/docs/index.html
@@ -14,6 +14,7 @@
     <script src="//cdn.jsdelivr.net/react/0.12.1/react-with-addons.min.js"></script>
     <script src="//cdn.jsdelivr.net/immutable.js/3.8.1/immutable.min.js"></script>
     <script src="bundle.js"></script>
+    <script src = "https://embed.runkit.com" async defer></script>
     <!-- ReactRender() -->
     <script>
       //<![CDATA[

--- a/pages/src/docs/src/index.js
+++ b/pages/src/docs/src/index.js
@@ -7,7 +7,7 @@ var defs = require('../../../lib/getTypeDefs');
 
 var { Route, DefaultRoute, RouteHandler } = Router;
 
-require("../../../lib/runkit-embed");
+require('../../../lib/runkit-embed');
 
 var Documentation = React.createClass({
   render() {

--- a/pages/src/docs/src/index.js
+++ b/pages/src/docs/src/index.js
@@ -7,6 +7,8 @@ var defs = require('../../../lib/getTypeDefs');
 
 var { Route, DefaultRoute, RouteHandler } = Router;
 
+require("../../../lib/runkit-embed");
+
 var Documentation = React.createClass({
   render() {
     return (

--- a/pages/src/index.html
+++ b/pages/src/index.html
@@ -15,6 +15,7 @@
     <script src="bundle.js"></script>
     <!-- ReactRender() -->
     <script src="//cdn.jsdelivr.net/immutable.js/3.8.1/immutable.min.js"></script>
+    <script src = "https://embed.runkit.com" async defer></script>
     <script>
       //<![CDATA[
       console.log(

--- a/pages/src/src/base.less
+++ b/pages/src/src/base.less
@@ -72,6 +72,7 @@ blockquote > :last-child {
   overflow-y: scroll;
   padding: 0.5rem 8px 0.5rem 12px;
   white-space: pre;
+  position:relative;
 }
 
 .t.blockParams {
@@ -137,4 +138,15 @@ blockquote > :last-child {
 .token.comment {
   color: #998;
   font-style: italic;
+}
+
+a.try-it
+{
+    position: absolute;
+    cursor: pointer;
+    right: 1em;
+    border: 0;
+    background: transparent;
+    border-bottom: 2px solid rgba(49, 50, 137, 0.2);
+    color: rgba(49, 50, 137, 1.0);
 }

--- a/pages/src/src/index.js
+++ b/pages/src/src/index.js
@@ -2,8 +2,7 @@ var React = require('react');
 var Header = require('./Header');
 var readme = require('../../generated/readme.json');
 
-require("../../lib/runkit-embed");
-
+require('../../lib/runkit-embed');
 
 var Index = React.createClass({
   render: function() {

--- a/pages/src/src/index.js
+++ b/pages/src/src/index.js
@@ -2,6 +2,9 @@ var React = require('react');
 var Header = require('./Header');
 var readme = require('../../generated/readme.json');
 
+require("../../lib/runkit-embed");
+
+
 var Index = React.createClass({
   render: function() {
     return (

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -149,7 +149,7 @@ declare module Immutable {
    * assert.equal(obj["1"], obj[1]); // "one" === "one"
    *
    * let map = Map(obj);
-   * assert.not_equal(map.get("1"), map.get(1)); // "one" !== undefined
+   * assert.notEqual(map.get("1"), map.get(1)); // "one" !== undefined
    * ```
    *
    * Property access for JavaScript Objects first converts the key to a string,
@@ -335,7 +335,7 @@ declare module Immutable {
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 1, 2, 3 ]);
-     * assert.not_identical(a, b); // different instances
+     * assert.notStrictEqual(a, b); // different instances
      * const set = Set([ a ]);
      * assert.equal(set.has(b), true);
      * ```
@@ -704,10 +704,9 @@ declare module Immutable {
      * Index numbers are used as keys to determine the path to follow in
      * the List.
      *
-     * <!-- runkit:activate
-     *      { "preamble": "const { List } = require(\"immutable\");" }
-     * -->
+     * <!-- runkit:activate -->
      * ```js
+     * const { List } = require("immutable")
      * const list = List([ 0, 1, 2, List([ 3, 4 ])])
      * list.setIn([3, 0], 999);
      * // List [ 0, 1, 2, List [ 999, 4 ] ]
@@ -721,10 +720,9 @@ declare module Immutable {
      * Returns a new List having removed the value at this `keyPath`. If any
      * keys in `keyPath` do not exist, no change will occur.
      *
-     * <!-- runkit:activate
-     *      { "preamble": "const { List } = require(\"immutable\");" }
-     * -->
+     * <!-- runkit:activate -->
      * ```js
+     * const { List } = require("immutable")
      * const list = List([ 0, 1, 2, List([ 3, 4 ])])
      * list.deleteIn([3, 0]);
      * // List [ 0, 1, 2, List [ 4 ] ]
@@ -970,7 +968,7 @@ declare module Immutable {
    * assert.equal(obj["1"], obj[1]) // "one" === "one"
    *
    * let map = Map(obj)
-   * assert.not_equal(map.get("1"), map.get(1)) // "one" !== undefined
+   * assert.notEqual(map.get("1"), map.get(1)) // "one" !== undefined
    * ```
    *
    * Property access for JavaScript Objects first converts the key to a string,
@@ -1121,7 +1119,7 @@ declare module Immutable {
      * const aMap = Map({ apples: 10 })
      * const newMap = aMap.update('oranges', 0, val => val)
      * // Map { "apples": 10 }
-     * assert.identical(newMap, map);
+     * assert.strictEqual(newMap, map);
      * ```
      *
      * For code using ES2015 or later, using `notSetValue` is discourged in
@@ -1366,7 +1364,7 @@ declare module Immutable {
      * const map = Map({ a: Map({ b: Map({ c: 10 }) }) })
      * const newMap = map.updateIn(['a', 'b', 'x'], 100, val => val)
      * // Map { "a": Map { "b": Map { "c": 10 } } }
-     * assert.identical(newMap, aMap)
+     * assert.strictEqual(newMap, aMap)
      * ```
      *
      * For code using ES2015 or later, using `notSetValue` is discourged in
@@ -3395,7 +3393,7 @@ declare module Immutable {
      * const seq = Collection.Set([ 'A', 'B', 'C' ])
      * // Seq { "A", "B", "C" }
      * seq.forEach((v, k) =>
-     *  assert(v, k)
+     *  assert.equal(v, k)
      * )
      * ```
      */
@@ -3523,7 +3521,7 @@ declare module Immutable {
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 1, 2, 3 ]);
-     * assert.not_identical(a, b); // different instances
+     * assert.notStrictEqual(a, b); // different instances
      * const set = Set([ a ]);
      * assert.equal(set.has(b), true);
      * ```

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -116,10 +116,10 @@ declare module Immutable {
    * This example converts native JS data to List and OrderedMap:
    *
    * ```js
-   * const { fromJS, isIndexed } = require('immutable')
+   * const { fromJS, Iterable } = require('immutable')
    * fromJS({ a: {b: [10, 20, 30]}, c: 40}, function (key, value, path) {
    *   console.log(key, value, path)
-   *   return isIndexed(value) ? value.toList() : value.toOrderedMap()
+   *   return Iterable.isIndexed(value) ? value.toList() : value.toOrderedMap()
    * })
    *
    * > "b", [ 10, 20, 30 ], [ "a", "b" ]
@@ -140,15 +140,16 @@ declare module Immutable {
    * JavaScript Object properties are always strings, even if written in a
    * quote-less shorthand, while Immutable Maps accept keys of any type.
    *
+   * <!-- runkit:activate
+   *      { "preamble": "const { Map } = require(\"immutable\");" }
+   * -->
    * ```js
    * let obj = { 1: "one" };
    * Object.keys(obj); // [ "1" ]
-   * obj["1"]; // "one"
-   * obj[1];   // "one"
+   * assert.equal(obj["1"], obj[1]); // "one" === "one"
    *
    * let map = Map(obj);
-   * map.get("1"); // "one"
-   * map.get(1);   // undefined
+   * assert.not_equal(map.get("1"), map.get(1)); // "one" !== undefined
    * ```
    *
    * Property access for JavaScript Objects first converts the key to a string,
@@ -176,13 +177,14 @@ declare module Immutable {
    * It's used throughout Immutable when checking for equality, including `Map`
    * key equality and `Set` membership.
    *
+   * <!-- runkit:activate -->
    * ```js
-   * import { Map, is } from 'immutable'
+   * const { Map, is } = require('immutable')
    * const map1 = Map({ a: 1, b: 1, c: 1 })
    * const map2 = Map({ a: 1, b: 1, c: 1 })
-   * assert(map1 !== map2)
-   * assert(Object.is(map1, map2) === false)
-   * assert(is(map1, map2) === true)
+   * assert.equal(map1 !== map2, true)
+   * assert.equal(Object.is(map1, map2), false)
+   * assert.equal(is(map1, map2), true)
    * ```
    *
    * `is()` compares primitive types like strings and numbers, Immutable.js
@@ -327,12 +329,15 @@ declare module Immutable {
      * and is used when adding this to a `Set` or as a key in a `Map`, enabling
      * lookup via a different instance.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List, Set } = require(\"immutable\")" }
+     * -->
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 1, 2, 3 ]);
-     * assert(a !== b); // different instances
+     * assert.not_identical(a, b); // different instances
      * const set = Set([ a ]);
-     * assert(set.has(b) === true);
+     * assert.equal(set.has(b), true);
      * ```
      *
      * If two values have the same `hashCode`, they are [not guaranteed
@@ -363,6 +368,9 @@ declare module Immutable {
     /**
      * True if the provided value is a List
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List.isList([]); // false
      * List.isList(List()); // true
@@ -373,6 +381,9 @@ declare module Immutable {
     /**
      * Creates a new List containing `values`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List.of(1, 2, 3, 4)
      * // List [ 1, 2, 3, 4 ]
@@ -380,6 +391,9 @@ declare module Immutable {
      *
      * Note: Values are not altered or converted in any way.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List.of({x:1}, 2, [3], 4)
      * // List [ { x: 1 }, 2, [ 3 ], 4 ]
@@ -392,6 +406,7 @@ declare module Immutable {
    * Create a new immutable List containing the values of the provided
    * collection-like.
    *
+   * <!-- runkit:activate -->
    * ```js
    * const { List, Set } = require('immutable')
    *
@@ -438,6 +453,9 @@ declare module Immutable {
      * If `index` larger than `size`, the returned List's `size` will be large
      * enough to include the `index`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const originalList = List([ 0 ]);
      * // List [ 0 ]
@@ -468,6 +486,9 @@ declare module Immutable {
      *
      * Note: `delete` cannot be safely used in IE8
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 0, 1, 2, 3, 4 ]).delete(0);
      * // List [ 1, 2, 3, 4 ]
@@ -486,6 +507,9 @@ declare module Immutable {
      *
      * This is synonymous with `list.splice(index, 0, value)`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 0, 1, 2, 3, 4 ]).insert(6, 5)
      * // List [ 0, 1, 2, 3, 4, 5 ]
@@ -498,6 +522,9 @@ declare module Immutable {
     /**
      * Returns a new List with 0 size and no values.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 1, 2, 3, 4 ]).clear()
      * // List []
@@ -511,6 +538,9 @@ declare module Immutable {
      * Returns a new List with the provided `values` appended, starting at this
      * List's `size`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 1, 2, 3, 4 ]).push(5)
      * // List [ 1, 2, 3, 4, 5 ]
@@ -541,6 +571,9 @@ declare module Immutable {
      * Returns a new List with the provided `values` prepended, shifting other
      * values ahead to higher indices.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 2, 3, 4]).unshift(1);
      * // List [ 1, 2, 3, 4 ]
@@ -558,6 +591,9 @@ declare module Immutable {
      * List rather than the removed value. Use `first()` to get the first
      * value in this List.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 0, 1, 2, 3, 4 ]).shift();
      * // List [ 1, 2, 3, 4 ]
@@ -576,6 +612,9 @@ declare module Immutable {
      * `index` may be a negative number, which indexes back from the end of the
      * List. `v.update(-1)` updates the last item in the List.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const list = List([ 'a', 'b', 'c' ])
      * const result = list.update(2, val => val.toUpperCase())
@@ -587,6 +626,9 @@ declare module Immutable {
      *
      * For example, to sum a List after mapping and filtering:
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * function sum(collection) {
      *   return collection.reduce((sum, x) => sum + x, 0)
@@ -662,8 +704,10 @@ declare module Immutable {
      * Index numbers are used as keys to determine the path to follow in
      * the List.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
-     * const { List } = require('immutable');
      * const list = List([ 0, 1, 2, List([ 3, 4 ])])
      * list.setIn([3, 0], 999);
      * // List [ 0, 1, 2, List [ 999, 4 ] ]
@@ -677,8 +721,10 @@ declare module Immutable {
      * Returns a new List having removed the value at this `keyPath`. If any
      * keys in `keyPath` do not exist, no change will occur.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
-     * const { List } = require('immutable');
      * const list = List([ 0, 1, 2, List([ 3, 4 ])])
      * list.deleteIn([3, 0]);
      * // List [ 0, 1, 2, List [ 4 ] ]
@@ -751,6 +797,9 @@ declare module Immutable {
      * Returns a new List with values passed through a
      * `mapper` function.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * List([ 1, 2 ]).map(x => 10 * x)
      * // List [ 10, 20 ]
@@ -795,6 +844,9 @@ declare module Immutable {
      *
      * Like `zipWith`, but using the default `zipper`: creating an `Array`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 4, 5, 6 ]);
@@ -807,6 +859,9 @@ declare module Immutable {
      * Returns a List "zipped" with the provided collections by using a
      * custom `zipper` function.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 4, 5, 6 ]);
@@ -844,6 +899,7 @@ declare module Immutable {
    * Immutable collections are treated as values, any Immutable collection may
    * be used as a key.
    *
+   * <!-- runkit:activate -->
    * ```js
    * const { Map, List } = require('immutable');
    * Map().set(List([ 1 ]), 'listofone').get(List([ 1 ]));
@@ -872,6 +928,7 @@ declare module Immutable {
     /**
      * Creates a new Map from alternating keys and values
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * Map.of(
@@ -893,6 +950,7 @@ declare module Immutable {
    * Created with the same key value pairs as the provided Collection.Keyed or
    * JavaScript Object or expects a Collection of [K, V] tuple entries.
    *
+   * <!-- runkit:activate -->
    * ```js
    * const { Map } = require('immutable')
    * Map({ key: "value" })
@@ -903,15 +961,16 @@ declare module Immutable {
    * JavaScript Object properties are always strings, even if written in a
    * quote-less shorthand, while Immutable Maps accept keys of any type.
    *
+   * <!-- runkit:activate
+   *      { "preamble": "const { Map } = require(\"immutable\");" }
+   * -->
    * ```js
    * let obj = { 1: "one" }
    * Object.keys(obj) // [ "1" ]
-   * obj["1"] // "one"
-   * obj[1]   // "one"
+   * assert.equal(obj["1"], obj[1]) // "one" === "one"
    *
    * let map = Map(obj)
-   * map.get("1") // "one"
-   * map.get(1)   // undefined
+   * assert.not_equal(map.get("1"), map.get(1)) // "one" !== undefined
    * ```
    *
    * Property access for JavaScript Objects first converts the key to a string,
@@ -937,6 +996,7 @@ declare module Immutable {
      * Returns a new Map also containing the new key, value pair. If an equivalent
      * key already exists in this Map, it will be replaced.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const originalMap = Map()
@@ -961,6 +1021,7 @@ declare module Immutable {
      * Note: `delete` cannot be safely used in IE8, but is provided to mirror
      * the ES6 collection API.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const originalMap = Map({
@@ -999,6 +1060,7 @@ declare module Immutable {
     /**
      * Returns a new Map containing no keys or values.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * Map({ key: 'value' }).clear()
@@ -1015,6 +1077,7 @@ declare module Immutable {
      *
      * Similar to: `map.set(key, updater(map.get(key)))`.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const aMap = Map({ key: 'value' })
@@ -1026,6 +1089,9 @@ declare module Immutable {
      * structure of data. For example, in order to `.push()` onto a nested `List`,
      * `update` and `push` can be used together:
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map, List } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ nestedList: List([ 1, 2, 3 ]) })
      * const newMap = aMap.update('nestedList', list => list.push(4))
@@ -1035,6 +1101,9 @@ declare module Immutable {
      * When a `notSetValue` is provided, it is provided to the `updater`
      * function when the value at the key does not exist in the Map.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ key: 'value' })
      * const newMap = aMap.update('noKey', 'no value', value => value + value)
@@ -1045,11 +1114,14 @@ declare module Immutable {
      * with, then no change will occur. This is still true if `notSetValue`
      * is provided.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ apples: 10 })
      * const newMap = aMap.update('oranges', 0, val => val)
      * // Map { "apples": 10 }
-     * assert(newMap === map);
+     * assert.identical(newMap, map);
      * ```
      *
      * For code using ES2015 or later, using `notSetValue` is discourged in
@@ -1058,6 +1130,9 @@ declare module Immutable {
      *
      * The previous example behaves differently when written with default values:
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ apples: 10 })
      * const newMap = aMap.update('oranges', (val = 0) => val)
@@ -1067,6 +1142,9 @@ declare module Immutable {
      * If no key is provided, then the `updater` function return value is
      * returned as well.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * const aMap = Map({ key: 'value' })
      * const result = aMap.update(aMap => aMap.get('key'))
@@ -1078,6 +1156,9 @@ declare module Immutable {
      *
      * For example, to sum the values in a Map
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\");" }
+     * -->
      * ```js
      * function sum(collection) {
      *   return collection.reduce((sum, x) => sum + x, 0)
@@ -1107,6 +1188,7 @@ declare module Immutable {
      * Collection but includes non-collection JS objects or arrays, those nested
      * values will be preserved.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const one = Map({ a: 10, b: 20, c: 30 })
@@ -1124,6 +1206,7 @@ declare module Immutable {
      * the provided Collections (or JS objects) into this Map, but uses the
      * `merger` function for dealing with conflicts.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const one = Map({ a: 10, b: 20, c: 30 })
@@ -1145,6 +1228,7 @@ declare module Immutable {
      * Like `merge()`, but when two Collections conflict, it merges them as well,
      * recursing deeply through the nested data.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const one = Map({ a: Map({ x: 10, y: 10 }), b: Map({ x: 20, y: 50 }) })
@@ -1165,6 +1249,7 @@ declare module Immutable {
      * Like `mergeDeep()`, but when two non-Collections conflict, it uses the
      * `merger` function to determine the resulting value.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const one = Map({ a: Map({ x: 10, y: 10 }), b: Map({ x: 20, y: 50 }) })
@@ -1191,6 +1276,7 @@ declare module Immutable {
      * Returns a new Map having set `value` at this `keyPath`. If any keys in
      * `keyPath` do not exist, a new immutable Map will be created at that key.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const originalMap = Map({
@@ -1248,6 +1334,7 @@ declare module Immutable {
      * structure of data. For example, in order to `.push()` onto a nested `List`,
      * `updateIn` and `push` can be used together:
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map, List } = require('immutable')
      * const map = Map({ inMap: Map({ inList: List([ 1, 2, 3 ]) }) })
@@ -1260,6 +1347,9 @@ declare module Immutable {
      * value, the `updater` function will be called with `notSetValue`, if
      * provided, otherwise `undefined`.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\")" }     
+     * -->
      * ```js
      * const map = Map({ a: Map({ b: Map({ c: 10 }) }) })
      * const newMap = map.updateIn(['a', 'b', 'c'], val => val * 2)
@@ -1269,11 +1359,14 @@ declare module Immutable {
      * If the `updater` function returns the same value it was called with, then
      * no change will occur. This is still true if `notSetValue` is provided.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\")" }     
+     * -->
      * ```js
      * const map = Map({ a: Map({ b: Map({ c: 10 }) }) })
      * const newMap = map.updateIn(['a', 'b', 'x'], 100, val => val)
      * // Map { "a": Map { "b": Map { "c": 10 } } }
-     * assert(newMap === map)
+     * assert.identical(newMap, aMap)
      * ```
      *
      * For code using ES2015 or later, using `notSetValue` is discourged in
@@ -1282,6 +1375,9 @@ declare module Immutable {
      *
      * The previous example behaves differently when written with default values:
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require(\"immutable\")" }     
+     * -->
      * ```js
      * const map = Map({ a: Map({ b: Map({ c: 10 }) }) })
      * const newMap = map.updateIn(['a', 'b', 'x'], (val = 100) => val)
@@ -1313,7 +1409,7 @@ declare module Immutable {
      * performing the deep merge at a point arrived at by following the keyPath.
      * In other words, these two lines are equivalent:
      *
-     * ```js
+     * ```javascript
      * map.updateIn(['a', 'b', 'c'], abc => abc.mergeDeep(y))
      * map.mergeDeepIn(['a', 'b', 'c'], y)
      * ```
@@ -1337,14 +1433,15 @@ declare module Immutable {
      *
      * As an example, this results in the creation of 2, not 4, new Maps:
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * const map1 = Map()
      * const map2 = map1.withMutations(map => {
      *   map.set('a', 1).set('b', 2).set('c', 3)
      * })
-     * assert(map1.size === 0)
-     * assert(map2.size === 3)
+     * assert.equal(map1.size, 0)
+     * assert.equal(map2.size, 3)
      * ```
      *
      * Note: Not all methods can be used on a mutable collection or within
@@ -1606,7 +1703,7 @@ declare module Immutable {
      * collection of other sets.
      *
      * ```js
-     * * const { Set } = require('immutable')
+     * const { Set } = require('immutable')
      * const unioned = Set.union([
      *   Set([ 'a', 'b', 'c' ])
      *   Set([ 'c', 'a', 't' ])
@@ -2930,6 +3027,7 @@ declare module Immutable {
        * Returns a new Collection.Keyed of the same type where the keys and values
        * have been flipped.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { Map } = require('immutable')
        * Map({ a: 'z', b: 'y' }).flip()
@@ -2966,6 +3064,7 @@ declare module Immutable {
        * Returns a new Collection.Keyed of the same type with keys passed through
        * a `mapper` function.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { Map } = require('immutable')
        * Map({ a: 1, b: 2 }).mapKeys(x => x.toUpperCase())
@@ -2984,6 +3083,7 @@ declare module Immutable {
        * Returns a new Collection.Keyed of the same type with entries
        * ([key, value] tuples) passed through a `mapper` function.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { Map } = require('immutable')
        * Map({ a: 1, b: 2 })
@@ -3105,6 +3205,7 @@ declare module Immutable {
        * The resulting Collection includes the first item from each, then the
        * second from each, etc.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { List } = require('immutable')
        * List([ 1, 2, 3 ]).interleave(List([ 'A', 'B', 'C' ]))
@@ -3113,6 +3214,9 @@ declare module Immutable {
        *
        * The shortest Collection stops interleave.
        *
+       * <!-- runkit:activate
+       *      { "preamble": "const { List } = require(\"immutable\")" }
+       * -->
        * ```js
        * List([ 1, 2, 3 ]).interleave(
        *   List([ 'A', 'B' ]),
@@ -3131,6 +3235,7 @@ declare module Immutable {
        * `index` may be a negative number, which indexes back from the end of the
        * Collection. `s.splice(-2)` splices after the second to last item.
        *
+       * <!-- runkit:activate -->
        * ```js
        * const { List } = require('immutable')
        * List([ 'a', 'b', 'c', 'd' ]).splice(1, 2, 'q', 'r', 's')
@@ -3149,6 +3254,10 @@ declare module Immutable {
        *
        * Like `zipWith`, but using the default `zipper`: creating an `Array`.
        *
+       *
+       * <!-- runkit:activate
+       *      { "preamble": "const { List } = require(\"immutable\")" }
+       * -->
        * ```js
        * const a = List([ 1, 2, 3 ]);
        * const b = List([ 4, 5, 6 ]);
@@ -3161,6 +3270,9 @@ declare module Immutable {
        * Returns a Collection of the same type "zipped" with the provided
        * collections by using a custom `zipper` function.
        *
+       * <!-- runkit:activate
+       *      { "preamble": "const { List } = require(\"immutable\")" }
+       * -->
        * ```js
        * const a = List([ 1, 2, 3 ]);
        * const b = List([ 4, 5, 6 ]);
@@ -3283,7 +3395,7 @@ declare module Immutable {
      * const seq = Collection.Set([ 'A', 'B', 'C' ])
      * // Seq { "A", "B", "C" }
      * seq.forEach((v, k) =>
-     *  assert.equal(v, k)
+     *  assert(v, k)
      * )
      * ```
      */
@@ -3405,12 +3517,15 @@ declare module Immutable {
      * and is used when adding this to a `Set` or as a key in a `Map`, enabling
      * lookup via a different instance.
      *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Set,  List } = require(\"immutable\")" }
+     * -->
      * ```js
      * const a = List([ 1, 2, 3 ]);
      * const b = List([ 1, 2, 3 ]);
-     * assert(a !== b); // different instances
+     * assert.not_identical(a, b); // different instances
      * const set = Set([ a ]);
-     * assert(set.has(b) === true);
+     * assert.equal(set.has(b), true);
      * ```
      *
      * If two values have the same `hashCode`, they are [not guaranteed
@@ -3574,6 +3689,7 @@ declare module Immutable {
      * `collection.toList()` discards the keys and creates a list of only the
      * values, whereas `List(collection)` creates a list of entry tuples.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map, List } = require('immutable')
      * var myMap = Map({ a: 'Apple', b: 'Banana' })
@@ -3708,6 +3824,7 @@ declare module Immutable {
      * Returns a new Collection of the same type with only the entries for which
      * the `predicate` function returns true.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * Map({ a: 1, b: 2, c: 3, d: 4}).filter(x => x % 2 === 0)
@@ -3730,6 +3847,7 @@ declare module Immutable {
      * Returns a new Collection of the same type with only the entries for which
      * the `predicate` function returns false.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { Map } = require('immutable')
      * Map({ a: 1, b: 2, c: 3, d: 4}).filterNot(x => x % 2 === 0)
@@ -3816,6 +3934,7 @@ declare module Immutable {
      * //   1: List [ Map{ "v": 1 }, Map { "v": 1 } ],
      * //   2: List [ Map{ "v": 2 } ],
      * // }
+     * groupsOfMaps
      * ```
      */
     groupBy<G>(
@@ -3887,6 +4006,7 @@ declare module Immutable {
      * Returns a new Collection of the same type which includes entries starting
      * from when `predicate` first returns false.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { List } = require('immutable')
      * List([ 'dog', 'frog', 'cat', 'hat', 'god' ])
@@ -3903,6 +4023,7 @@ declare module Immutable {
      * Returns a new Collection of the same type which includes entries starting
      * from when `predicate` first returns true.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { List } = require('immutable')
      * List([ 'dog', 'frog', 'cat', 'hat', 'god' ])
@@ -3931,6 +4052,7 @@ declare module Immutable {
      * Returns a new Collection of the same type which includes entries from this
      * Collection as long as the `predicate` returns true.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { List } = require('immutable')
      * List([ 'dog', 'frog', 'cat', 'hat', 'god' ])
@@ -3947,6 +4069,7 @@ declare module Immutable {
      * Returns a new Collection of the same type which includes entries from this
      * Collection as long as the `predicate` returns false.
      *
+     * <!-- runkit:activate -->
      * ```js
      * const { List } = require('immutable')
      * List([ 'dog', 'frog', 'cat', 'hat', 'god' ])

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -116,10 +116,10 @@ declare module Immutable {
    * This example converts native JS data to List and OrderedMap:
    *
    * ```js
-   * const { fromJS, Iterable } = require('immutable')
+   * const { fromJS, isIndexed } = require('immutable')
    * fromJS({ a: {b: [10, 20, 30]}, c: 40}, function (key, value, path) {
    *   console.log(key, value, path)
-   *   return Iterable.isIndexed(value) ? value.toList() : value.toOrderedMap()
+   *   return isIndexed(value) ? value.toList() : value.toOrderedMap()
    * })
    *
    * > "b", [ 10, 20, 30 ], [ "a", "b" ]
@@ -1407,7 +1407,7 @@ declare module Immutable {
      * performing the deep merge at a point arrived at by following the keyPath.
      * In other words, these two lines are equivalent:
      *
-     * ```javascript
+     * ```js
      * map.updateIn(['a', 'b', 'c'], abc => abc.mergeDeep(y))
      * map.mergeDeepIn(['a', 'b', 'c'], y)
      * ```

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -3932,7 +3932,6 @@ declare module Immutable {
      * //   1: List [ Map{ "v": 1 }, Map { "v": 1 } ],
      * //   2: List [ Map{ "v": 2 } ],
      * // }
-     * groupsOfMaps
      * ```
      */
     groupBy<G>(


### PR DESCRIPTION
I'd like to propose using RunKit embeds for the examples in immutable's documentation. The way I've implemented it, the existing examples remain as is, but also have a "run it" button on the bottom right. When clicked, a RunKit embed is swapped in and the example becomes runnable and editable:

![gif1](https://user-images.githubusercontent.com/23753/27927823-da7c9be4-6241-11e7-987f-d8a214d2da9c.gif)

As you can see from the above gif, we've also taken the time to add native support for Immutable classes into RunKit, so that all the objects show up correctly (you can try this now [here](https://runkit.com/tolmasky/immutable-classes/branches/master/clone)).

Additionally, I made some custom assert.equals/etc so they show up nicely too:

![screen shot 2017-07-06 at 11 57 51 am](https://user-images.githubusercontent.com/23753/27928071-a95c4e00-6242-11e7-938e-a9189b910ba4.png)

Some technical details:

1. Its designed in such a way that if RunKit is down, the site behaves like before (so no absolute dependency).
2. I've modified the markdown parser so that if you add "\<!-- runkit:activate --\>" before a code snippet, it will be turned into a runnable snippet, and the others are left alone.
3. I've left some as not runnable, since they rely on the new unpublished 4.0.0 changes. Once 4.0.0 goes live, these could be made runnable too (or alternatively I could modify the examples to use the current API, but I decided to not make any content changes at all, just usability).
4. Some examples were not technically runnable on their own, as they do not contain the proper imports. RunKit has a solution for this called the preamble (where you can load code before the users code). I've kept these examples the same by using this feature and placing the imports in a not visible first cell. However, I am happy to simply add the imports to the examples themselves too.

The basic goal we're trying to accomplish is to make code immediately usable in docs, to shorten the time it takes to get familiar with a library. Lodash has been using RunKit on their documentation for about a year now, and Express recently incorporated RunKit into their Getting Started example as well. https://expressjs.com/en/starter/hello-world.html . Would love to see the same here, and I am happy to make any changes as necessary. 
