### PR TITLE
docs: updates hash() docs to indicate that it's new in v4.0

### DIFF
--- a/dist/immutable-nonambient.d.ts
+++ b/dist/immutable-nonambient.d.ts
@@ -206,6 +206,8 @@
    *
    * Note that `hash()` attempts to balance between speed and avoiding
    * collisions, however it makes no attempt to produce secure hashes.
+   *
+   * *New in Version 4.0*
    */
   export function hash(value: any): number;
 

--- a/dist/immutable.d.ts
+++ b/dist/immutable.d.ts
@@ -206,6 +206,8 @@ declare module Immutable {
    *
    * Note that `hash()` attempts to balance between speed and avoiding
    * collisions, however it makes no attempt to produce secure hashes.
+   *
+   * *New in Version 4.0*
    */
   export function hash(value: any): number;
 

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -206,6 +206,8 @@ declare module Immutable {
    *
    * Note that `hash()` attempts to balance between speed and avoiding
    * collisions, however it makes no attempt to produce secure hashes.
+   *
+   * *New in Version 4.0*
    */
   export function hash(value: any): number;
 


### PR DESCRIPTION
this tripped me up the other day when i was looking to use `hash()`. I couldn't offhand find another method that indicated which version it appeared in so i just italicized the string.

<img width="696" alt="grnk" src="https://user-images.githubusercontent.com/216572/27972429-33d93eda-630b-11e7-86e7-81b9f00e7622.png">
