### PR TITLE
Upgrade flow; solidify Record and RecordInstance a bit

### DIFF
--- a/dist/immutable.js.flow
+++ b/dist/immutable.js.flow
@@ -1151,35 +1151,35 @@ declare class RecordInstance<T: Object> {
   size: number;
 
   has(key: string): boolean;
-  get<K: $Keys<T>>(key: K): /*T[K]*/any;
+  get<K: $Keys<T>>(key: K): $ElementType<T, K>;
 
   equals(other: any): boolean;
   hashCode(): number;
 
-  set<K: $Keys<T>>(key: K, value: /*T[K]*/any): this;
-  update<K: $Keys<T>>(key: K, updater: (value: /*T[K]*/any) => /*T[K]*/any): this;
-  merge(...collections: Array<$Shape<T> | Iterable<[string, any]>>): this;
-  mergeDeep(...collections: Array<$Shape<T> | Iterable<[string, any]>>): this;
+  set<K: $Keys<T>>(key: K, value: $ElementType<T, K>): this & T;
+  update<K: $Keys<T>>(key: K, updater: (value: $ElementType<T, K>) => $ElementType<T, K>): this & T;
+  merge(...collections: Array<$Shape<T> | Iterable<[string, any]>>): this & T;
+  mergeDeep(...collections: Array<$Shape<T> | Iterable<[string, any]>>): this & T;
 
   mergeWith(
     merger: (oldVal: any, newVal: any, key: $Keys<T>) => any,
     ...collections: Array<$Shape<T> | Iterable<[string, any]>>
-  ): this;
+  ): this & T;
   mergeDeepWith(
     merger: (oldVal: any, newVal: any, key: any) => any,
     ...collections: Array<$Shape<T> | Iterable<[string, any]>>
-  ): this;
+  ): this & T;
 
-  delete<K: $Keys<T>>(key: K): this;
-  remove<K: $Keys<T>>(key: K): this;
-  clear(): this;
+  delete<K: $Keys<T>>(key: K): this & T;
+  remove<K: $Keys<T>>(key: K): this & T;
+  clear(): this & T;
 
-  setIn(keyPath: Iterable<any>, value: any): this;
-  updateIn(keyPath: Iterable<any>, updater: (value: any) => any): this;
-  mergeIn(keyPath: Iterable<any>, ...collections: Array<any>): this;
-  mergeDeepIn(keyPath: Iterable<any>, ...collections: Array<any>): this;
-  deleteIn(keyPath: Iterable<any>): this;
-  removeIn(keyPath: Iterable<any>): this;
+  setIn(keyPath: Iterable<any>, value: any): this & T;
+  updateIn(keyPath: Iterable<any>, updater: (value: any) => any): this & T;
+  mergeIn(keyPath: Iterable<any>, ...collections: Array<any>): this & T;
+  mergeDeepIn(keyPath: Iterable<any>, ...collections: Array<any>): this & T;
+  deleteIn(keyPath: Iterable<any>): this & T;
+  removeIn(keyPath: Iterable<any>): this & T;
 
   toSeq(): KeyedSeq<$Keys<T>, any>;
 
@@ -1187,9 +1187,9 @@ declare class RecordInstance<T: Object> {
   toJSON(): T;
   toObject(): T;
 
-  withMutations(mutator: (mutable: this) => mixed): this;
-  asMutable(): this;
-  asImmutable(): this;
+  withMutations(mutator: (mutable: this) => mixed): this & T;
+  asMutable(): this & T;
+  asImmutable(): this & T;
 
   @@iterator(): Iterator<[$Keys<T>, any]>;
 }
@@ -1268,6 +1268,7 @@ export type {
   SetCollection,
   KeyedSeq,
   IndexedSeq,
+  RecordInstance,
   SetSeq,
   ValueObject,
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-plugin-jsx-a11y": "4.0.0",
     "eslint-plugin-prettier": "2.0.1",
     "eslint-plugin-react": "6.10.0",
-    "flow-bin": "0.41.0",
+    "flow-bin": "0.50.0",
     "gulp": "3.9.1",
     "gulp-concat": "2.6.1",
     "gulp-filter": "5.0.0",

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1151,35 +1151,35 @@ declare class RecordInstance<T: Object> {
   size: number;
 
   has(key: string): boolean;
-  get<K: $Keys<T>>(key: K): /*T[K]*/any;
+  get<K: $Keys<T>>(key: K): $ElementType<T, K>;
 
   equals(other: any): boolean;
   hashCode(): number;
 
-  set<K: $Keys<T>>(key: K, value: /*T[K]*/any): this;
-  update<K: $Keys<T>>(key: K, updater: (value: /*T[K]*/any) => /*T[K]*/any): this;
-  merge(...collections: Array<$Shape<T> | Iterable<[string, any]>>): this;
-  mergeDeep(...collections: Array<$Shape<T> | Iterable<[string, any]>>): this;
+  set<K: $Keys<T>>(key: K, value: $ElementType<T, K>): this & T;
+  update<K: $Keys<T>>(key: K, updater: (value: $ElementType<T, K>) => $ElementType<T, K>): this & T;
+  merge(...collections: Array<$Shape<T> | Iterable<[string, any]>>): this & T;
+  mergeDeep(...collections: Array<$Shape<T> | Iterable<[string, any]>>): this & T;
 
   mergeWith(
     merger: (oldVal: any, newVal: any, key: $Keys<T>) => any,
     ...collections: Array<$Shape<T> | Iterable<[string, any]>>
-  ): this;
+  ): this & T;
   mergeDeepWith(
     merger: (oldVal: any, newVal: any, key: any) => any,
     ...collections: Array<$Shape<T> | Iterable<[string, any]>>
-  ): this;
+  ): this & T;
 
-  delete<K: $Keys<T>>(key: K): this;
-  remove<K: $Keys<T>>(key: K): this;
-  clear(): this;
+  delete<K: $Keys<T>>(key: K): this & T;
+  remove<K: $Keys<T>>(key: K): this & T;
+  clear(): this & T;
 
-  setIn(keyPath: Iterable<any>, value: any): this;
-  updateIn(keyPath: Iterable<any>, updater: (value: any) => any): this;
-  mergeIn(keyPath: Iterable<any>, ...collections: Array<any>): this;
-  mergeDeepIn(keyPath: Iterable<any>, ...collections: Array<any>): this;
-  deleteIn(keyPath: Iterable<any>): this;
-  removeIn(keyPath: Iterable<any>): this;
+  setIn(keyPath: Iterable<any>, value: any): this & T;
+  updateIn(keyPath: Iterable<any>, updater: (value: any) => any): this & T;
+  mergeIn(keyPath: Iterable<any>, ...collections: Array<any>): this & T;
+  mergeDeepIn(keyPath: Iterable<any>, ...collections: Array<any>): this & T;
+  deleteIn(keyPath: Iterable<any>): this & T;
+  removeIn(keyPath: Iterable<any>): this & T;
 
   toSeq(): KeyedSeq<$Keys<T>, any>;
 
@@ -1187,9 +1187,9 @@ declare class RecordInstance<T: Object> {
   toJSON(): T;
   toObject(): T;
 
-  withMutations(mutator: (mutable: this) => mixed): this;
-  asMutable(): this;
-  asImmutable(): this;
+  withMutations(mutator: (mutable: this) => mixed): this & T;
+  asMutable(): this & T;
+  asImmutable(): this & T;
 
   @@iterator(): Iterator<[$Keys<T>, any]>;
 }
@@ -1268,6 +1268,7 @@ export type {
   SetCollection,
   KeyedSeq,
   IndexedSeq,
+  RecordInstance,
   SetSeq,
   ValueObject,
 }

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -13,6 +13,7 @@ import Immutable, {
   Seq,
   Range,
   Repeat,
+  Record,
   OrderedMap,
   OrderedSet,
 } from '../../'
@@ -21,6 +22,7 @@ import * as Immutable2 from '../../'
 import type {
   KeyedCollection,
   IndexedCollection,
+  RecordInstance,
   SetCollection,
   KeyedSeq,
   IndexedSeq,
@@ -773,3 +775,26 @@ let numberSeq = Seq([ 1, 2, 3 ])
 // $ExpectError
 let numberSeqSize: number = numberSeq.size
 let maybeNumberSeqSize: ?number = numberSeq.size
+
+/* Record */
+
+type PersonRecordMembers = { age: number, name: string }
+const PersonRecordClass = Record(({
+  age: 12,
+  name: 'Facebook',
+}: PersonRecordMembers))
+type PersonRecordInstance = RecordInstance<PersonRecordMembers> & PersonRecordMembers;
+
+const personRecordInstance: PersonRecordInstance = PersonRecordClass({ age: 25 })
+
+// $ExpectError
+{ const age: string = personRecordInstance.get('age') }
+// $ExpectError
+{ const age: string = personRecordInstance.age }
+{ const age: number = personRecordInstance.get('age') }
+{ const age: number = personRecordInstance.age }
+
+// $ExpectError
+personRecordInstance.set('invalid', 25)
+personRecordInstance.set('name', '25')
+personRecordInstance.set('age', 33)


### PR DESCRIPTION
This pull request aims to help out a bit with issues #1240 and #1172 . It does 3 things:

1) Exposes `RecordInstance` for import
2) Changes the return type of some chainable functions to return `this & T` instead of just `this`
3) Uses the new `$ElementType<T, K>` for some better type safety

Note that I cannot seem to get `$ElementType<T, K>` to check `set` properly, but it works fine for `get`. I really don't know why it wouldn't work the same, so any assistance would be appreciated.