### PR TITLE
Fix get and set types using the new $ElementType

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1151,13 +1151,13 @@ declare class RecordInstance<T: Object> {
   size: number;
 
   has(key: string): boolean;
-  get<K: $Keys<T>>(key: K): /*T[K]*/any;
+  get<K: $Keys<T>>(key: K): $ElementType<T, K>;
 
   equals(other: any): boolean;
   hashCode(): number;
 
-  set<K: $Keys<T>>(key: K, value: /*T[K]*/any): this;
-  update<K: $Keys<T>>(key: K, updater: (value: /*T[K]*/any) => /*T[K]*/any): this;
+  set<K: $Keys<T>>(key: K, value: $ElementType<T, K>): this;
+  update<K: $Keys<T>>(key: K, updater: (value: $ElementType<T, K>) => $ElementType<T, K>): this;
   merge(...collections: Array<$Shape<T> | Iterable<[string, any]>>): this;
   mergeDeep(...collections: Array<$Shape<T> | Iterable<[string, any]>>): this;
 


### PR DESCRIPTION
Flow finally added $ElementType<T, K> which works exactly like Typescript's `T[K]`.
Updated the types of record to use it.