### PR TITLE
Only build docs on tagged releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ deploy:
     on:
       branch: master
       repo: facebook/immutable-js
+      tags: true

--- a/pages/src/docs/src/DocHeader.js
+++ b/pages/src/docs/src/DocHeader.js
@@ -1,6 +1,7 @@
 var React = require('react');
 var SVGSet = require('../../src/SVGSet');
 var Logo = require('../../src/Logo');
+var packageJson = require('../../../../package.json');
 
 var DocHeader = React.createClass({
   render() {
@@ -15,7 +16,7 @@ var DocHeader = React.createClass({
               </SVGSet>
             </a>
             <a href="./" target="_self">
-              Docs
+              Docs (v{packageJson.version})
             </a>
             <a href="https://stackoverflow.com/questions/tagged/immutable.js?sort=votes">
               Questions

--- a/pages/src/src/Header.js
+++ b/pages/src/src/Header.js
@@ -2,6 +2,7 @@ var React = require('react');
 var SVGSet = require('./SVGSet');
 var Logo = require('./Logo');
 var StarBtn = require('./StarBtn');
+var packageJson = require('../../../package.json');
 
 var isMobileMatch =
   window.matchMedia && window.matchMedia('(max-device-width: 680px)');
@@ -59,7 +60,7 @@ var Header = React.createClass({
               </SVGSet>
             </a>
             <a href="docs/" target="_self">
-              Docs
+              Docs (v{packageJson.version})
             </a>
             <a href="https://stackoverflow.com/questions/tagged/immutable.js?sort=votes">
               Questions
@@ -73,7 +74,7 @@ var Header = React.createClass({
               <div className="filler">
                 <div className="miniHeaderContents">
                   <a href="docs/" target="_self">
-                    Docs
+                    Docs (v{packageJson.version})
                   </a>
                   <a href="https://stackoverflow.com/questions/tagged/immutable.js?sort=votes">
                     Questions


### PR DESCRIPTION
This adds a version number to the "docs" link on the site to resolve confusion, and ensures docs are only rebuilt on a tagged release so they do not get out of sync with real releases