### PR TITLE
Adds RecordFactory<TObj> as a better way to type the result of Record()

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1296,17 +1296,21 @@ declare class Stack<+T> extends IndexedCollection<T> {
 declare function Range(start?: number, end?: number, step?: number): IndexedSeq<number>;
 declare function Repeat<T>(value: T, times?: number): IndexedSeq<T>;
 
+// The type of a Record factory function.
+type RecordFactory<Values: Object> = Class<RecordInstance<Values>>;
+
+// The type of runtime Record instances.
+type RecordOf<Values: Object> = RecordInstance<Values> & Values;
+
 declare function isRecord(maybeRecord: any): boolean %checks(maybeRecord instanceof RecordInstance);
 declare class Record {
-  static <Values: Object>(spec: Values, name?: string): Class<RecordInstance<Values>>;
-  constructor<Values: Object>(spec: Values, name?: string): Class<RecordInstance<Values>>;
+  static <Values: Object>(spec: Values, name?: string): RecordFactory<Values>;
+  constructor<Values: Object>(spec: Values, name?: string): RecordFactory<Values>;
 
   static isRecord: typeof isRecord;
 
   static getDescriptiveName(record: RecordInstance<any>): string;
 }
-
-type RecordOf<Values: Object> = RecordInstance<Values> & Values;
 
 declare class RecordInstance<T: Object> {
   static (values?: $Shape<T> | Iterable<[string, any]>): RecordOf<T>;
@@ -1435,7 +1439,7 @@ export type {
   KeyedSeq,
   IndexedSeq,
   SetSeq,
+  RecordFactory,
   RecordOf,
-  RecordInstance,
   ValueObject,
 }

--- a/type-definitions/tests/record.js
+++ b/type-definitions/tests/record.js
@@ -10,12 +10,17 @@
 // Some tests look like they are repeated in order to avoid false positives.
 // Flow might not complain about an instance of (what it thinks is) T to be assigned to T<K, V>
 
-import { Record, type RecordOf } from '../../';
+import { Record, type RecordFactory, type RecordOf } from '../../';
 
-const Point2 = Record({x:0, y:0});
-const Point3 = Record({x:0, y:0, z:0});
+// Use the RecordFactory type to annotate
+const Point2: RecordFactory<{x: number, y: number}> = Record({x:0, y:0});
+const Point3: RecordFactory<{x: number, y: number, z: number}> =
+  Record({x:0, y:0, z:0});
 type TGeoPoint = {lat: ?number, lon: ?number}
-const GeoPoint = Record(({lat: null, lon: null}: TGeoPoint));
+const GeoPoint: RecordFactory<TGeoPoint> = Record({lat: null, lon: null});
+
+// $ExpectError - 'abc' is not a number
+const PointWhoops: RecordFactory<{x: number, y: number}> = Record({x:0, y:'abc'});
 
 let origin2 = Point2({});
 let origin3 = Point3({});
@@ -26,8 +31,10 @@ origin3 = GeoPoint({lat:34})
 geo = Point3({});
 
 // Use RecordOf to type the return value of a Record factory function.
-// This should expect an error, is flow confused?
-let geoPointExpected: RecordOf<TGeoPoint> = GeoPoint({});
+let geoPointExpected1: RecordOf<TGeoPoint> = GeoPoint({});
+
+// $ExpectError - Point2 does not return GeoPoint.
+let geoPointExpected2: RecordOf<TGeoPoint> = Point2({});
 
 const px = origin2.get('x');
 const px2: number = origin2.x;
@@ -37,7 +44,7 @@ const pz = origin2.get('z');
 const pz2 = origin2.z;
 
 origin2.set('x', 4);
-// Note: this should be an error, but Flow does not yet support index types.
+// $ExpectError
 origin2.set('x', 'not-a-number');
 // $ExpectError
 origin2.set('z', 3);


### PR DESCRIPTION
For example:

```js
import type {RecordFactory, RecordOf} from 'immutable';

const Point2: RecordFactory<{x: number, y: number}> = Record({x:0, y:0});

const aPoint2: RecordOf<{x: number, y: number}> = Point2();
```