### PR TITLE
Set wasAltered() to false after List.asImmutable()

### DIFF
--- a/__tests__/issues.ts
+++ b/__tests__/issues.ts
@@ -8,7 +8,7 @@
 ///<reference path='../resources/jest.d.ts'/>
 
 declare var Symbol: any;
-import { List, OrderedMap, Seq, Set } from '../';
+import { List, OrderedMap, Record, Seq, Set } from '../';
 
 describe('Issue #1175', () => {
   it('invalid hashCode() response should not infinitly recurse', () => {
@@ -49,5 +49,13 @@ describe('Issue #1287', () => {
   it('should skip all items in OrderedMap when skipping Infinity', () => {
     const size = OrderedMap([['a', 1]]).skip(Infinity).size;
     expect(size).toEqual(0);
+  });
+});
+
+describe('Issue #1247', () => {
+  it('Records should not be considered altered after creation', () => {
+    const R = Record({ a: 1 });
+    const r = new R();
+    expect(r.wasAltered()).toBe(false);
   });
 });

--- a/src/List.js
+++ b/src/List.js
@@ -208,6 +208,7 @@ export class List extends IndexedCollection {
         return emptyList();
       }
       this.__ownerID = ownerID;
+      this.__altered = false;
       return this;
     }
     return makeList(

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -790,6 +790,11 @@ declare module Immutable {
     asMutable(): this;
 
     /**
+     * @see `Map#wasAltered`
+     */
+    wasAltered(): boolean;
+
+    /**
      * @see `Map#asImmutable`
      */
     asImmutable(): this;
@@ -1515,6 +1520,14 @@ declare module Immutable {
     asMutable(): this;
 
     /**
+     * Returns true if this is a mutable copy (see `asMutable()`) and mutative
+     * alterations have been applied.
+     *
+     * @see `Map#asMutable`
+     */
+    wasAltered(): boolean;
+
+    /**
      * The yin to `asMutable`'s yang. Because it applies to mutable collections,
      * this operation is *mutable* and returns itself. Once performed, the mutable
      * copy has become immutable and can be safely returned from a function.
@@ -1851,6 +1864,11 @@ declare module Immutable {
      * @see `Map#asMutable`
      */
     asMutable(): this;
+
+    /**
+     * @see `Map#wasAltered`
+     */
+    wasAltered(): boolean;
 
     /**
      * @see `Map#asImmutable`
@@ -2218,6 +2236,11 @@ declare module Immutable {
     asMutable(): this;
 
     /**
+     * @see `Map#wasAltered`
+     */
+    wasAltered(): boolean;
+
+    /**
      * @see `Map#asImmutable`
      */
     asImmutable(): this;
@@ -2563,6 +2586,11 @@ declare module Immutable {
        * @see `Map#asMutable`
        */
       asMutable(): this;
+
+      /**
+       * @see `Map#wasAltered`
+       */
+      wasAltered(): boolean;
 
       /**
        * @see `Map#asImmutable`

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -665,6 +665,7 @@ declare class List<+T> extends IndexedCollection<T> {
 
   withMutations(mutator: (mutable: this) => mixed): this;
   asMutable(): this;
+  wasAltered(): boolean;
   asImmutable(): this;
 
   // Override specialized return types
@@ -847,6 +848,7 @@ declare class Map<K, +V> extends KeyedCollection<K, V> {
 
   withMutations(mutator: (mutable: this) => mixed): this;
   asMutable(): this;
+  wasAltered(): boolean;
   asImmutable(): this;
 
   // Override specialized return types
@@ -941,6 +943,7 @@ declare class OrderedMap<K, +V> extends Map<K, V> {
 
   withMutations(mutator: (mutable: this) => mixed): this;
   asMutable(): this;
+  wasAltered(): boolean;
   asImmutable(): this;
 
   // Override specialized return types
@@ -1000,6 +1003,7 @@ declare class Set<+T> extends SetCollection<T> {
 
   withMutations(mutator: (mutable: this) => mixed): this;
   asMutable(): this;
+  wasAltered(): boolean;
   asImmutable(): this;
 
   // Override specialized return types
@@ -1175,6 +1179,7 @@ declare class Stack<+T> extends IndexedCollection<T> {
 
   withMutations(mutator: (mutable: this) => mixed): this;
   asMutable(): this;
+  wasAltered(): boolean;
   asImmutable(): this;
 
   // Override specialized return types
@@ -1359,6 +1364,7 @@ declare class RecordInstance<T: Object> {
 
   withMutations(mutator: (mutable: this) => mixed): this & T;
   asMutable(): this & T;
+  wasAltered(): boolean;
   asImmutable(): this & T;
 
   @@iterator(): Iterator<[$Keys<T>, any]>;


### PR DESCRIPTION
Also adds wasAltered() to type definitions, since it was missing.

Fixes #1247