### PR TITLE
Fix slow iterator for Set

### DIFF
--- a/src/Set.js
+++ b/src/Set.js
@@ -64,7 +64,7 @@ export class Set extends SetCollection {
   // @pragma Modification
 
   add(value) {
-    return updateSet(this, this._map.set(value, true));
+    return updateSet(this, this._map.set(value, value));
   }
 
   remove(value) {
@@ -150,11 +150,11 @@ export class Set extends SetCollection {
   }
 
   __iterate(fn, reverse) {
-    return this._map.__iterate((_, k) => fn(k, k, this), reverse);
+    return this._map.__iterate(k => fn(k, k, this), reverse);
   }
 
   __iterator(type, reverse) {
-    return this._map.map((_, k) => k).__iterator(type, reverse);
+    return this._map.__iterator(type, reverse);
   }
 
   __ensureOwner(ownerID) {


### PR DESCRIPTION
Replace's Set's internal representation of Map<V, true> to Map<V, V>, which more closely mirrors Set's own representation of presenting keys and values as the same value.

Fixes #1249