### PR TITLE
Fix ts definitions for merge functions

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -680,7 +680,7 @@ declare module Immutable {
      *
      * @see `Map#merge`
      */
-    merge(...collections: Array<Collection.Indexed<T> | Array<T>>): this;
+    merge(...collections: Array<Iterable<T>>): this;
 
     /**
      * Note: `mergeWith` can be used in `withMutations`.
@@ -689,7 +689,7 @@ declare module Immutable {
      */
     mergeWith(
       merger: (oldVal: T, newVal: T, key: number) => T,
-      ...collections: Array<Collection.Indexed<T> | Array<T>>
+      ...collections: Array<Iterable<T>>
     ): this;
 
     /**
@@ -697,7 +697,7 @@ declare module Immutable {
      *
      * @see `Map#mergeDeep`
      */
-    mergeDeep(...collections: Array<Collection.Indexed<T> | Array<T>>): this;
+    mergeDeep(...collections: Array<Iterable<T>>): this;
 
     /**
      * Note: `mergeDeepWith` can be used in `withMutations`.
@@ -705,7 +705,7 @@ declare module Immutable {
      */
     mergeDeepWith(
       merger: (oldVal: T, newVal: T, key: number) => T,
-      ...collections: Array<Collection.Indexed<T> | Array<T>>
+      ...collections: Array<Iterable<T>>
     ): this;
 
     /**
@@ -1251,7 +1251,7 @@ declare module Immutable {
      *
      * Note: `merge` can be used in `withMutations`.
      */
-    merge(...collections: Array<Collection<K, V> | {[key: string]: V}>): this;
+    merge(...collections: Array<Iterable<[K, V]> | {[key: string]: V}>): this;
 
     /**
      * Like `merge()`, `mergeWith()` returns a new Map resulting from merging
@@ -1273,7 +1273,7 @@ declare module Immutable {
      */
     mergeWith(
       merger: (oldVal: V, newVal: V, key: K) => V,
-      ...collections: Array<Collection<K, V> | {[key: string]: V}>
+      ...collections: Array<Iterable<[K, V]> | {[key: string]: V}>
     ): this;
 
     /**
@@ -1295,7 +1295,7 @@ declare module Immutable {
      *
      * Note: `mergeDeep` can be used in `withMutations`.
      */
-    mergeDeep(...collections: Array<Collection<K, V> | {[key: string]: V}>): this;
+    mergeDeep(...collections: Array<Iterable<[K, V]> | {[key: string]: V}>): this;
 
     /**
      * Like `mergeDeep()`, but when two non-Collections conflict, it uses the
@@ -1318,7 +1318,7 @@ declare module Immutable {
      */
     mergeDeepWith(
       merger: (oldVal: V, newVal: V, key: K) => V,
-      ...collections: Array<Collection<K, V> | {[key: string]: V}>
+      ...collections: Array<Iterable<[K, V]> | {[key: string]: V}>
     ): this;
 
 
@@ -1825,8 +1825,8 @@ declare module Immutable {
      * Note: `union` can be used in `withMutations`.
      * @alias merge
      */
-    union(...collections: Array<Collection<any, T> | Array<T>>): this;
-    merge(...collections: Array<Collection<any, T> | Array<T>>): this;
+    union(...collections: Array<Iterable<T>>): this;
+    merge(...collections: Array<Iterable<T>>): this;
 
     /**
      * Returns a Set which has removed any values not also contained


### PR DESCRIPTION
Merge functions accept any iterable, not just collections.

Closes #1303