### PR TITLE
BREAKING: no longer deeply coerce argument to merge()

### DIFF
--- a/__tests__/issues.ts
+++ b/__tests__/issues.ts
@@ -59,3 +59,15 @@ describe('Issue #1247', () => {
     expect(r.wasAltered()).toBe(false);
   });
 });
+
+describe('Issue #1293', () => {
+  it('merge() should not deeply coerce values', () => {
+    const State = Record({ foo: 'bar' as any, biz: 'baz' });
+    const deepObject = { qux: 'quux' };
+
+    const firstState = State({ foo: deepObject });
+    const secondState = State().merge({ foo: deepObject });
+
+    expect(secondState).toEqual(firstState);
+  });
+});

--- a/src/List.js
+++ b/src/List.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { fromJS } from './fromJS';
 import {
   DELETE,
   SHIFT,
@@ -21,7 +20,6 @@ import {
   resolveEnd
 } from './TrieUtils';
 import { IndexedCollection } from './Collection';
-import { isCollection } from './Predicates';
 import {
   MapPrototype,
   mergeIntoCollectionWith,
@@ -658,13 +656,9 @@ function mergeIntoListWith(list, merger, collections) {
   const iters = [];
   let maxSize = 0;
   for (let ii = 0; ii < collections.length; ii++) {
-    const value = collections[ii];
-    let iter = IndexedCollection(value);
+    const iter = IndexedCollection(collections[ii]);
     if (iter.size > maxSize) {
       maxSize = iter.size;
-    }
-    if (!isCollection(value)) {
-      iter = iter.map(v => fromJS(v));
     }
     iters.push(iter);
   }

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -1234,11 +1234,8 @@ declare module Immutable {
      * (or JS objects) into this Map. In other words, this takes each entry of
      * each collection and sets it on this Map.
      *
-     * If any of the values provided to `merge` are not Collection (would return
-     * false for `isCollection`) then they are deeply converted
-     * via `fromJS` before being merged. However, if the value is an
-     * Collection but includes non-collection JS objects or arrays, those nested
-     * values will be preserved.
+     * Note: Values provided to `merge` are shallowly converted before being
+     * merged. No nested values are altered.
      *
      * <!-- runkit:activate -->
      * ```js
@@ -1279,6 +1276,10 @@ declare module Immutable {
     /**
      * Like `merge()`, but when two Collections conflict, it merges them as well,
      * recursing deeply through the nested data.
+     *
+     * Note: Values provided to `merge` are shallowly converted before being
+     * merged. No nested values are altered unless they will also be merged at
+     * a deeper level.
      *
      * <!-- runkit:activate -->
      * ```js


### PR DESCRIPTION
The methods `merge()` and `mergeDeep()` were the last places internally to call `fromJS()`, a method that is expensive, and limits the ability to use plain object and array values within immutable collections.

This PR removes fromJS, not doing any deep coercion at all for `merge()` and simply passing object (incl array) values into the `merge()` function recursively for `mergeDeep()` operations, so only coercing those values that expect to be - leaving others alone.

This is breaking because calls to `merge()` previously were implicitly `fromJS()`'d to get deeply immutable collections, however that is no longer the case.

To update code which relied on this behavior, convert `collection.merge(x)` to `collection.merge(fromJS(x))`.

Fixes #1293