### PR TITLE
BREAKING: KeyedCollection.toArray() returns array of tuples.

### DIFF
--- a/__tests__/ObjectSeq.ts
+++ b/__tests__/ObjectSeq.ts
@@ -32,13 +32,13 @@ describe('ObjectSequence', () => {
   it('is reversable', () => {
     let i = Seq({a: 'A', b: 'B', c: 'C'});
     let k = i.reverse().toArray();
-    expect(k).toEqual(['C', 'B', 'A']);
+    expect(k).toEqual([['c', 'C'], ['b', 'B'], ['a', 'A']]);
   });
 
-  it('can double reversable', () => {
+  it('is double reversable', () => {
     let i = Seq({a: 'A', b: 'B', c: 'C'});
     let k = i.reverse().reverse().toArray();
-    expect(k).toEqual(['A', 'B', 'C']);
+    expect(k).toEqual([['a', 'A'], ['b', 'B'], ['c', 'C']]);
   });
 
   it('can be iterated', () => {

--- a/__tests__/OrderedMap.ts
+++ b/__tests__/OrderedMap.ts
@@ -16,7 +16,7 @@ describe('OrderedMap', () => {
     expect(m.get('a')).toBe('A');
     expect(m.get('b')).toBe('B');
     expect(m.get('c')).toBe('C');
-    expect(m.toArray()).toEqual(['C', 'B', 'A']);
+    expect(m.toArray()).toEqual([['c', 'C'], ['b', 'B'], ['a', 'A']]);
   });
 
   it('constructor provides initial values', () => {
@@ -25,7 +25,7 @@ describe('OrderedMap', () => {
     expect(m.get('b')).toBe('B');
     expect(m.get('c')).toBe('C');
     expect(m.size).toBe(3);
-    expect(m.toArray()).toEqual(['A', 'B', 'C']);
+    expect(m.toArray()).toEqual([['a', 'A'], ['b', 'B'], ['c', 'C']]);
   });
 
   it('provides initial values in a mixed order', () => {
@@ -34,7 +34,7 @@ describe('OrderedMap', () => {
     expect(m.get('b')).toBe('B');
     expect(m.get('c')).toBe('C');
     expect(m.size).toBe(3);
-    expect(m.toArray()).toEqual(['C', 'B', 'A']);
+    expect(m.toArray()).toEqual([['c', 'C'], ['b', 'B'], ['a', 'A']]);
   });
 
   it('constructor accepts sequences', () => {
@@ -44,7 +44,7 @@ describe('OrderedMap', () => {
     expect(m.get('b')).toBe('B');
     expect(m.get('c')).toBe('C');
     expect(m.size).toBe(3);
-    expect(m.toArray()).toEqual(['C', 'B', 'A']);
+    expect(m.toArray()).toEqual([['c', 'C'], ['b', 'B'], ['a', 'A']]);
   });
 
   it('maintains order when new keys are set', () => {
@@ -53,7 +53,7 @@ describe('OrderedMap', () => {
       .set('Z', 'zebra')
       .set('A', 'antelope');
     expect(m.size).toBe(2);
-    expect(m.toArray()).toEqual(['antelope', 'zebra']);
+    expect(m.toArray()).toEqual([['A', 'antelope'], ['Z', 'zebra']]);
   });
 
   it('resets order when a keys is deleted', () => {
@@ -63,7 +63,7 @@ describe('OrderedMap', () => {
       .remove('A')
       .set('A', 'antelope');
     expect(m.size).toBe(2);
-    expect(m.toArray()).toEqual(['zebra', 'antelope']);
+    expect(m.toArray()).toEqual([['Z', 'zebra'], ['A', 'antelope']]);
   });
 
   it('removes correctly', () => {

--- a/__tests__/concat.ts
+++ b/__tests__/concat.ts
@@ -125,8 +125,11 @@ describe('concat', () => {
   it('iterates repeated keys', () => {
     let a = Seq({a: 1, b: 2, c: 3});
     expect(a.concat(a, a).toObject()).toEqual({a: 1, b: 2, c: 3});
-    expect(a.concat(a, a).toArray()).toEqual([1, 2, 3, 1, 2, 3, 1, 2, 3]);
+    expect(a.concat(a, a).valueSeq().toArray()).toEqual([1, 2, 3, 1, 2, 3, 1, 2, 3]);
     expect(a.concat(a, a).keySeq().toArray()).toEqual(['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c']);
+    expect(a.concat(a, a).toArray()).toEqual(
+      [['a', 1], ['b', 2], ['c', 3], ['a', 1], ['b', 2], ['c', 3], ['a', 1], ['b', 2], ['c', 3]],
+    );
   });
 
   it('lazily reverses un-indexed sequences', () => {
@@ -145,7 +148,7 @@ describe('concat', () => {
     let a = Seq([1, 2, 3]).filter(x => true);
     expect(a.size).toBe(undefined); // Note: lazy filter does not know what size in O(1).
     expect(a.concat(a, a).toKeyedSeq().reverse().size).toBe(undefined);
-    expect(a.concat(a, a).toKeyedSeq().reverse().entrySeq().toArray()).toEqual(
+    expect(a.concat(a, a).toKeyedSeq().reverse().toArray()).toEqual(
       [[8, 3], [7, 2], [6, 1], [5, 3], [4, 2], [3, 1], [2, 3], [1, 2], [0, 1]],
     );
   });

--- a/__tests__/groupBy.ts
+++ b/__tests__/groupBy.ts
@@ -17,7 +17,7 @@ describe('groupBy', () => {
 
     // Each group should be a keyed sequence, not an indexed sequence
     const firstGroup = grouped.get(1);
-    expect(firstGroup && firstGroup.toArray()).toEqual([1, 3]);
+    expect(firstGroup && firstGroup.toArray()).toEqual([['a', 1], ['c', 3]]);
   });
 
   it('groups indexed sequence', () => {

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -104,8 +104,11 @@ mixin(Collection, {
   toArray() {
     assertNotInfinite(this.size);
     const array = new Array(this.size || 0);
-    this.valueSeq().__iterate((v, i) => {
-      array[i] = v;
+    const useTuples = isKeyed(this);
+    let i = 0;
+    this.__iterate((v, k) => {
+      // Keyed collections produce an array of tuples.
+      array[i++] = useTuples ? [k, v] : v;
     });
     return array;
   },

--- a/src/Operations.js
+++ b/src/Operations.js
@@ -734,6 +734,7 @@ export function sortFactory(collection, comparator, mapper) {
   const entries = collection
     .toSeq()
     .map((v, k) => [k, v, index++, mapper ? mapper(v, k, collection) : v])
+    .valueSeq()
     .toArray();
   entries.sort((a, b) => comparator(a[3], b[3]) || a[2] - b[2]).forEach(
     isKeyedCollection

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2662,6 +2662,11 @@ declare module Immutable {
       toJSON(): { [key: string]: V };
 
       /**
+       * Shallowly converts this collection to an Array.
+       */
+      toArray(): Array<[K, V]>;
+
+      /**
        * Returns itself
        */
       toSeq(): this;
@@ -2771,6 +2776,11 @@ declare module Immutable {
        * Shallowly converts this Indexed Seq to equivalent native JavaScript Array.
        */
       toJSON(): Array<T>;
+
+      /**
+       * Shallowly converts this collection to an Array.
+       */
+      toArray(): Array<T>;
 
       /**
        * Returns itself
@@ -2915,6 +2925,11 @@ declare module Immutable {
        * Shallowly converts this Set Seq to equivalent native JavaScript Array.
        */
       toJSON(): Array<T>;
+
+      /**
+       * Shallowly converts this collection to an Array.
+       */
+      toArray(): Array<T>;
 
       /**
        * Returns itself
@@ -3183,6 +3198,11 @@ declare module Immutable {
       toJSON(): { [key: string]: V };
 
       /**
+       * Shallowly converts this collection to an Array.
+       */
+      toArray(): Array<[K, V]>;
+
+      /**
        * Returns Seq.Keyed.
        * @override
        */
@@ -3329,6 +3349,11 @@ declare module Immutable {
        * Shallowly converts this Indexed collection to equivalent native JavaScript Array.
        */
       toJSON(): Array<T>;
+
+      /**
+       * Shallowly converts this collection to an Array.
+       */
+      toArray(): Array<T>;
 
       // Reading values
 
@@ -3606,6 +3631,11 @@ declare module Immutable {
       toJSON(): Array<T>;
 
       /**
+       * Shallowly converts this collection to an Array.
+       */
+      toArray(): Array<T>;
+
+      /**
        * Returns Seq.Set.
        * @override
        */
@@ -3822,9 +3852,12 @@ declare module Immutable {
     toJSON(): Array<V> | { [key: string]: V };
 
     /**
-     * Shallowly converts this collection to an Array, discarding keys.
+     * Shallowly converts this collection to an Array.
+     *
+     * `Collection.Indexed`, and `Collection.Set` produce an Array of values.
+     * `Collection.Keyed` produce an Array of [key, value] tuples.
      */
-    toArray(): Array<V>;
+    toArray(): Array<V> | Array<[K, V]>;
 
     /**
      * Shallowly converts this Collection to an Object.

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -50,7 +50,7 @@ declare class _Collection<K, +V> /*implements ValueObject*/ {
 
   toJS(): Array<any> | { [key: string]: mixed };
   toJSON(): Array<V> | { [key: string]: V };
-  toArray(): Array<V>;
+  toArray(): Array<V> | Array<[K,V]>;
   toObject(): { [key: string]: V };
   toMap(): Map<K, V>;
   toOrderedMap(): OrderedMap<K, V>;
@@ -209,6 +209,7 @@ declare class KeyedCollection<K, +V> extends Collection<K, V> {
 
   toJS(): { [key: string]: mixed };
   toJSON(): { [key: string]: V };
+  toArray(): Array<[K, V]>;
   @@iterator(): Iterator<[K, V]>;
   toSeq(): KeyedSeq<K, V>;
   flip(): KeyedCollection<V, K>;
@@ -247,6 +248,7 @@ declare class IndexedCollection<+T> extends Collection<number, T> {
 
   toJS(): Array<mixed>;
   toJSON(): Array<T>;
+  toArray(): Array<T>;
   @@iterator(): Iterator<T>;
   toSeq(): IndexedSeq<T>;
   fromEntrySeq<K, V>(): KeyedSeq<K, V>;
@@ -388,6 +390,7 @@ declare class SetCollection<+T> extends Collection<T, T> {
 
   toJS(): Array<mixed>;
   toJSON(): Array<T>;
+  toArray(): Array<T>;
   @@iterator(): Iterator<T>;
   toSeq(): SetSeq<T>;
 


### PR DESCRIPTION
This fixes a long standing API quirk where `x.toArray()` had different behavior from `[...x]` or `Array.from(x)`.

This is breaking since previously Map, and other keyed collections would provide an array of only values from `.toArray()`, to fix code that relies on this behavior, convert `x.toArray()` to `x.valueSeq().toArray()`.

Likewise, for code that was working around this behavior before, `x.entrySeq().toArray()` can typically be replaced with `x.toArray()`.

Fixes #333