### PR TITLE
Remove the custom "is" matcher in favor of "toEqual"

### DIFF
--- a/__tests__/Conversion.ts
+++ b/__tests__/Conversion.ts
@@ -11,27 +11,6 @@ import * as jasmineCheck from "jasmine-check";
 import {fromJS, is, List, Map, OrderedMap, Record} from "../";
 jasmineCheck.install();
 
-declare function expect(val: any): ExpectWithIs;
-
-interface ExpectWithIs extends Expect {
-  is(expected: any): void;
-  not: ExpectWithIs;
-}
-
-jasmine.addMatchers({
-  is() {
-    return {
-      compare(actual, expected) {
-        let passed = is(actual, expected);
-        return {
-          pass: passed,
-          message: 'Expected ' + actual + (passed ? '' : ' not') + ' to equal ' + expected,
-        };
-      },
-    };
-  },
-});
-
 // Symbols
 declare function Symbol(name: string): Object;
 
@@ -131,7 +110,7 @@ describe('Conversion', () => {
   let nonStringKeyMapString = 'OrderedMap { 1: true, false: "foo" }';
 
   it('Converts deep JS to deep immutable sequences', () => {
-    expect(fromJS(js)).is(immutableData);
+    expect(fromJS(js)).toEqual(immutableData);
   });
 
   it('Throws when provided circular reference', () => {
@@ -149,8 +128,8 @@ describe('Conversion', () => {
       }
       return Array.isArray(this[key]) ? sequence.toList() : sequence.toOrderedMap();
     });
-    expect(seq).is(immutableOrderedData);
-    expect(seq.toString()).is(immutableOrderedDataString);
+    expect(seq).toEqual(immutableOrderedData);
+    expect(seq.toString()).toEqual(immutableOrderedDataString);
   });
 
   it('Converts deep JSON with custom conversion including keypath if requested', () => {
@@ -178,12 +157,12 @@ describe('Conversion', () => {
   });
 
   it('Prints keys as JS values', () => {
-    expect(nonStringKeyMap.toString()).is(nonStringKeyMapString);
+    expect(nonStringKeyMap.toString()).toEqual(nonStringKeyMapString);
   });
 
   it('Converts deep sequences to JS', () => {
     let js2 = immutableData.toJS();
-    expect(js2).not.is(js); // raw JS is not immutable.
+    expect(is(js2, js)).toBe(false); // raw JS is not immutable.
     expect(js2).toEqual(js); // but should be deep equal.
   });
 
@@ -211,7 +190,7 @@ describe('Conversion', () => {
   });
 
   it('is conservative with array-likes, only accepting true Arrays.', () => {
-    expect(fromJS({1: 2, length: 3})).is(
+    expect(fromJS({1: 2, length: 3})).toEqual(
       Map().set('1', 2).set('length', 3),
     );
     expect(fromJS('string')).toEqual('string');

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -10,27 +10,6 @@
 declare var Symbol: any;
 import { is, List, Map, OrderedSet, Seq, Set } from '../';
 
-declare function expect(val: any): ExpectWithIs;
-
-interface ExpectWithIs extends Expect {
-  is(expected: any): void;
-  not: ExpectWithIs;
-}
-
-jasmine.addMatchers({
-  is() {
-    return {
-      compare(actual, expected) {
-        let passed = is(actual, expected);
-        return {
-          pass: passed,
-          message: 'Expected ' + actual + (passed ? '' : ' not') + ' to equal ' + expected,
-        };
-      },
-    };
-  },
-});
-
 describe('Set', () => {
   it('accepts array of values', () => {
     let s = Set([1, 2, 3]);
@@ -211,17 +190,17 @@ describe('Set', () => {
 
   it('unions multiple sets', () => {
     let s = Set.of('A', 'B', 'C').union(Set.of('C', 'D', 'E'), Set.of('D', 'B', 'F'));
-    expect(s).is(Set.of('A', 'B', 'C', 'D', 'E', 'F'));
+    expect(s).toEqual(Set.of('A', 'B', 'C', 'D', 'E', 'F'));
   });
 
   it('intersects multiple sets', () => {
     let s = Set.of('A', 'B', 'C').intersect(Set.of('B', 'C', 'D'), Set.of('A', 'C', 'E'));
-    expect(s).is(Set.of('C'));
+    expect(s).toEqual(Set.of('C'));
   });
 
   it('diffs multiple sets', () => {
     let s = Set.of('A', 'B', 'C').subtract(Set.of('C', 'D', 'E'), Set.of('D', 'B', 'F'));
-    expect(s).is(Set.of('A'));
+    expect(s).toEqual(Set.of('A'));
   });
 
   it('expresses value equality with set sequences', () => {

--- a/__tests__/concat.ts
+++ b/__tests__/concat.ts
@@ -9,33 +9,12 @@
 
 import { is, List, Seq, Set } from '../';
 
-declare function expect(val: any): ExpectWithIs;
-
-interface ExpectWithIs extends Expect {
-  is(expected: any): void;
-  not: ExpectWithIs;
-}
-
-jasmine.addMatchers({
-  is() {
-    return {
-      compare(actual, expected) {
-        let passed = is(actual, expected);
-        return {
-          pass: passed,
-          message: 'Expected ' + actual + (passed ? '' : ' not') + ' to equal ' + expected,
-        };
-      },
-    };
-  },
-});
-
 describe('concat', () => {
 
   it('concats two sequences', () => {
     let a = Seq([1, 2, 3]);
     let b = Seq([4, 5, 6]);
-    expect(a.concat(b)).is(Seq([1, 2, 3, 4, 5, 6]));
+    expect(is(a.concat(b), Seq([1, 2, 3, 4, 5, 6]))).toBe(true);
     expect(a.concat(b).size).toBe(6);
     expect(a.concat(b).toArray()).toEqual([1, 2, 3, 4, 5, 6]);
   });
@@ -119,7 +98,7 @@ describe('concat', () => {
     let b = List();
     expect(b.concat(a)).not.toBe(a);
     expect(List.isList(b.concat(a))).toBe(true);
-    expect(b.concat(a)).is(List([1, 2, 3]));
+    expect(b.concat(a)).toEqual(List([1, 2, 3]));
   });
 
   it('iterates repeated keys', () => {

--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -9,44 +9,23 @@
 
 import { fromJS, is, List, Map } from '../';
 
-declare function expect(val: any): ExpectWithIs;
-
-interface ExpectWithIs extends Expect {
-  is(expected: any): void;
-  not: ExpectWithIs;
-}
-
-jasmine.addMatchers({
-  is() {
-    return {
-      compare(actual, expected) {
-        let passed = is(actual, expected);
-        return {
-          pass: passed,
-          message: 'Expected ' + actual + (passed ? '' : ' not') + ' to equal ' + expected,
-        };
-      },
-    };
-  },
-});
-
 describe('merge', () => {
   it('merges two maps', () => {
     let m1 = Map({a: 1, b: 2, c: 3});
     let m2 = Map({d: 10, b: 20, e: 30});
-    expect(m1.merge(m2)).is(Map({a: 1, b: 20, c: 3, d: 10, e: 30}));
+    expect(m1.merge(m2)).toEqual(Map({a: 1, b: 20, c: 3, d: 10, e: 30}));
   });
 
   it('can merge in an explicitly undefined value', () => {
     let m1 = Map({a: 1, b: 2});
     let m2 = Map({a: undefined as any});
-    expect(m1.merge(m2)).is(Map({a: undefined, b: 2}));
+    expect(m1.merge(m2)).toEqual(Map({a: undefined, b: 2}));
   });
 
   it('merges two maps with a merge function', () => {
     let m1 = Map({a: 1, b: 2, c: 3});
     let m2 = Map({d: 10, b: 20, e: 30});
-    expect(m1.mergeWith((a, b) => a + b, m2)).is(Map({a: 1, b: 22, c: 3, d: 10, e: 30}));
+    expect(m1.mergeWith((a, b) => a + b, m2)).toEqual(Map({a: 1, b: 22, c: 3, d: 10, e: 30}));
   });
 
   it('provides key as the third argument of merge function', () => {
@@ -55,13 +34,13 @@ describe('merge', () => {
     let add = (a, b) => a + b;
     expect(
       m1.mergeWith((a, b, key) => key !== 'id' ? add(a, b) : b, m2),
-    ).is(Map({id: 10, b: 22, c: 3, e: 30}));
+    ).toEqual(Map({id: 10, b: 22, c: 3, e: 30}));
   });
 
   it('deep merges two maps', () => {
     let m1 = fromJS({a: {b: {c: 1, d: 2}}});
     let m2 = fromJS({a: {b: {c: 10, e: 20}, f: 30}, g: 40});
-    expect(m1.mergeDeep(m2)).is(fromJS({a: {b: {c: 10, d: 2, e: 20}, f: 30}, g: 40}));
+    expect(m1.mergeDeep(m2)).toEqual(fromJS({a: {b: {c: 10, d: 2, e: 20}, f: 30}, g: 40}));
   });
 
   it('deep merge uses is() for return-self optimization', () =>  {
@@ -75,7 +54,7 @@ describe('merge', () => {
   it('deep merges raw JS', () => {
     let m1 = fromJS({a: {b: {c: 1, d: 2}}});
     let js = {a: {b: {c: 10, e: 20}, f: 30}, g: 40};
-    expect(m1.mergeDeep(js)).is(fromJS({a: {b: {c: 10, d: 2, e: 20}, f: 30}, g: 40}));
+    expect(m1.mergeDeep(js)).toEqual(fromJS({a: {b: {c: 10, d: 2, e: 20}, f: 30}, g: 40}));
   });
 
   it('deep merges raw JS with a merge function', () => {
@@ -83,7 +62,7 @@ describe('merge', () => {
     let js = {a: {b: {c: 10, e: 20}, f: 30}, g: 40};
     expect(
       m1.mergeDeepWith((a, b) => a + b, js),
-    ).is(fromJS(
+    ).toEqual(fromJS(
       {a: {b: {c: 11, d: 2, e: 20}, f: 30}, g: 40},
     ));
   });
@@ -152,7 +131,7 @@ describe('merge', () => {
       Map({a: Map({b: List.of( {plain: 'obj'} )})}),
     );
 
-    expect(m1.getIn(['a', 'b', 0])).is(Map([['imm', 'map']]));
+    expect(m1.getIn(['a', 'b', 0])).toEqual(Map([['imm', 'map']]));
     // However mergeDeep will merge that value into the inner Map
     expect(m2.getIn(['a', 'b', 0])).toEqual(Map({imm: 'map', plain: 'obj'}));
   });


### PR DESCRIPTION
jest has dramatically improved over the years, and supports Immutable values directly! No need for our custom checker.