### PR TITLE
Speed up test runs

### DIFF
--- a/resources/jestPreprocessor.js
+++ b/resources/jestPreprocessor.js
@@ -7,29 +7,18 @@
 
 var typescript = require('typescript');
 
+var options = {
+  noEmitOnError: true,
+  target: typescript.ScriptTarget.ES2015,
+  module: typescript.ModuleKind.CommonJS,
+  strictNullChecks: true,
+};
+
 module.exports = {
-  process: function(src, filePath) {
-    var compiled;
-
-    var options = {
-      noEmitOnError: true,
-      target: typescript.ScriptTarget.ES2015,
-      module: typescript.ModuleKind.CommonJS,
-      strictNullChecks: true,
-    };
-
-    var host = typescript.createCompilerHost(options);
-    var program = typescript.createProgram([filePath], options, host);
-
-    host.writeFile = (name, text) => compiled = text;
-    var emitResult = program.emit();
-    var diagnostics = typescript.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
-
-    if (diagnostics.length === 0) {
-      return compiled;
+  process(src, path) {
+    if (path.endsWith('.ts') || path.endsWith('.tsx')) {
+      return typescript.transpile(src, options, path, []);
     }
-
-    var report = typescript.formatDiagnostics(diagnostics, host);
-    throw new Error('Compiling ' + filePath + ' failed' + '\n' + report);
-  }
+    return src;
+  },
 };


### PR DESCRIPTION
This replaces type checking of tests with a simple transpile, which makes running tests 10x faster.

This is possible without reducing test coverage by the recent addition of ts-tests which performs type checking against the typescript tests.