### PR TITLE
BREAKING: concat Lists when merging deeply

### DIFF
--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -7,7 +7,7 @@
 
 ///<reference path='../resources/jest.d.ts'/>
 
-import { fromJS, is, List, Map } from '../';
+import { fromJS, is, List, Map, Set } from '../';
 
 describe('merge', () => {
   it('merges two maps', () => {
@@ -108,7 +108,15 @@ describe('merge', () => {
     expect(m1.mergeDeep(m2).get('a')).toEqual(Map({x: 1, y: 1, z: 10}));
   });
 
-  it('merges map entries with Vector values', () => {
+  it('merges map enties with List and Set values', () => {
+    const initial = Map({a: Map({x: 10, y: 20}), b: List([1, 2, 3]), c: Set([1, 2, 3])});
+    const additions = Map({a: Map({y: 50, z: 100}), b: List([4, 5, 6]), c: Set([4, 5, 6])});
+    expect(initial.mergeDeep(additions)).toEqual(
+      Map({a: Map({x: 10, y: 50, z: 100}), b: List([1, 2, 3, 4, 5, 6]), c: Set([1, 2, 3, 4, 5, 6])}),
+    );
+  });
+
+  it('merges map entries with new values', () => {
     const initial = Map({a: List([1])});
 
     // Note: merge and mergeDeep do not deeply coerce values, they only merge
@@ -126,14 +134,14 @@ describe('merge', () => {
   });
 
   it('maintains JS values inside immutable collections', () => {
-    let m1 = fromJS({a: {b: [{imm: 'map'}]}});
+    let m1 = fromJS({a: {b: {imm: 'map'}}});
     let m2 = m1.mergeDeep(
-      Map({a: Map({b: List.of( {plain: 'obj'} )})}),
+      Map({a: Map({b: {plain: 'obj'} })}),
     );
 
-    expect(m1.getIn(['a', 'b', 0])).toEqual(Map([['imm', 'map']]));
+    expect(m1.getIn(['a', 'b'])).toEqual(Map([['imm', 'map']]));
     // However mergeDeep will merge that value into the inner Map
-    expect(m2.getIn(['a', 'b', 0])).toEqual(Map({imm: 'map', plain: 'obj'}));
+    expect(m2.getIn(['a', 'b'])).toEqual(Map({imm: 'map', plain: 'obj'}));
   });
 
 });

--- a/src/List.js
+++ b/src/List.js
@@ -20,12 +20,7 @@ import {
   resolveEnd
 } from './TrieUtils';
 import { IndexedCollection } from './Collection';
-import {
-  MapPrototype,
-  mergeIntoCollectionWith,
-  deepMerger,
-  deepMergerWith
-} from './Map';
+import { MapPrototype } from './Map';
 import { Iterator, iteratorValue, iteratorDone } from './Iterator';
 
 import assertNotInfinite from './utils/assertNotInfinite';
@@ -140,20 +135,8 @@ export class List extends IndexedCollection {
 
   // @pragma Composition
 
-  merge(/*...iters*/) {
-    return mergeIntoListWith(this, undefined, arguments);
-  }
-
-  mergeWith(merger, ...iters) {
-    return mergeIntoListWith(this, merger, iters);
-  }
-
-  mergeDeep(/*...iters*/) {
-    return mergeIntoListWith(this, deepMerger, arguments);
-  }
-
-  mergeDeepWith(merger, ...iters) {
-    return mergeIntoListWith(this, deepMergerWith(merger), iters);
+  merge(/*...collections*/) {
+    return this.concat.apply(this, arguments);
   }
 
   setSize(size) {
@@ -650,22 +633,6 @@ function setListBounds(list, begin, end) {
     return list;
   }
   return makeList(newOrigin, newCapacity, newLevel, newRoot, newTail);
-}
-
-function mergeIntoListWith(list, merger, collections) {
-  const iters = [];
-  let maxSize = 0;
-  for (let ii = 0; ii < collections.length; ii++) {
-    const iter = IndexedCollection(collections[ii]);
-    if (iter.size > maxSize) {
-      maxSize = iter.size;
-    }
-    iters.push(iter);
-  }
-  if (maxSize > list.size) {
-    list = list.setSize(maxSize);
-  }
-  return mergeIntoCollectionWith(list, merger, iters);
 }
 
 function getTailOffset(size) {

--- a/src/Map.js
+++ b/src/Map.js
@@ -159,7 +159,7 @@ export class Map extends KeyedCollection {
   }
 
   mergeDeep(/*...iters*/) {
-    return mergeIntoMapWith(this, deepMerger, arguments);
+    return mergeIntoMapWith(this, deepMergerWith(alwaysNewVal), arguments);
   }
 
   mergeDeepWith(merger, ...iters) {
@@ -839,21 +839,19 @@ function mergeIntoMapWith(map, merger, collections) {
   return mergeIntoCollectionWith(map, merger, iters);
 }
 
-export function deepMerger(oldVal, newVal) {
-  return newVal && typeof newVal === 'object' && oldVal && oldVal.mergeDeep
-    ? oldVal.mergeDeep(newVal)
-    : is(oldVal, newVal) ? oldVal : newVal;
+function alwaysNewVal(oldVal, newVal) {
+  return newVal;
 }
 
 export function deepMergerWith(merger) {
-  return (oldVal, newVal, key) => {
-    if (
-      newVal &&
-      typeof newVal === 'object' &&
-      oldVal &&
-      oldVal.mergeDeepWith
-    ) {
-      return oldVal.mergeDeepWith(merger, newVal);
+  return function(oldVal, newVal, key) {
+    if (oldVal && newVal && typeof newVal === 'object') {
+      if (oldVal.mergeDeepWith) {
+        return oldVal.mergeDeepWith(merger, newVal);
+      }
+      if (oldVal.merge) {
+        return oldVal.merge(newVal);
+      }
     }
     const nextValue = merger(oldVal, newVal, key);
     return is(oldVal, nextValue) ? oldVal : nextValue;

--- a/src/Set.js
+++ b/src/Set.js
@@ -128,14 +128,6 @@ export class Set extends SetCollection {
     });
   }
 
-  merge() {
-    return this.union.apply(this, arguments);
-  }
-
-  mergeWith(merger, ...iters) {
-    return this.union.apply(this, iters);
-  }
-
   sort(comparator) {
     // Late binding
     return OrderedSet(sortFactory(this, comparator));
@@ -186,8 +178,7 @@ const IS_SET_SENTINEL = '@@__IMMUTABLE_SET__@@';
 const SetPrototype = Set.prototype;
 SetPrototype[IS_SET_SENTINEL] = true;
 SetPrototype[DELETE] = SetPrototype.remove;
-SetPrototype.mergeDeep = SetPrototype.merge;
-SetPrototype.mergeDeepWith = SetPrototype.mergeWith;
+SetPrototype.merge = SetPrototype.union;
 SetPrototype.withMutations = MapPrototype.withMutations;
 SetPrototype.asMutable = MapPrototype.asMutable;
 SetPrototype.asImmutable = MapPrototype.asImmutable;

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -676,39 +676,6 @@ declare module Immutable {
     update<R>(updater: (value: this) => R): R;
 
     /**
-     * Note: `merge` can be used in `withMutations`.
-     *
-     * @see `Map#merge`
-     */
-    merge(...collections: Array<Iterable<T>>): this;
-
-    /**
-     * Note: `mergeWith` can be used in `withMutations`.
-     *
-     * @see `Map#mergeWith`
-     */
-    mergeWith(
-      merger: (oldVal: T, newVal: T, key: number) => T,
-      ...collections: Array<Iterable<T>>
-    ): this;
-
-    /**
-     * Note: `mergeDeep` can be used in `withMutations`.
-     *
-     * @see `Map#mergeDeep`
-     */
-    mergeDeep(...collections: Array<Iterable<T>>): this;
-
-    /**
-     * Note: `mergeDeepWith` can be used in `withMutations`.
-     * @see `Map#mergeDeepWith`
-     */
-    mergeDeepWith(
-      merger: (oldVal: T, newVal: T, key: number) => T,
-      ...collections: Array<Iterable<T>>
-    ): this;
-
-    /**
      * Returns a new List with size `size`. If `size` is less than this
      * List's size, the new List will exclude values at the higher indices.
      * If `size` is greater than this List's size, the new List will have
@@ -819,8 +786,13 @@ declare module Immutable {
 
     /**
      * Returns a new List with other values or collections concatenated to this one.
+     *
+     * Note: `concat` *cannot* be safely used in `withMutations`.
+     *
+     * @alias merge
      */
     concat<C>(...valuesOrCollections: Array<Iterable<C> | C>): List<T | C>;
+    merge<C>(...collections: Array<Iterable<C>): List<T | C>;
 
     /**
      * Returns a new List with values passed through a

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -636,18 +636,6 @@ declare class List<+T> extends IndexedCollection<T> {
 
   merge<U>(...collections: Iterable<U>[]): List<T | U>;
 
-  mergeWith<U, V>(
-    merger: (oldVal: T, newVal: U, key: number) => V,
-    ...collections: Iterable<U>[]
-  ): List<T | U | V>;
-
-  mergeDeep<U>(...collections: Iterable<U>[]): List<T | U>;
-
-  mergeDeepWith<U, V>(
-    merger: (oldVal: T, newVal: U, key: number) => V,
-    ...collections: Iterable<U>[]
-  ): List<T | U | V>;
-
   setSize(size: number): this;
   setIn(keyPath: Iterable<mixed>, value: mixed): this;
   deleteIn(keyPath: Iterable<mixed>, value: mixed): this;

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -163,18 +163,6 @@ numberOrStringList = List.of('a').merge(List.of(1))
 // $ExpectError
 numberList = List.of('a').merge(List.of(1))
 
-numberList = List.of(1).mergeWith((previous, next, key) => 1, [1])
-// $ExpectError
-numberList = List.of(1).mergeWith((previous, next, key) => previous + next, ['a'])
-
-numberOrStringList = List.of(1).mergeDeep(['a'])
-// $ExpectError
-numberList = List.of(1).mergeDeep(['a'])
-
-numberList = List.of(1).mergeDeepWith((previous, next, key) => 1, [1])
-// $ExpectError
-numberList = List.of(1).mergeDeepWith((previous, next, key) => previous + next, ['a'])
-
 nullableNumberList = List.of(1).setSize(2)
 
 numberList = List.of(1).setIn([], 0)

--- a/type-definitions/ts-tests/list.ts
+++ b/type-definitions/ts-tests/list.ts
@@ -288,7 +288,7 @@ import { List } from '../../';
   // $ExpectType List<number>
   List<number>().merge(List<number>());
 
-  // $ExpectError
+  // $ExpectType List<string | number>
   List<number>().merge(List<string>());
 
   // $ExpectType List<string | number>
@@ -304,73 +304,10 @@ import { List } from '../../';
   List<number>().mergeIn([], []);
 }
 
-{ // #mergeWith
-
-  // $ExpectType List<number>
-  List<number>().mergeWith((prev: number, next: number, key: number) => 1, List<number>());
-
-  // $ExpectError
-  List<number>().mergeWith((prev: string, next: number, key: number) => 1, List<number>());
-
-  // $ExpectError
-  List<number>().mergeWith((prev: number, next: string, key: number) => 1, List<number>());
-
-  // $ExpectError
-  List<number>().mergeWith((prev: number, next: number, key: string) => 1, List<number>());
-
-  // $ExpectError
-  List<number>().mergeWith((prev: number, next: number, key: number) => 'a', List<number>());
-
-  // $ExpectError
-  List<number>().mergeWith((prev: number, next: number, key: number) => 1, List<string>());
-
-  // $ExpectType List<string | number>
-  List<number | string>().mergeWith((prev: number, next: string, key: number) => 1, List<string>());
-}
-
-{ // #mergeDeep
-
-  // $ExpectType List<number>
-  List<number>().mergeDeep(List<number>());
-
-  // $ExpectError
-  List<number>().mergeDeep(List<string>());
-
-  // $ExpectType List<string | number>
-  List<number | string>().mergeDeep(List<string>());
-
-  // $ExpectType List<string | number>
-  List<number | string>().mergeDeep(List<number>());
-}
-
 { // #mergeDeepIn
 
   // $ExpectType List<number>
   List<number>().mergeDeepIn([], []);
-}
-
-{ // #mergeDeepWith
-
-  // $ExpectType List<number>
-  List<number>().mergeDeepWith((prev: number, next: number, key: number) => 1, List<number>());
-
-  // $ExpectError
-  List<number>().mergeDeepWith((prev: string, next: number, key: number) => 1, List<number>());
-
-  // $ExpectError
-  List<number>().mergeDeepWith((prev: number, next: string, key: number) => 1, List<number>());
-
-  // $ExpectError
-  List<number>().mergeDeepWith((prev: number, next: number, key: string) => 1, List<number>());
-
-  // $ExpectError
-  List<number>().mergeDeepWith((prev: number, next: number, key: number) => 'a', List<number>());
-
-  // $ExpectError
-  List<number>().mergeDeepWith((prev: number, next: number, key: number) => 1, List<string>());
-
-  // $ExpectType List<string | number>
-  List<number | string>().mergeDeepWith((prev: number, next: string, key: number) => 1, List<string>());
 }
 
 { // #flatten


### PR DESCRIPTION
Fixes a long standing issue where "merge" did not treat List as an expected monoid form, overwriting entries as if it were a Map instead. This *changes* `merge` on List to be an alias of `concat` (much like `merge` is an alias for `union` on Set). Other functions like `mergeDeep` and `mergeWith` have been *removed* from List, since they no longer make sense with this behavior. When `mergeDeep` is called on a Map, nested Lists are now concatenated instead of overwritten.

Fixes #406