### PR TITLE
Add `getIn` and `hasIn` methods to Record flow type

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1341,6 +1341,8 @@ declare class RecordInstance<T: Object> {
   clear(): this & T;
 
   setIn(keyPath: Iterable<any>, value: any): this & T;
+  getIn(searchKeyPath: Iterable<mixed>, notSetValue?: mixed): any;
+  hasIn(searchKeyPath: Iterable<mixed>): boolean;
   updateIn(keyPath: Iterable<any>, updater: (value: any) => any): this & T;
   mergeIn(keyPath: Iterable<any>, ...collections: Array<any>): this & T;
   mergeDeepIn(keyPath: Iterable<any>, ...collections: Array<any>): this & T;


### PR DESCRIPTION
Copied these from `_Collection` type. Little unsure if they should be typed as `mixed` vs `any`?