### PR TITLE
V4 get in fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ TODO
 /gh-pages
 /npm
 /dist
+tags

--- a/__tests__/CollectionImpl.ts
+++ b/__tests__/CollectionImpl.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+///<reference path='../resources/jest.d.ts'/>
+
+import * as jasmineCheck from 'jasmine-check';
+jasmineCheck.install();
+
+import { fromJS, Map } from '../';
+
+describe('CollectionImpl', () => {
+  it('should allow getIn past null values', () => {
+    console.warn = jest.genMockFunction();
+
+    const m = Map({a: { b: null }});
+
+    expect(m.getIn(['a', 'b', 'c', 'd'], 'notSetValue')).toBe('notSetValue');
+    expect(console.warn.mock.calls.length).toBe(0);
+  });
+
+  it('should allow hasIn past null values', () => {
+    console.warn = jest.genMockFunction();
+
+    const m = Map({a: { b: null }});
+
+    expect(m.hasIn(['a', 'b', 'c', 'd'])).toBeFalsy();
+    expect(console.warn.mock.calls.length).toBe(0);
+  });
+});

--- a/__tests__/getIn.ts
+++ b/__tests__/getIn.ts
@@ -10,24 +10,35 @@
 import * as jasmineCheck from 'jasmine-check';
 jasmineCheck.install();
 
-import { fromJS, Map } from '../';
+import { fromJS } from '../';
 
-describe('CollectionImpl', () => {
+describe('getIn', () => {
   it('should allow getIn past null values', () => {
     console.warn = jest.genMockFunction();
 
-    const m = Map({a: { b: null }});
+    const m = fromJS({ a: { b: { c: null }}});
 
     expect(m.getIn(['a', 'b', 'c', 'd'], 'notSetValue')).toBe('notSetValue');
     expect(console.warn.mock.calls.length).toBe(0);
   });
 
+  it('shouldn\'t allow getIn past defined values without .get', () => {
+    console.warn = jest.genMockFunction();
+
+    const m = fromJS({ a: { b: { c: 'fail point' }}});
+
+    m.getIn(['a', 'b', 'c', 'd'], 'notSetValue');
+    expect(console.warn.mock.calls.length).toBe(1);
+  });
+
+  // hasIn calls getIn
   it('should allow hasIn past null values', () => {
     console.warn = jest.genMockFunction();
 
-    const m = Map({a: { b: null }});
+    const m = fromJS({ a: { b: { c: null }}});
 
     expect(m.hasIn(['a', 'b', 'c', 'd'])).toBeFalsy();
     expect(console.warn.mock.calls.length).toBe(0);
   });
+
 });

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -861,7 +861,7 @@ function getIn(value, notSetValue, searchKeyPath, reportBadKeyPath) {
       return notSetValue;
     }
     value = value.get(keyPath[i++], NOT_SET);
-    if (value === NOT_SET) {
+    if (value === NOT_SET || value === null || value === undefined) {
       return notSetValue;
     }
   }


### PR DESCRIPTION
resolves #1361 

A pretty simple fix.  However, it might not be 100% how the Immutable team wants to continue.

There's a default `NOT_SET` constant in `TrieUtils.js`.  [Here](https://github.com/facebook/immutable-js/blob/master/src/TrieUtils.js#L18)

Since `NOT_SET = {}` declaring the `notSetValue` for `null` and `undefined` was left up to the `warn` call in `getIn`.  

However, based on the conversation in #1161, we can safely assume that `undefined` and `null` should be counted as `NOT_SET` values as well.

So, this PR resolves #1361 by including those values in the `NOT_SET` conditonal.

-------------

### Potential Improvements
Perhaps, a better (larger) solution would be to make `NOT_SET` a function that can compare against all `NOT_SET` values (including `null` and `undefined`) so that this conditional can be brought back down to one statement, and this logic wouldn't have to be repeated elsewhere in the code base.



