### PR TITLE
Flow types for getIn()

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1409,7 +1409,7 @@ declare class RecordInstance<T: Object> {
 
   hasIn(keyPath: Iterable<mixed>): boolean;
 
-  getIn(keyPath: [], notSetValue?: mixed): this;
+  getIn(keyPath: [], notSetValue?: mixed): this & T;
   getIn<K: $Keys<T>>(keyPath: [K], notSetValue?: mixed): $ElementType<T, K>;
   getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>>(keyPath: [K, K2], notSetValue: NSV): $ValOf<$ElementType<T, K>, K2> | NSV;
   getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>>(keyPath: [K, K2, K3], notSetValue: NSV): $ValOf<$ValOf<$ElementType<T, K>, K2>, K3> | NSV;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -32,6 +32,21 @@
 // some constructors and functions.
 type PlainObjInput<K, V> = {[key: K]: V, __proto__: null};
 
+// Helper types to extract the "keys" and "values" use by the *In() methods.
+// Exported for experimental use only, may change.
+export type $KeyOf<C> = $Call<
+  & (<K>(?_Collection<K, *>) => K)
+  & (<T>(?RecordInstance<T>) => $Keys<T>),
+  C
+>;
+
+export type $ValOf<C, K = *> = $Call<
+  & (<V>(?_Collection<*, V>) => V)
+  & (<T, K: $Keys<T>>(?RecordInstance<T>, K) => $ElementType<T, K>),
+  C,
+  K
+>;
+
 declare class _Collection<K, +V> /*implements ValueObject*/ {
   equals(other: mixed): boolean;
   hashCode(): number;
@@ -43,8 +58,14 @@ declare class _Collection<K, +V> /*implements ValueObject*/ {
   first(): V | void;
   last(): V | void;
 
-  getIn(keyPath: Iterable<mixed>, notSetValue?: mixed): any;
   hasIn(keyPath: Iterable<mixed>): boolean;
+
+  getIn(keyPath: [], notSetValue?: mixed): this;
+  getIn<NSV>(keyPath: [K], notSetValue: NSV): V | NSV;
+  getIn<NSV, K2: $KeyOf<V>>(keyPath: [K, K2], notSetValue: NSV): $ValOf<V, K2> | NSV;
+  getIn<NSV, K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>>(keyPath: [K, K2, K3], notSetValue: NSV): $ValOf<$ValOf<V, K2>, K3> | NSV;
+  getIn<NSV, K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, K4: $KeyOf<$ValOf<$ValOf<V, K2>, K3>>>(keyPath: [K, K2, K3, K4], notSetValue: NSV): $ValOf<$ValOf<$ValOf<V, K2>, K3>, K4> | NSV;
+  getIn<NSV, K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, K4: $KeyOf<$ValOf<$ValOf<V, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>>>(keyPath: [K, K2, K3, K4, K5], notSetValue: NSV): $ValOf<$ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>, K5> | NSV;
 
   update<U>(updater: (value: this) => U): U;
 
@@ -1387,7 +1408,13 @@ declare class RecordInstance<T: Object> {
   get<K: $Keys<T>>(key: K): $ElementType<T, K>;
 
   hasIn(keyPath: Iterable<mixed>): boolean;
-  getIn(keyPath: Iterable<mixed>, notSetValue?: mixed): any;
+
+  getIn(keyPath: [], notSetValue?: mixed): this;
+  getIn<K: $Keys<T>>(keyPath: [K], notSetValue?: mixed): $ElementType<T, K>;
+  getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>>(keyPath: [K, K2], notSetValue: NSV): $ValOf<$ElementType<T, K>, K2> | NSV;
+  getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>>(keyPath: [K, K2, K3], notSetValue: NSV): $ValOf<$ValOf<$ElementType<T, K>, K2>, K3> | NSV;
+  getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>>(keyPath: [K, K2, K3, K4], notSetValue: NSV): $ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4> | NSV;
+  getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>>(keyPath: [K, K2, K3, K4, K5], notSetValue: NSV): $ValOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>, K5> | NSV;
 
   equals(other: any): boolean;
   hashCode(): number;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -35,13 +35,13 @@ type PlainObjInput<K, V> = {[key: K]: V, __proto__: null};
 // Helper types to extract the "keys" and "values" use by the *In() methods.
 // Exported for experimental use only, may change.
 export type $KeyOf<C> = $Call<
-  & (<K>(?_Collection<K, *>) => K)
+  & (<K>(?_Collection<K, mixed>) => K)
   & (<T>(?RecordInstance<T>) => $Keys<T>),
   C
 >;
 
-export type $ValOf<C, K = *> = $Call<
-  & (<V>(?_Collection<*, V>) => V)
+export type $ValOf<C, K = $KeyOf<C>> = $Call<
+  & (<V>(?_Collection<any, V>) => V)
   & (<T, K: $Keys<T>>(?RecordInstance<T>, K) => $ElementType<T, K>),
   C,
   K

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -812,3 +812,79 @@ someObj.y = 2;
 let mapOfSomeObj: Map<string, number> = Map(someObj);
 // $ExpectError - someObj is string -> number
 let mapOfSomeObjMistake: Map<string, string> = Map(someObj);
+
+
+// getIn() type
+
+// Deep nested
+const deepData1: List<Map<string, string>> = List([Map([['apple', 'sauce']])]);
+const deepNestedString1 = deepData1.getIn([0, 'apple']);
+// $ExpectError string is not a number
+{ const fail: ?number = deepNestedString1; }
+// $ExpectError getIn can return undefined
+{ const fail: string = deepNestedString1; }
+{ const success: ?string = deepNestedString1; }
+
+const listOfListOfNumber: List<?List<?number>> = List([List([1, 2, 3])]);
+const nestedNum = listOfListOfNumber.getIn([0, 1]);
+// $ExpectError number is not string
+{ const fail: ?string = nestedNum; }
+// $ExpectError getIn can return undefined
+{ const fail: number = nestedNum; }
+{ const success: ?number = nestedNum; }
+// $ExpectError expected a number 1st key
+listOfListOfNumber.getIn(['whoops', 1]);
+// $ExpectError expected a number 2nd key
+listOfListOfNumber.getIn([0, 'whoops']);
+// $ExpectError too many keys!
+listOfListOfNumber.getIn([0, 0, 'whoops']);
+
+// Deep nested
+const deepData: List<Map<string, List<string>>> = List([Map([['apple', List(['sauce'])]])]);
+const deepNestedString = deepData.getIn([0, 'apple', 0]);
+// $ExpectError string is not a number
+{ const fail: ?number = deepNestedString; }
+// $ExpectError getIn can return undefined
+{ const fail: string = deepNestedString; }
+{ const success: ?string = deepNestedString; }
+// $ExpectError expected a string 2nd key
+deepData.getIn([0, 0, 0]);
+// $ExpectError expected a number 3rd key
+deepData.getIn([0, 'apple', 'whoops']);
+
+// Containing Records
+const listOfPersonRecord: List<PersonRecord> = List([personRecordInstance]);
+const firstAge = listOfPersonRecord.getIn([0, 'age']);
+// $ExpectError expected a string key
+{ const age: string = firstAge }
+// $ExpectError getIn can return undefined
+{ const age: number = firstAge }
+{ const age: ?number = firstAge }
+// $ExpectError - the first key is not an index
+listOfPersonRecord.getIn(['wrong', 'age']);
+// $ExpectError - the second key is not an record key
+listOfPersonRecord.getIn([0, 'mispeld']);
+// $ExpectError - the second key is not an record key
+listOfPersonRecord.getIn([0, 0]);
+
+// Recursive Records
+type PersonRecord2Fields = { name: string, friends: List<PersonRecord2> };
+type PersonRecord2 = RecordOf<PersonRecord2Fields>;
+const makePersonRecord2: RecordFactory<PersonRecord2Fields> = Record({
+  name: 'Adam',
+  friends: List(),
+});
+const friendly: PersonRecord2 = makePersonRecord2();
+// $ExpectError string is not a number
+{ const fail: ?number = friendly.getIn(['friends', 0, 'name']); }
+// notSetValue provided
+{ const success: string = friendly.getIn(['friends', 0, 'name'], 'Abbie'); }
+{ const success: ?string = friendly.getIn(['friends', 0, 'name']); }
+
+// Deep nested containing recursive Records
+const friendlies: List<PersonRecord2> = List([makePersonRecord2()]);
+// $ExpectError string is not a number
+{ const fail: ?number = friendlies.getIn([0, 'friends', 0, 'name']); }
+// notSetValue provided
+{ const success: string = friendlies.getIn([0, 'friends', 0, 'name'], 'Abbie'); }
+{ const success: ?string = friendlies.getIn([0, 'friends', 0, 'name']); }


### PR DESCRIPTION
This adds a flow type for getIn() using the new $Call type to define two new utility type operators: `$KeyOf` and `$ValOf` which are similar to `$ElementType` but work on both Records and Collections.

To keep this PR small, this only addresses `getIn()` - though in a follow up will do other `*In` methods.