### PR TITLE
BREAKING: Support for Array and plain Object (adds functional API)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
     "no-param-reassign": "off",
     "no-plusplus": "off",
     "no-prototype-builtins": "off",
+    "no-restricted-syntax": "off",
     "no-return-assign": "off",
     "no-self-compare": "off",
     "no-sequences": "off",

--- a/__tests__/Seq.ts
+++ b/__tests__/Seq.ts
@@ -85,4 +85,16 @@ describe('Seq', () => {
     expect(list.take(NaN).toJS()).toEqual([]);
   });
 
+  it('Converts deeply toJS after converting to entries', () => {
+    const list = Seq([Seq([1, 2]), Seq({a: 'z'})]);
+    expect(list.entrySeq().toJS()).toEqual(
+      [[0, [1, 2]], [1, {a: 'z'}]],
+    );
+
+    const map = Seq({x: Seq([1, 2]), y: Seq({a: 'z'})});
+    expect(map.entrySeq().toJS()).toEqual(
+      [['x', [1, 2]], ['y', {a: 'z'}]],
+    );
+  });
+
 });

--- a/__tests__/getIn.ts
+++ b/__tests__/getIn.ts
@@ -36,7 +36,7 @@ describe('getIn', () => {
     ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
     expect(() =>
       getIn(Map(), 'abc' as any),
-  ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
+    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
   });
 
   it('deep get returns not found if path does not match', () => {

--- a/__tests__/getIn.ts
+++ b/__tests__/getIn.ts
@@ -7,18 +7,20 @@
 
 ///<reference path='../resources/jest.d.ts'/>
 
-import { fromJS, List, Map, Set } from '../';
+import { fromJS, getIn, List, Map, Set } from '../';
 
 describe('getIn', () => {
 
   it('deep get', () => {
     const m = fromJS({a: {b: {c: 10}}});
     expect(m.getIn(['a', 'b', 'c'])).toEqual(10);
+    expect(getIn(m, ['a', 'b', 'c'])).toEqual(10);
   });
 
   it('deep get with list as keyPath', () => {
     const m = fromJS({a: {b: {c: 10}}});
     expect(m.getIn(fromJS(['a', 'b', 'c']))).toEqual(10);
+    expect(getIn(m, fromJS(['a', 'b', 'c']))).toEqual(10);
   });
 
   it('deep get throws without list or array-like', () => {
@@ -32,6 +34,9 @@ describe('getIn', () => {
     expect(() =>
       Map().getIn('abc' as any),
     ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
+    expect(() =>
+      getIn(Map(), 'abc' as any),
+  ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
   });
 
   it('deep get returns not found if path does not match', () => {
@@ -40,6 +45,8 @@ describe('getIn', () => {
     expect(m.getIn(['a', 'b', 'z'], 123)).toEqual(123);
     expect(m.getIn(['a', 'y', 'z'])).toEqual(undefined);
     expect(m.getIn(['a', 'y', 'z'], 123)).toEqual(123);
+    expect(getIn(m, ['a', 'y', 'z'])).toEqual(undefined);
+    expect(getIn(m, ['a', 'y', 'z'], 123)).toEqual(123);
   });
 
   it('does not use notSetValue when path does exist but value is nullable', () => {
@@ -48,14 +55,44 @@ describe('getIn', () => {
     expect(m.getIn(['a', 'b', 'd'])).toEqual(undefined);
     expect(m.getIn(['a', 'b', 'c'], 123)).toEqual(null);
     expect(m.getIn(['a', 'b', 'd'], 123)).toEqual(undefined);
+    expect(getIn(m, ['a', 'b', 'c'], 123)).toEqual(null);
+    expect(getIn(m, ['a', 'b', 'd'], 123)).toEqual(undefined);
   });
 
   it('deep get returns not found if path encounters null or undefined', () => {
     const m = fromJS({a: {b: {c: null, d: undefined}}});
     expect(m.getIn(['a', 'b', 'c', 'x'])).toEqual(undefined);
-    expect(m.getIn(['a', 'b', 'd', 'x'])).toEqual(undefined);
     expect(m.getIn(['a', 'b', 'c', 'x'], 123)).toEqual(123);
+    expect(m.getIn(['a', 'b', 'd', 'x'])).toEqual(undefined);
     expect(m.getIn(['a', 'b', 'd', 'x'], 123)).toEqual(123);
+    expect(getIn(m, ['a', 'b', 'd', 'x'])).toEqual(undefined);
+    expect(getIn(m, ['a', 'b', 'd', 'x'], 123)).toEqual(123);
+  });
+
+  it('gets in nested plain Objects and Arrays', () => {
+    const m = List([ { key: [ 'item' ] } ]);
+    expect(m.getIn([0, 'key', 0])).toEqual('item');
+  });
+
+  it('deep get returns not found if non-existing path in nested plain Object', () => {
+    const deep = Map({ key: { regular: 'jsobj' }, list: List([ Map({num: 10}) ]) });
+    expect(deep.getIn(['key', 'foo', 'item'])).toBe(undefined);
+    expect(deep.getIn(['key', 'foo', 'item'], 'notSet')).toBe('notSet');
+    expect(deep.getIn(['list', 0, 'num', 'badKey'])).toBe(undefined);
+    expect(deep.getIn(['list', 0, 'num', 'badKey'], 'notSet')).toBe('notSet');
+  });
+
+  it('gets in plain Objects and Arrays', () => {
+    const m = [ { key: [ 'item' ] } ];
+    expect(getIn(m, [0, 'key', 0])).toEqual('item');
+  });
+
+  it('deep get returns not found if non-existing path in plain Object', () => {
+    const deep = { key: { regular: 'jsobj' }, list: [ {num: 10} ] };
+    expect(getIn(deep, ['key', 'foo', 'item'])).toBe(undefined);
+    expect(getIn(deep, ['key', 'foo', 'item'], 'notSet')).toBe('notSet');
+    expect(getIn(deep, ['list', 0, 'num', 'badKey'])).toBe(undefined);
+    expect(getIn(deep, ['list', 0, 'num', 'badKey'], 'notSet')).toBe('notSet');
   });
 
 });

--- a/__tests__/getIn.ts
+++ b/__tests__/getIn.ts
@@ -59,7 +59,7 @@ describe('getIn', () => {
     expect(getIn(m, ['a', 'b', 'd'], 123)).toEqual(undefined);
   });
 
-  it('deep get returns not found if path encounters null or undefined', () => {
+  it('deep get returns not found if path encounters non-data-structure', () => {
     const m = fromJS({a: {b: {c: null, d: undefined}}});
     expect(m.getIn(['a', 'b', 'c', 'x'])).toEqual(undefined);
     expect(m.getIn(['a', 'b', 'c', 'x'], 123)).toEqual(123);
@@ -67,6 +67,9 @@ describe('getIn', () => {
     expect(m.getIn(['a', 'b', 'd', 'x'], 123)).toEqual(123);
     expect(getIn(m, ['a', 'b', 'd', 'x'])).toEqual(undefined);
     expect(getIn(m, ['a', 'b', 'd', 'x'], 123)).toEqual(123);
+
+    expect(getIn('a', ['length'])).toEqual(undefined);
+    expect(getIn(new Date(), ['getDate'])).toEqual(undefined);
   });
 
   it('gets in nested plain Objects and Arrays', () => {

--- a/__tests__/getIn.ts
+++ b/__tests__/getIn.ts
@@ -34,35 +34,6 @@ describe('getIn', () => {
     ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
   });
 
-  function withWarnings(fn) {
-    const realWarn = console.warn;
-    const warnings: Array<any> = [];
-    console.warn = w => warnings.push(w);
-    try {
-      fn(warnings);
-    } finally {
-      console.warn = realWarn;
-    }
-  }
-
-  it('deep get throws if non-readable path', withWarnings(warnings => {
-    const deep = Map({ key: { regular: "jsobj" }, list: List([ Map({num: 10}) ]) });
-    deep.getIn(["key", "foo", "item"]);
-    expect(warnings.length).toBe(1);
-    expect(warnings[0]).toBe(
-      'Invalid keyPath: Value at ["key"] does not have a .get() method: [object Object]' +
-      '\nThis warning will throw in a future version',
-    );
-
-    warnings.length = 0;
-    deep.getIn(["list", 0, "num", "badKey"]);
-    expect(warnings.length).toBe(1);
-    expect(warnings[0]).toBe(
-      'Invalid keyPath: Value at ["list",0,"num"] does not have a .get() method: 10' +
-      '\nThis warning will throw in a future version',
-    );
-  }));
-
   it('deep get returns not found if path does not match', () => {
     const m = fromJS({a: {b: {c: 10}}});
     expect(m.getIn(['a', 'b', 'z'])).toEqual(undefined);
@@ -79,12 +50,12 @@ describe('getIn', () => {
     expect(m.getIn(['a', 'b', 'd'], 123)).toEqual(undefined);
   });
 
-  it('deep get returns not found if path encounters null or undefined', withWarnings(warnings => {
+  it('deep get returns not found if path encounters null or undefined', () => {
     const m = fromJS({a: {b: {c: null, d: undefined}}});
     expect(m.getIn(['a', 'b', 'c', 'x'])).toEqual(undefined);
     expect(m.getIn(['a', 'b', 'd', 'x'])).toEqual(undefined);
     expect(m.getIn(['a', 'b', 'c', 'x'], 123)).toEqual(123);
     expect(m.getIn(['a', 'b', 'd', 'x'], 123)).toEqual(123);
-    expect(warnings.length).toBe(0);
-  }));
+  });
+
 });

--- a/__tests__/hasIn.ts
+++ b/__tests__/hasIn.ts
@@ -7,15 +7,18 @@
 
 ///<reference path='../resources/jest.d.ts'/>
 
-import { fromJS, List, Map } from '../';
+import { fromJS, hasIn, List, Map } from '../';
 
 describe('hasIn', () => {
 
   it('deep has', () => {
-    const m = fromJS({a: {b: {c: 10}}});
+    const m = fromJS({a: {b: {c: 10, d: undefined}}});
     expect(m.hasIn(['a', 'b', 'c'])).toEqual(true);
+    expect(m.hasIn(['a', 'b', 'd'])).toEqual(true);
     expect(m.hasIn(['a', 'b', 'z'])).toEqual(false);
     expect(m.hasIn(['a', 'y', 'z'])).toEqual(false);
+    expect(hasIn(m, ['a', 'b', 'c'])).toEqual(true);
+    expect(hasIn(m, ['a', 'b', 'z'])).toEqual(false);
   });
 
   it('deep has with list as keyPath', () => {
@@ -23,6 +26,8 @@ describe('hasIn', () => {
     expect(m.hasIn(fromJS(['a', 'b', 'c']))).toEqual(true);
     expect(m.hasIn(fromJS(['a', 'b', 'z']))).toEqual(false);
     expect(m.hasIn(fromJS(['a', 'y', 'z']))).toEqual(false);
+    expect(hasIn(m, fromJS(['a', 'b', 'c']))).toEqual(true);
+    expect(hasIn(m, fromJS(['a', 'y', 'z']))).toEqual(false);
   });
 
   it('deep has throws without list or array-like', () => {
@@ -36,23 +41,27 @@ describe('hasIn', () => {
     expect(() =>
       Map().hasIn('abc' as any),
     ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
+    expect(() =>
+      hasIn(Map(), 'abc' as any),
+    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
   });
 
   it('deep has does not throw if non-readable path', () => {
-    const realWarn = console.warn;
-    const warnings: Array<any> = [];
-    console.warn = w => warnings.push(w);
+    const deep = Map({ key: { regular: "jsobj" }, list: List([ Map({num: 10}) ]) });
+    expect(deep.hasIn(['key', 'foo', 'item'])).toBe(false);
+    expect(deep.hasIn(['list', 0, 'num', 'badKey'])).toBe(false);
+    expect(hasIn(deep, ['key', 'foo', 'item'])).toBe(false);
+    expect(hasIn(deep, ['list', 0, 'num', 'badKey'])).toBe(false);
+  });
 
-    try {
-      const deep = Map({ key: { regular: "jsobj" }, list: List([ Map({num: 10}) ]) });
-      expect(deep.hasIn(['key', 'foo', 'item'])).toBe(false);
-      expect(warnings.length).toBe(0);
-
-      expect(deep.hasIn(['list', 0, 'num', 'badKey'])).toBe(false);
-      expect(warnings.length).toBe(0);
-    } finally {
-      console.warn = realWarn;
-    }
+  it('deep has in plain Object and Array', () => {
+    const m = {a: {b: {c: [10, undefined], d: undefined}}};
+    expect(hasIn(m, ['a', 'b', 'c', 0])).toEqual(true);
+    expect(hasIn(m, ['a', 'b', 'c', 1])).toEqual(true);
+    expect(hasIn(m, ['a', 'b', 'c', 2])).toEqual(false);
+    expect(hasIn(m, ['a', 'b', 'd'])).toEqual(true);
+    expect(hasIn(m, ['a', 'b', 'z'])).toEqual(false);
+    expect(hasIn(m, ['a', 'b', 'z'])).toEqual(false);
   });
 
 });

--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -108,7 +108,7 @@ describe('merge', () => {
     expect(m1.mergeDeep(m2).get('a')).toEqual(Map({x: 1, y: 1, z: 10}));
   });
 
-  it('merges map enties with List and Set values', () => {
+  it('merges map entries with List and Set values', () => {
     const initial = Map({a: Map({x: 10, y: 20}), b: List([1, 2, 3]), c: Set([1, 2, 3])});
     const additions = Map({a: Map({y: 50, z: 100}), b: List([4, 5, 6]), c: Set([4, 5, 6])});
     expect(initial.mergeDeep(additions)).toEqual(

--- a/__tests__/updateIn.ts
+++ b/__tests__/updateIn.ts
@@ -7,7 +7,7 @@
 
 ///<reference path='../resources/jest.d.ts'/>
 
-import { fromJS, List, Map, removeIn, Set, setIn, updateIn } from '../';
+import { fromJS, List, Map, removeIn, Seq, Set, setIn, updateIn } from '../';
 
 describe('updateIn', () => {
 
@@ -56,14 +56,21 @@ describe('updateIn', () => {
     expect(() =>
       deep.updateIn(['key', 'foo', 'item'], () => 'newval'),
     ).toThrow(
-      'Cannot update value without .set() method: Set { List [ "item" ] }',
+      'Cannot update immutable value without .set() method: Set { List [ "item" ] }',
+    );
+
+    const deepSeq = Map({ key: Seq([ List([ 'item' ]) ]) });
+    expect(() =>
+      deepSeq.updateIn(['key', 'foo', 'item'], () => 'newval'),
+    ).toThrow(
+      'Cannot update immutable value without .set() method: Seq [ List [ "item" ] ]',
     );
 
     const nonObj = Map({ key: 123 });
     expect(() =>
       nonObj.updateIn(['key', 'foo'], () => 'newval'),
     ).toThrow(
-      'Cannot update within non-updatable value in path ["key"]: 123',
+      'Cannot update within non-data-structure value in path ["key"]: 123',
     );
   });
 

--- a/__tests__/updateIn.ts
+++ b/__tests__/updateIn.ts
@@ -43,12 +43,18 @@ describe('updateIn', () => {
   });
 
   it('deep edit throws if non-editable path', () => {
-    const deep = Map({ key: Set([ List([ "item" ]) ]) });
+    const deep = Map({ key: Set([ List([ 'item' ]) ]) });
     expect(() =>
-      deep.updateIn(["key", "foo", "item"], x => x),
+      deep.updateIn(['key', 'foo', 'item'], () => 'newval'),
     ).toThrow(
-      'Invalid keyPath: Value at ["key"] does not have a .set() method ' +
-      'and cannot be updated: Set { List [ "item" ] }',
+      'Cannot update value without .set() method: Set { List [ "item" ] }',
+    );
+
+    const nonObj = Map({ key: 123 });
+    expect(() =>
+      nonObj.updateIn(['key', 'foo'], () => 'newval'),
+    ).toThrow(
+      'Cannot update within non-updatable value in path ["key"]: 123',
     );
   });
 
@@ -181,7 +187,7 @@ describe('updateIn', () => {
 
     it('can setIn undefined', () => {
       const m = Map().setIn(['a', 'b', 'c'], undefined);
-      expect(m.toJS()).toEqual({a: {b: {c: undefined}}});
+      expect(m).toEqual(Map({a: Map({b: Map({c: undefined})})}));
     });
 
   });

--- a/__tests__/zip.ts
+++ b/__tests__/zip.ts
@@ -22,6 +22,26 @@ describe('zip', () => {
     );
   });
 
+  it('zip results can be converted to JS', () => {
+    const l1 = List([List([1]), List([2]), List([3])]);
+    const l2 = List([List([4]), List([5]), List([6])]);
+    const zipped = l1.zip(l2);
+    expect(zipped).toEqual(
+      List([
+        [List([1]), List([4])],
+        [List([2]), List([5])],
+        [List([3]), List([6])],
+      ]),
+    );
+    expect(zipped.toJS()).toEqual(
+      [
+        [[1], [4]],
+        [[2], [5]],
+        [[3], [6]],
+      ],
+    );
+  });
+
   it('zips with infinite lists', () => {
     expect(
       Range().zip(Seq(['A', 'B', 'C'])).toArray(),

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -24,8 +24,10 @@ import {
 } from './Predicates';
 
 import { is } from './is';
+import { getIn } from './functional/getIn';
+import { hasIn } from './functional/hasIn';
+
 import {
-  arrCopy,
   NOT_SET,
   ensureSize,
   wrapIndex,
@@ -42,8 +44,8 @@ import {
   ITERATE_ENTRIES
 } from './Iterator';
 
+import arrCopy from './utils/arrCopy';
 import assertNotInfinite from './utils/assertNotInfinite';
-import coerceKeyPath from './utils/coerceKeyPath';
 import deepEqual from './utils/deepEqual';
 import mixin from './utils/mixin';
 import quoteString from './utils/quoteString';
@@ -402,7 +404,7 @@ mixin(Collection, {
   },
 
   getIn(searchKeyPath, notSetValue) {
-    return getIn(this, notSetValue, searchKeyPath, true /* report bad path */);
+    return getIn(this, searchKeyPath, notSetValue);
   },
 
   groupBy(grouper, context) {
@@ -414,10 +416,7 @@ mixin(Collection, {
   },
 
   hasIn(searchKeyPath) {
-    return (
-      getIn(this, NOT_SET, searchKeyPath, false /* report bad path */) !==
-      NOT_SET
-    );
+    return hasIn(this, searchKeyPath);
   },
 
   isSubset(iter) {
@@ -827,42 +826,4 @@ function murmurHashOfSize(size, h) {
 
 function hashMerge(a, b) {
   return (a ^ (b + 0x9e3779b9 + (a << 6) + (a >> 2))) | 0; // int
-}
-
-function warn(message) {
-  /* eslint-disable no-console */
-  if (typeof console === 'object' && console.warn) {
-    console.warn(message);
-  } else {
-    throw new Error(message);
-  }
-  /* eslint-enable no-console */
-}
-
-function getIn(value, notSetValue, searchKeyPath, reportBadKeyPath) {
-  const keyPath = coerceKeyPath(searchKeyPath);
-  let i = 0;
-  while (i !== keyPath.length) {
-    // Intermediate null/undefined value along path
-    if (value == null) {
-      return notSetValue;
-    }
-    if (!value || !value.get) {
-      if (reportBadKeyPath) {
-        warn(
-          'Invalid keyPath: Value at [' +
-            keyPath.slice(0, i).map(quoteString) +
-            '] does not have a .get() method: ' +
-            value +
-            '\nThis warning will throw in a future version'
-        );
-      }
-      return notSetValue;
-    }
-    value = value.get(keyPath[i++], NOT_SET);
-    if (value === NOT_SET) {
-      return notSetValue;
-    }
-  }
-  return value;
 }

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -335,13 +335,6 @@ mixin(Collection, {
       .map(entryMapper)
       .toIndexedSeq();
     entriesSequence.fromEntrySeq = () => collection.toSeq();
-
-    // Entries are plain Array, which do not define toJS, so it must
-    // manually converts keys and values before conversion.
-    entriesSequence.toJS = function() {
-      return this.map(entry => [toJS(entry[0]), toJS(entry[1])]).toJSON();
-    };
-
     return entriesSequence;
   },
 

--- a/src/Immutable.js
+++ b/src/Immutable.js
@@ -29,6 +29,19 @@ import {
 import { Collection } from './CollectionImpl';
 import { hash } from './Hash';
 
+// Functional read/write API
+import { get } from './functional/get';
+import { getIn } from './functional/getIn';
+import { has } from './functional/has';
+import { hasIn } from './functional/hasIn';
+import { merge, mergeDeep, mergeWith, mergeDeepWith } from './functional/merge';
+import { remove } from './functional/remove';
+import { removeIn } from './functional/removeIn';
+import { set } from './functional/set';
+import { setIn } from './functional/setIn';
+import { update } from './functional/update';
+import { updateIn } from './functional/updateIn';
+
 import { version } from '../package.json';
 
 export default {
@@ -60,7 +73,22 @@ export default {
   isIndexed: isIndexed,
   isAssociative: isAssociative,
   isOrdered: isOrdered,
-  isValueObject: isValueObject
+  isValueObject: isValueObject,
+
+  get: get,
+  getIn: getIn,
+  has: has,
+  hasIn: hasIn,
+  merge: merge,
+  mergeDeep: mergeDeep,
+  mergeWith: mergeWith,
+  mergeDeepWith: mergeDeepWith,
+  remove: remove,
+  removeIn: removeIn,
+  set: set,
+  setIn: setIn,
+  update: update,
+  updateIn: updateIn
 };
 
 // Note: Iterable is deprecated
@@ -89,5 +117,19 @@ export {
   isIndexed,
   isAssociative,
   isOrdered,
-  isValueObject
+  isValueObject,
+  get,
+  getIn,
+  has,
+  hasIn,
+  merge,
+  mergeDeep,
+  mergeWith,
+  mergeDeepWith,
+  remove,
+  removeIn,
+  set,
+  setIn,
+  update,
+  updateIn
 };

--- a/src/Map.js
+++ b/src/Map.js
@@ -10,7 +10,7 @@ import { setIn } from './functional/setIn';
 import { update } from './functional/update';
 import { updateIn } from './functional/updateIn';
 import { removeIn } from './functional/removeIn';
-import { mergeDeep, mergeDeepWith } from './functional/merge';
+import { merge, mergeDeep, mergeDeepWith } from './functional/merge';
 import { Collection, KeyedCollection } from './Collection';
 import { isOrdered } from './Predicates';
 import {
@@ -136,14 +136,7 @@ export class Map extends KeyedCollection {
   }
 
   mergeIn(keyPath, ...iters) {
-    return this.updateIn(
-      keyPath,
-      emptyMap(),
-      m =>
-        typeof m.merge === 'function'
-          ? m.merge.apply(m, iters)
-          : iters[iters.length - 1]
-    );
+    return updateIn(this, keyPath, emptyMap(), m => merge(m, ...iters));
   }
 
   mergeDeep(...iters) {
@@ -155,14 +148,7 @@ export class Map extends KeyedCollection {
   }
 
   mergeDeepIn(keyPath, ...iters) {
-    return this.updateIn(
-      keyPath,
-      emptyMap(),
-      m =>
-        typeof m.mergeDeep === 'function'
-          ? m.mergeDeep.apply(m, iters)
-          : iters[iters.length - 1]
-    );
+    return updateIn(this, keyPath, emptyMap(), m => mergeDeep(m, ...iters));
   }
 
   sort(comparator) {

--- a/src/Seq.js
+++ b/src/Seq.js
@@ -24,6 +24,7 @@ import {
   getIterator
 } from './Iterator';
 
+import hasOwnProperty from './utils/hasOwnProperty';
 import isArrayLike from './utils/isArrayLike';
 
 export class Seq extends Collection {
@@ -205,7 +206,7 @@ class ObjectSeq extends KeyedSeq {
   }
 
   has(key) {
-    return this._object.hasOwnProperty(key);
+    return hasOwnProperty.call(this._object, key);
   }
 
   __iterate(fn, reverse) {

--- a/src/TrieUtils.js
+++ b/src/TrieUtils.js
@@ -35,17 +35,6 @@ export function SetRef(ref) {
 // the return of any subsequent call of this function.
 export function OwnerID() {}
 
-// http://jsperf.com/copy-array-inline
-export function arrCopy(arr, offset) {
-  offset = offset || 0;
-  const len = Math.max(0, arr.length - offset);
-  const newArr = new Array(len);
-  for (let ii = 0; ii < len; ii++) {
-    newArr[ii] = arr[ii + offset];
-  }
-  return newArr;
-}
-
 export function ensureSize(iter) {
   if (iter.size === undefined) {
     iter.size = iter.__iterate(returnTrue);

--- a/src/fromJS.js
+++ b/src/fromJS.js
@@ -7,6 +7,7 @@
 
 import { KeyedSeq, IndexedSeq } from './Seq';
 import { isKeyed } from './Predicates';
+import isPlainObj from './utils/isPlainObj';
 
 export function fromJS(value, converter) {
   return fromJSWith(
@@ -46,10 +47,4 @@ function fromJSWith(stack, converter, value, key, keyPath, parentValue) {
 
 function defaultConverter(k, v) {
   return isKeyed(v) ? v.toMap() : v.toList();
-}
-
-function isPlainObj(value) {
-  return (
-    value && (value.constructor === Object || value.constructor === undefined)
-  );
 }

--- a/src/functional/get.js
+++ b/src/functional/get.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { isCollection, isRecord } from '../Predicates';
+import { has } from './has';
+
+export function get(collection, key, notSetValue) {
+  return isCollection(collection) || isRecord(collection)
+    ? collection.get(key, notSetValue)
+    : !has(collection, key)
+      ? notSetValue
+      : typeof collection.get === 'function'
+        ? collection.get(key)
+        : collection[key];
+}

--- a/src/functional/get.js
+++ b/src/functional/get.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { isCollection, isRecord } from '../Predicates';
+import { isImmutable } from '../Predicates';
 import { has } from './has';
 
 export function get(collection, key, notSetValue) {
-  return isCollection(collection) || isRecord(collection)
+  return isImmutable(collection)
     ? collection.get(key, notSetValue)
     : !has(collection, key)
       ? notSetValue

--- a/src/functional/getIn.js
+++ b/src/functional/getIn.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import coerceKeyPath from '../utils/coerceKeyPath';
+import { NOT_SET } from '../TrieUtils';
+import { get } from './get';
+
+export function getIn(collection, searchKeyPath, notSetValue) {
+  const keyPath = coerceKeyPath(searchKeyPath);
+  let i = 0;
+  while (i !== keyPath.length) {
+    // Intermediate null/undefined value along path
+    if (!collection) {
+      return notSetValue;
+    }
+    collection = get(collection, keyPath[i++], NOT_SET);
+    if (collection === NOT_SET) {
+      return notSetValue;
+    }
+  }
+  return collection;
+}

--- a/src/functional/getIn.js
+++ b/src/functional/getIn.js
@@ -13,10 +13,6 @@ export function getIn(collection, searchKeyPath, notSetValue) {
   const keyPath = coerceKeyPath(searchKeyPath);
   let i = 0;
   while (i !== keyPath.length) {
-    // Intermediate null/undefined value along path
-    if (!collection) {
-      return notSetValue;
-    }
     collection = get(collection, keyPath[i++], NOT_SET);
     if (collection === NOT_SET) {
       return notSetValue;

--- a/src/functional/has.js
+++ b/src/functional/has.js
@@ -7,9 +7,10 @@
 
 import { isImmutable } from '../Predicates';
 import hasOwnProperty from '../utils/hasOwnProperty';
+import isDataStructure from '../utils/isDataStructure';
 
 export function has(collection, key) {
   return isImmutable(collection)
     ? collection.has(key)
-    : hasOwnProperty.call(collection, key);
+    : isDataStructure(collection) && hasOwnProperty.call(collection, key);
 }

--- a/src/functional/has.js
+++ b/src/functional/has.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { isCollection, isRecord } from '../Predicates';
+import hasOwnProperty from '../utils/hasOwnProperty';
+
+export function has(collection, key) {
+  return isCollection(collection) || isRecord(collection)
+    ? collection.has(key)
+    : hasOwnProperty.call(collection, key);
+}

--- a/src/functional/has.js
+++ b/src/functional/has.js
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { isCollection, isRecord } from '../Predicates';
+import { isImmutable } from '../Predicates';
 import hasOwnProperty from '../utils/hasOwnProperty';
 
 export function has(collection, key) {
-  return isCollection(collection) || isRecord(collection)
+  return isImmutable(collection)
     ? collection.has(key)
     : hasOwnProperty.call(collection, key);
 }

--- a/src/functional/hasIn.js
+++ b/src/functional/hasIn.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { getIn } from './getIn';
+import { NOT_SET } from '../TrieUtils';
+
+export function hasIn(collection, keyPath) {
+  return getIn(collection, keyPath, NOT_SET) !== NOT_SET;
+}

--- a/src/functional/merge.js
+++ b/src/functional/merge.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import shallowCopy from '../utils/shallowCopy';
+import hasOwnProperty from '../utils/hasOwnProperty';
+import { is } from '../is';
+
+export function merge(collection, ...sources) {
+  return mergeWithSources(undefined, collection, sources);
+}
+
+export function mergeWith(merger, collection, ...sources) {
+  return mergeWithSources(merger, collection, sources);
+}
+
+export function mergeDeep(collection, ...sources) {
+  return mergeWithSources(deepMergerWith(alwaysNewVal), collection, sources);
+}
+
+export function mergeDeepWith(merger, collection, ...sources) {
+  return mergeWithSources(deepMergerWith(merger), collection, sources);
+}
+
+function mergeWithSources(merger, collection, sources) {
+  if (typeof collection.mergeWith === 'function') {
+    return collection.mergeWith.apply(collection, [merger, ...sources]);
+  }
+  // TODO: Set needs concat!
+  if (typeof collection.concat === 'function') {
+    return collection.concat.apply(collection, sources);
+  }
+  const collectionCopy = shallowCopy(collection);
+  // TODO: can clean up with KeyedSeq?
+  for (let i = 0; i < sources.length; i++) {
+    const nextSource = sources[i];
+    if (nextSource != null) {
+      for (const key in nextSource) {
+        if (hasOwnProperty.call(nextSource, key)) {
+          collectionCopy[key] =
+            merger && hasOwnProperty.call(collectionCopy, key)
+              ? merger(collectionCopy[key], nextSource[key], key)
+              : nextSource[key];
+        }
+      }
+    }
+  }
+  return collectionCopy;
+}
+
+function deepMergerWith(merger) {
+  function deepMerger(oldVal, newVal, key) {
+    if (oldVal && newVal && typeof newVal === 'object') {
+      return mergeWithSources(deepMerger, oldVal, newVal);
+    }
+    const nextValue = merger(oldVal, newVal, key);
+    return is(oldVal, nextValue) ? oldVal : nextValue;
+  }
+  return deepMerger;
+}
+
+function alwaysNewVal(oldVal, newVal) {
+  return newVal;
+}

--- a/src/functional/remove.js
+++ b/src/functional/remove.js
@@ -6,11 +6,19 @@
  */
 
 import { isCollection, isRecord } from '../Predicates';
+import hasOwnProperty from '../utils/hasOwnProperty';
+import isPlainUpdatable from '../utils/isPlainUpdatable';
 import shallowCopy from '../utils/shallowCopy';
 
 export function remove(collection, key) {
   if (isCollection(collection) || isRecord(collection)) {
     return collection.delete(key);
+  }
+  if (!isPlainUpdatable(collection)) {
+    throw new TypeError('Cannot update non-updatable value: ' + collection);
+  }
+  if (!hasOwnProperty.call(collection, key)) {
+    return collection;
   }
   const collectionCopy = shallowCopy(collection);
   if (Array.isArray(collectionCopy)) {

--- a/src/functional/remove.js
+++ b/src/functional/remove.js
@@ -5,17 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { isCollection, isRecord } from '../Predicates';
+import { isImmutable } from '../Predicates';
 import hasOwnProperty from '../utils/hasOwnProperty';
-import isPlainUpdatable from '../utils/isPlainUpdatable';
+import isUpdatable from '../utils/isUpdatable';
 import shallowCopy from '../utils/shallowCopy';
 
 export function remove(collection, key) {
-  if (isCollection(collection) || isRecord(collection)) {
-    return collection.delete(key);
-  }
-  if (!isPlainUpdatable(collection)) {
+  if (!isUpdatable(collection)) {
     throw new TypeError('Cannot update non-updatable value: ' + collection);
+  }
+  if (isImmutable(collection)) {
+    return collection.delete(key);
   }
   if (!hasOwnProperty.call(collection, key)) {
     return collection;

--- a/src/functional/remove.js
+++ b/src/functional/remove.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { isCollection, isRecord } from '../Predicates';
+import shallowCopy from '../utils/shallowCopy';
+
+export function remove(collection, key) {
+  if (isCollection(collection) || isRecord(collection)) {
+    return collection.delete(key);
+  }
+  const collectionCopy = shallowCopy(collection);
+  if (Array.isArray(collectionCopy)) {
+    collectionCopy.splice(key, 1);
+  } else {
+    delete collectionCopy[key];
+  }
+  return collectionCopy;
+}

--- a/src/functional/remove.js
+++ b/src/functional/remove.js
@@ -7,15 +7,22 @@
 
 import { isImmutable } from '../Predicates';
 import hasOwnProperty from '../utils/hasOwnProperty';
-import isUpdatable from '../utils/isUpdatable';
+import isDataStructure from '../utils/isDataStructure';
 import shallowCopy from '../utils/shallowCopy';
 
 export function remove(collection, key) {
-  if (!isUpdatable(collection)) {
-    throw new TypeError('Cannot update non-updatable value: ' + collection);
+  if (!isDataStructure(collection)) {
+    throw new TypeError(
+      'Cannot update non-data-structure value: ' + collection
+    );
   }
   if (isImmutable(collection)) {
-    return collection.delete(key);
+    if (!collection.remove) {
+      throw new TypeError(
+        'Cannot update immutable value without .remove() method: ' + collection
+      );
+    }
+    return collection.remove(key);
   }
   if (!hasOwnProperty.call(collection, key)) {
     return collection;

--- a/src/functional/removeIn.js
+++ b/src/functional/removeIn.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { updateIn } from './updateIn';
+import { NOT_SET } from '../TrieUtils';
+
+export function removeIn(collection, keyPath) {
+  return updateIn(collection, keyPath, () => NOT_SET);
+}
+
+/*
+keyPath = [...coerceKeyPath(keyPath)];
+if (keyPath.length) {
+  const lastKey = keyPath.pop();
+  return this.updateIn(keyPath, c => c && c.remove(lastKey));
+}
+*/

--- a/src/functional/set.js
+++ b/src/functional/set.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { isCollection, isRecord } from '../Predicates';
+import shallowCopy from '../utils/shallowCopy';
+
+export function set(collection, key, value) {
+  if (isCollection(collection) || isRecord(collection)) {
+    // TODO: Set needs set!
+    return collection.set(key, value);
+  }
+  const collectionCopy = shallowCopy(collection);
+  collectionCopy[key] = value;
+  return collectionCopy;
+}

--- a/src/functional/set.js
+++ b/src/functional/set.js
@@ -7,17 +7,19 @@
 
 import { isImmutable } from '../Predicates';
 import hasOwnProperty from '../utils/hasOwnProperty';
-import isUpdatable from '../utils/isUpdatable';
+import isDataStructure from '../utils/isDataStructure';
 import shallowCopy from '../utils/shallowCopy';
 
 export function set(collection, key, value) {
-  if (!isUpdatable(collection)) {
-    throw new TypeError('Cannot update non-updatable value: ' + collection);
+  if (!isDataStructure(collection)) {
+    throw new TypeError(
+      'Cannot update non-data-structure value: ' + collection
+    );
   }
   if (isImmutable(collection)) {
     if (!collection.set) {
       throw new TypeError(
-        'Cannot update value without .set() method: ' + collection
+        'Cannot update immutable value without .set() method: ' + collection
       );
     }
     return collection.set(key, value);

--- a/src/functional/set.js
+++ b/src/functional/set.js
@@ -6,12 +6,24 @@
  */
 
 import { isCollection, isRecord } from '../Predicates';
+import hasOwnProperty from '../utils/hasOwnProperty';
+import isPlainUpdatable from '../utils/isPlainUpdatable';
 import shallowCopy from '../utils/shallowCopy';
 
 export function set(collection, key, value) {
   if (isCollection(collection) || isRecord(collection)) {
-    // TODO: Set needs set!
+    if (!collection.set) {
+      throw new TypeError(
+        'Cannot update value without .set() method: ' + collection
+      );
+    }
     return collection.set(key, value);
+  }
+  if (!isPlainUpdatable(collection)) {
+    throw new TypeError('Cannot update non-updatable value: ' + collection);
+  }
+  if (hasOwnProperty.call(collection, key) && value === collection[key]) {
+    return collection;
   }
   const collectionCopy = shallowCopy(collection);
   collectionCopy[key] = value;

--- a/src/functional/set.js
+++ b/src/functional/set.js
@@ -5,22 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { isCollection, isRecord } from '../Predicates';
+import { isImmutable } from '../Predicates';
 import hasOwnProperty from '../utils/hasOwnProperty';
-import isPlainUpdatable from '../utils/isPlainUpdatable';
+import isUpdatable from '../utils/isUpdatable';
 import shallowCopy from '../utils/shallowCopy';
 
 export function set(collection, key, value) {
-  if (isCollection(collection) || isRecord(collection)) {
+  if (!isUpdatable(collection)) {
+    throw new TypeError('Cannot update non-updatable value: ' + collection);
+  }
+  if (isImmutable(collection)) {
     if (!collection.set) {
       throw new TypeError(
         'Cannot update value without .set() method: ' + collection
       );
     }
     return collection.set(key, value);
-  }
-  if (!isPlainUpdatable(collection)) {
-    throw new TypeError('Cannot update non-updatable value: ' + collection);
   }
   if (hasOwnProperty.call(collection, key) && value === collection[key]) {
     return collection;

--- a/src/functional/setIn.js
+++ b/src/functional/setIn.js
@@ -6,7 +6,8 @@
  */
 
 import { updateIn } from './updateIn';
+import { NOT_SET } from '../TrieUtils';
 
 export function setIn(collection, keyPath, value) {
-  return updateIn(collection, keyPath, () => value);
+  return updateIn(collection, keyPath, NOT_SET, () => value);
 }

--- a/src/functional/setIn.js
+++ b/src/functional/setIn.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { updateIn } from './updateIn';
+
+export function setIn(collection, keyPath, value) {
+  return updateIn(collection, keyPath, () => value);
+}

--- a/src/functional/update.js
+++ b/src/functional/update.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { updateIn } from './updateIn';
+
+export function update(collection, key, notSetValue, updater) {
+  return updateIn(collection, [key], notSetValue, updater);
+}

--- a/src/functional/updateIn.js
+++ b/src/functional/updateIn.js
@@ -7,7 +7,7 @@
 
 import { isImmutable } from '../Predicates';
 import coerceKeyPath from '../utils/coerceKeyPath';
-import isUpdatable from '../utils/isUpdatable';
+import isDataStructure from '../utils/isDataStructure';
 import quoteString from '../utils/quoteString';
 import { NOT_SET } from '../TrieUtils';
 import { emptyMap } from '../Map';
@@ -45,9 +45,9 @@ function updateInDeeply(
     const newValue = updater(existingValue);
     return newValue === existingValue ? existing : newValue;
   }
-  if (!wasNotSet && !isUpdatable(existing)) {
+  if (!wasNotSet && !isDataStructure(existing)) {
     throw new TypeError(
-      'Cannot update within non-updatable value in path [' +
+      'Cannot update within non-data-structure value in path [' +
         keyPath.slice(0, i).map(quoteString) +
         ']: ' +
         existing

--- a/src/functional/updateIn.js
+++ b/src/functional/updateIn.js
@@ -67,12 +67,9 @@ function updateInDeeply(
     ? existing
     : nextUpdated === NOT_SET
       ? remove(existing, key)
-      : set(wasNotSet ? empty(key, inImmutable) : existing, key, nextUpdated);
-}
-
-function empty(key, inImmutable) {
-  // TODO: use emptyList(), but fix dependency cycle
-  return typeof key === 'number'
-    ? inImmutable ? emptyMap() : []
-    : inImmutable ? emptyMap() : {};
+      : set(
+          wasNotSet ? (inImmutable ? emptyMap() : {}) : existing,
+          key,
+          nextUpdated
+        );
 }

--- a/src/functional/updateIn.js
+++ b/src/functional/updateIn.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import coerceKeyPath from '../utils/coerceKeyPath';
+import { NOT_SET } from '../TrieUtils';
+import { emptyMap } from '../Map';
+import { get } from './get';
+import { remove } from './remove';
+import { set } from './set';
+
+export function updateIn(collection, keyPath, notSetValue, updater) {
+  if (!updater) {
+    updater = notSetValue;
+    notSetValue = undefined;
+  }
+  const updatedValue = updateInDeeply(
+    collection,
+    coerceKeyPath(keyPath),
+    0,
+    notSetValue,
+    updater
+  );
+  return updatedValue === NOT_SET ? notSetValue : updatedValue;
+}
+
+function updateInDeeply(existing, keyPath, i, notSetValue, updater) {
+  const wasNotSet = existing === NOT_SET;
+  if (i === keyPath.length) {
+    const existingValue = wasNotSet ? notSetValue : existing;
+    const newValue = updater(existingValue);
+    return newValue === existingValue ? existing : newValue;
+  }
+  // if (!(wasNotSet || (existing && existing.set))) {
+  //   throw new TypeError(
+  //     'Invalid keyPath: Value at [' +
+  //       keyPath.slice(0, i).map(quoteString) +
+  //       '] does not have a .set() method and cannot be updated: ' +
+  //       existing
+  //   );
+  // }
+  const key = keyPath[i];
+  const nextExisting = wasNotSet ? NOT_SET : get(existing, key, NOT_SET);
+  const nextUpdated = updateInDeeply(
+    nextExisting,
+    keyPath,
+    i + 1,
+    notSetValue,
+    updater
+  );
+  return nextUpdated === nextExisting
+    ? existing
+    : nextUpdated === NOT_SET
+      ? remove(existing, key)
+      : set(wasNotSet ? emptyMap() : existing, key, nextUpdated);
+}

--- a/src/toJS.js
+++ b/src/toJS.js
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Collection } from './Collection';
-import { isImmutable } from './Predicates';
+import { Seq } from './Seq';
+import isDataStructure from './utils/isDataStructure';
 
 export function toJS(value) {
-  return isImmutable(value)
-    ? Collection(value)
+  return isDataStructure(value)
+    ? Seq(value)
         .map(toJS)
         .toJSON()
     : value;

--- a/src/utils/arrCopy.js
+++ b/src/utils/arrCopy.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// http://jsperf.com/copy-array-inline
+export default function arrCopy(arr, offset) {
+  offset = offset || 0;
+  const len = Math.max(0, arr.length - offset);
+  const newArr = new Array(len);
+  for (let ii = 0; ii < len; ii++) {
+    newArr[ii] = arr[ii + offset];
+  }
+  return newArr;
+}

--- a/src/utils/hasOwnProperty.js
+++ b/src/utils/hasOwnProperty.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default Object.prototype.hasOwnProperty;

--- a/src/utils/isDataStructure.js
+++ b/src/utils/isDataStructure.js
@@ -8,10 +8,10 @@
 import { isImmutable } from '../Predicates';
 import isPlainObj from './isPlainObj';
 
-export default function isUpdatable(collection) {
-  return (
-    isImmutable(collection) ||
-    Array.isArray(collection) ||
-    isPlainObj(collection)
-  );
+/**
+ * Returns true if the value is a potentially-persistent data structure, either
+ * provided by Immutable.js or a plain Array or Object.
+ */
+export default function isDataStructure(value) {
+  return isImmutable(value) || Array.isArray(value) || isPlainObj(value);
 }

--- a/src/utils/isPlainObj.js
+++ b/src/utils/isPlainObj.js
@@ -5,9 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { updateIn } from './updateIn';
-import { NOT_SET } from '../TrieUtils';
-
-export function removeIn(collection, keyPath) {
-  return updateIn(collection, keyPath, () => NOT_SET);
+export default function isPlainObj(value) {
+  return (
+    value && (value.constructor === Object || value.constructor === undefined)
+  );
 }

--- a/src/utils/isPlainUpdatable.js
+++ b/src/utils/isPlainUpdatable.js
@@ -5,9 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { updateIn } from './updateIn';
-import { NOT_SET } from '../TrieUtils';
+import isPlainObj from './isPlainObj';
 
-export function removeIn(collection, keyPath) {
-  return updateIn(collection, keyPath, () => NOT_SET);
+export default function isPlainUpdatable(collection) {
+  return collection && (Array.isArray(collection) || isPlainObj(collection));
 }

--- a/src/utils/isUpdatable.js
+++ b/src/utils/isUpdatable.js
@@ -5,8 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { isImmutable } from '../Predicates';
 import isPlainObj from './isPlainObj';
 
-export default function isPlainUpdatable(collection) {
-  return collection && (Array.isArray(collection) || isPlainObj(collection));
+export default function isUpdatable(collection) {
+  return (
+    isImmutable(collection) ||
+    Array.isArray(collection) ||
+    isPlainObj(collection)
+  );
 }

--- a/src/utils/shallowCopy.js
+++ b/src/utils/shallowCopy.js
@@ -12,7 +12,7 @@ export default function shallowCopy(from) {
   if (Array.isArray(from)) {
     return arrCopy(from);
   }
-  const to = Object.create ? Object.create(Object.getPrototypeOf(from)) : {};
+  const to = {};
   for (const key in from) {
     if (hasOwnProperty.call(from, key)) {
       to[key] = from[key];

--- a/src/utils/shallowCopy.js
+++ b/src/utils/shallowCopy.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import arrCopy from './arrCopy';
+import hasOwnProperty from './hasOwnProperty';
+
+export default function shallowCopy(from) {
+  if (Array.isArray(from)) {
+    return arrCopy(from);
+  }
+  const to = Object.create ? Object.create(Object.getPrototypeOf(from)) : {};
+  for (const key in from) {
+    if (hasOwnProperty.call(from, key)) {
+      to[key] = from[key];
+    }
+  }
+  return to;
+}

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -707,6 +707,18 @@ declare module Immutable {
      * // List [ 0, 1, 2, List [ 999, 4 ] ]
      * ```
      *
+     * Plain JavaScript Object or Arrays may be nested within an Immutable.js
+     * Collection, and setIn() can update those values as well, treating them
+     * immutably by creating new copies of those values with the changes applied.
+     *
+     * <!-- runkit:activate -->
+     * ```js
+     * const { List } = require('immutable@4.0.0-rc.7')
+     * const list = List([ 0, 1, 2, { plain: 'object' }])
+     * list.setIn([3, 'plain'], 'value');
+     * // List([ 0, 1, 2, { plain: 'value' }])
+     * ```
+     *
      * Note: `setIn` can be used in `withMutations`.
      */
     setIn(keyPath: Iterable<any>, value: any): this;
@@ -721,6 +733,18 @@ declare module Immutable {
      * const list = List([ 0, 1, 2, List([ 3, 4 ])])
      * list.deleteIn([3, 0]);
      * // List [ 0, 1, 2, List [ 4 ] ]
+     * ```
+     *
+     * Plain JavaScript Object or Arrays may be nested within an Immutable.js
+     * Collection, and removeIn() can update those values as well, treating them
+     * immutably by creating new copies of those values with the changes applied.
+     *
+     * <!-- runkit:activate -->
+     * ```js
+     * const { List } = require('immutable@4.0.0-rc.7')
+     * const list = List([ 0, 1, 2, { plain: 'object' }])
+     * list.removeIn([3, 'plain']);
+     * // List([ 0, 1, 2, {}])
      * ```
      *
      * Note: `deleteIn` *cannot* be safely used in `withMutations`.
@@ -1344,8 +1368,33 @@ declare module Immutable {
      * // }
      * ```
      *
-     * If any key in the path exists but does not have a `.set()` method
-     * (such as Map and List), an error will be throw.
+     * Plain JavaScript Object or Arrays may be nested within an Immutable.js
+     * Collection, and setIn() can update those values as well, treating them
+     * immutably by creating new copies of those values with the changes applied.
+     *
+     * <!-- runkit:activate -->
+     * ```js
+     * const { Map } = require('immutable@4.0.0-rc.7')
+     * const originalMap = Map({
+     *   subObject: {
+     *     subKey: 'subvalue',
+     *     subSubObject: {
+     *       subSubKey: 'subSubValue'
+     *     }
+     *   }
+     * })
+     *
+     * originalMap.setIn(['subObject', 'subKey'], 'ha ha!')
+     * // Map {
+     * //   "subObject": {
+     * //     subKey: "ha ha!",
+     * //     subSubObject: { subSubKey: "subSubValue" }
+     * //   }
+     * // }
+     * ```
+     *
+     * If any key in the path exists but cannot be updated (such as a primitive
+     * like number or a custom Object like Date), an error will be thrown.
      *
      * Note: `setIn` can be used in `withMutations`.
      */
@@ -1420,8 +1469,23 @@ declare module Immutable {
      * // Map { "a": Map { "b": Map { "c": 10, "x": 100 } } }
      * ```
      *
-     * If any key in the path exists but does not have a .set() method (such as
-     * Map and List), an error will be thrown.
+     * Plain JavaScript Object or Arrays may be nested within an Immutable.js
+     * Collection, and updateIn() can update those values as well, treating them
+     * immutably by creating new copies of those values with the changes applied.
+     *
+     * <!-- runkit:activate
+     *      { "preamble": "const { Map } = require('immutable@4.0.0-rc.7')" }
+     * -->
+     * ```js
+     * const map = Map({ a: { b: { c: 10 } } })
+     * const newMap = map.updateIn(['a', 'b', 'c'], val => val * 2)
+     * // Map { "a": { b: { c: 20 } } }
+     * ```
+     *
+     * If any key in the path exists but cannot be updated (such as a primitive
+     * like number or a custom Object like Date), an error will be thrown.
+     *
+     * Note: `updateIn` can be used in `withMutations`.
      */
     updateIn(keyPath: Iterable<any>, notSetValue: any, updater: (value: any) => any): this;
     updateIn(keyPath: Iterable<any>, updater: (value: any) => any): this;
@@ -3903,6 +3967,23 @@ declare module Immutable {
     /**
      * Returns the value found by following a path of keys or indices through
      * nested Collections.
+     *
+     * <!-- runkit:activate -->
+     * ```js
+     * const { Map, List } = require('immutable@4.0.0-rc.7')
+     * const deepData = Map({ x: List([ Map({ y: 123 }) ]) });
+     * getIn(deepData, ['x', 0, 'y']) // 123
+     * ```
+     *
+     * Plain JavaScript Object or Arrays may be nested within an Immutable.js
+     * Collection, and getIn() can access those values as well:
+     *
+     * <!-- runkit:activate -->
+     * ```js
+     * const { Map, List } = require('immutable@4.0.0-rc.7')
+     * const deepData = Map({ x: [ { y: 123 } ] });
+     * getIn(deepData, ['x', 0, 'y']) // 123
+     * ```
      */
     getIn(searchKeyPath: Iterable<any>, notSetValue?: any): any;
 

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -4708,6 +4708,171 @@ declare module Immutable {
      */
     isSuperset(iter: Iterable<V>): boolean;
   }
+
+  /**
+   * Returns the value within the provided collection associated with the
+   * provided key, or notSetValue if the key is not defined in the collection.
+   *
+   * A functional alternative to `collection.get(key)` which will also work on
+   * plain Objects and Arrays as an alternative for `collection[key]`.
+   */
+  export function get<K, V>(collection: Collection<K, V>, key: K): V | undefined;
+  export function get<K, V, NSV>(collection: Collection<K, V>, key: K, notSetValue: NSV): V | NSV;
+  export function get<TProps, K extends keyof TProps>(record: Record<TProps>, key: K, notSetValue: any): TProps[K];
+  export function get<V>(collection: Array<V>, key: number): V | undefined;
+  export function get<V, NSV>(collection: Array<V>, key: number, notSetValue: NSV): V | NSV;
+  export function get<C extends Object, K extends keyof C>(object: C, key: K, notSetValue: any): C[K];
+  export function get<V>(collection: {[key: string]: V}, key: string): V | undefined;
+  export function get<V, NSV>(collection: {[key: string]: V}, key: string, notSetValue: NSV): V | NSV;
+
+  /**
+   * Returns true if the key is defined in the provided collection.
+   *
+   * A functional alternative to `collection.has(key)` which will also work with
+   * plain Objects and Arrays as an alternative for
+   * `collection.hasOwnProperty(key)`.
+   */
+  export function has(collection: Object, key: mixed): boolean;
+
+  /**
+   * Returns a copy of the collection with the value at key removed.
+   *
+   * A functional alternative to `collection.remove(key)` which will also work
+   * with plain Objects and Arrays as an alternative for
+   * `delete collectionCopy[key]`.
+   */
+  export function remove<K, C extends Collection<K, any>>(collection: C, key: K): C;
+  export function remove<TProps, R extends Record<TProps>, K extends keyof TProps>(collection: C, key: K): C;
+  export function remove<C extends Array<any>>(collection: C, key: number): C;
+  export function remove<C, K extends keyof Obj>(collection: C, key: K): C;
+  export function remove<K, C extends {[key: string]: any}>(collection: C, key: K): C;
+
+  /**
+   * Returns a copy of the collection with the value at key set to the provided
+   * value.
+   *
+   * A functional alternative to `collection.set(key, value)` which will also
+   * work with plain Objects and Arrays as an alternative for
+   * `collectionCopy[key] = value`.
+   */
+  export function set<K, V, C extends Collection<K, V>>(collection: C, key: K, value: V): C;
+  export function set<TProps, C extends Record<TProps>, K extends keyof TProps>(record: C, key: K, value: TProps[K]): C;
+  export function set<V, C extends Array<V>>(collection: C, key: number, value: V): C;
+  export function set<C, K extends keyof C>(object: C, key: K, value: C[K]): C;
+  export function set<V, C extends {[key: string]: V}>(collection: C, key: string, value: V): C;
+
+  /**
+   * Returns a copy of the collection with the value at key set to the result of
+   * providing the existing value to the updating function.
+   *
+   * A functional alternative to `collection.update(key, fn)` which will also
+   * work with plain Objects and Arrays as an alternative for
+   * `collectionCopy[key] = fn(collection[key])`.
+   */
+  export function update<K, V, C extends Collection<K, V>>(collection: C, key: K, updater: (value: V) => V): C;
+  export function update<K, V, C extends Collection<K, V>, NSV>(collection: C, key: K, notSetValue: NSV, updater: (value: V | NSV) => V): C;
+  export function update<TProps, C extends Record<TProps>, K extends keyof TProps>(record: C, key: K, updater: (value: TProps[K]) => TProps[K]): C;
+  export function update<TProps, C extends Record<TProps>, K extends keyof TProps, NSV>(record: C, key: K, notSetValue: NSV, updater: (value: TProps[K] | NSV) => TProps[K]): C;
+  export function update<V>(collection: Array<V>, key: number, updater: (value: V) => V): Array<V>;
+  export function update<V, NSV>(collection: Array<V>, key: number, notSetValue: NSV, updater: (value: V | NSV) => V): C;
+  export function update<C, K extends keyof C>(object: C, key: K, updater: (value: C[K]) => C[K]): C;
+  export function update<C, K extends keyof C, NSV>(object: C, key: K, notSetValue: NSV, updater: (value: C[K] | NSV) => C[K]): C;
+  export function update<V, C extends {[key: string]: V}>(collection: C, key: K, updater: (value: V) => V): {[key: string]: V};
+  export function update<V, C extends {[key: string]: V}, NSV>(collection: C, key: K, notSetValue: NSV, updater: (value: V | NSV) => V): {[key: string]: V};
+
+  /**
+   * Returns the value at the provided key path starting at the provided
+   * collection, or notSetValue if the key path is not defined.
+   *
+   * A functional alternative to `collection.getIn(keypath)` which will also
+   * work with plain Objects and Arrays.
+   */
+  export function getIn(collection: any, keyPath: Iterable<any>, notSetValue: any): any;
+
+  /**
+   * Returns true if the key path is defined in the provided collection.
+   *
+   * A functional alternative to `collection.hasIn(keypath)` which will also
+   * work with plain Objects and Arrays.
+   */
+  export function hasIn(collection: any, keyPath: Iterable<any>): boolean;
+
+  /**
+   * Returns a copy of the collection with the value at the key path removed.
+   *
+   * A functional alternative to `collection.removeIn(keypath)` which will also
+   * work with plain Objects and Arrays.
+   */
+  export function removeIn<C>(collection: C, keyPath: Iterable<any>): C;
+
+  /**
+   * Returns a copy of the collection with the value at the key path set to the
+   * provided value.
+   *
+   * A functional alternative to `collection.setIn(keypath)` which will also
+   * work with plain Objects and Arrays.
+   */
+  export function setIn<C>(collection: C, keyPath: Iterable<any>, value: any): C;
+
+  /**
+   * Returns a copy of the collection with the value at key path set to the
+   * result of providing the existing value to the updating function.
+   *
+   * A functional alternative to `collection.updateIn(keypath)` which will also
+   * work with plain Objects and Arrays.
+   */
+  export function updateIn<C>(collection: C, keyPath: Iterable<any>, updater: (value: any) => any): C;
+
+
+  /**
+   * Returns a copy of the collection with the remaining collections merged in.
+   *
+   * A functional alternative to `collection.merge()` which will also work with
+   * plain Objects and Arrays.
+   */
+  export function merge<C>(
+    collection: C,
+    ...collections: Array<Iterable<any> | Iterable<[any, any]> | {[key: string]: any}>
+  ): C;
+
+  /**
+   * Returns a copy of the collection with the remaining collections merged in,
+   * calling the `merger` function whenever an existing value is encountered.
+   *
+   * A functional alternative to `collection.mergeWith()` which will also work
+   * with plain Objects and Arrays.
+   */
+  export function mergeWith<C>(
+    merger: (oldVal: any, newVal: any, key: any) => any,
+    collection: C,
+    ...collections: Array<Iterable<any> | Iterable<[any, any]> | {[key: string]: any}>
+  ): C;
+
+  /**
+   * Returns a copy of the collection with the remaining collections merged in
+   * deeply (recursively).
+   *
+   * A functional alternative to `collection.mergeDeep()` which will also work
+   * with plain Objects and Arrays.
+   */
+  export function mergeDeep<C>(
+    collection: C,
+    ...collections: Array<Iterable<any> | Iterable<[any, any]> | {[key: string]: any}>
+  ): C;
+
+  /**
+   * Returns a copy of the collection with the remaining collections merged in
+   * deeply (recursively), calling the `merger` function whenever an existing
+   * value is encountered.
+   *
+   * A functional alternative to `collection.mergeDeepWith()` which will also
+   * work with plain Objects and Arrays.
+   */
+  export function mergeDeepWith<C>(
+    merger: (oldVal: any, newVal: any, key: any) => mixed,
+    collection: C,
+    ...collections: Array<Iterable<any> | Iterable<[any, any]> | {[key: string]: any}>
+  ): C;
 }
 
 declare module "immutable" {

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2518,6 +2518,44 @@ declare module Immutable {
    * export type Point3D = RecordOf<Point3DProps>;
    * const some3DPoint: Point3D = makePoint3D({ x: 10, y: 20, z: 30 });
    * ```
+   *
+   *
+   * **Choosing Records vs plain JavaScript objects**
+   *
+   * Records ofters a persistently immutable alternative to plain JavaScript
+   * objects, however they're not required to be used within Immutable.js
+   * collections. In fact, the deep-access and deep-updating functions
+   * like `getIn()` and `setIn()` work with plain JavaScript Objects as well.
+   *
+   * Deciding to use Records or Objects in your application should be informed
+   * by the tradeoffs and relative benefits of each:
+   *
+   * - *Runtime immutability*: plain JS objects may be carefully treated as
+   *   immutable, however Record instances will *throw* if attempted to be
+   *   mutated directly. Records provide this additional guarantee, however at
+   *   some marginal runtime cost. While JS objects are mutable by nature, the
+   *   use of type-checking tools like [Flow](https://medium.com/@gcanti/immutability-with-flow-faa050a1aef4)
+   *   can help gain confidence in code written to favor immutability.
+   *
+   * - *Value equality*: Records use value equality when compared with `is()`
+   *   or `record.equals()`. That is, two Records with the same keys and values
+   *   are equal. Plain objects use *reference equality*. Two objects with the
+   *   same keys and values are not equal since they are different objects.
+   *   This is important to consider when using objects as keys in a `Map` or
+   *   values in a `Set`, which use equality when retrieving values.
+   *
+   * - *API methods*: Records have a full featured API, with methods like
+   *   `.getIn()`, and `.equals()`. These can make working with these values
+   *   easier, but comes at the cost of not allowing keys with those names.
+   *
+   * - *Default values*: Records provide default values for every key, which
+   *   can be useful when constructing Records with often unchanging values.
+   *   However default values can make using Flow and TypeScript more laborious.
+   *
+   * - *Serialization*: Records use a custom internal representation to
+   *   efficiently store and update their values. Converting to and from this
+   *   form isn't free. If converting Records to plain objects is common,
+   *   consider sticking with plain objects to begin with.
    */
   export module Record {
 

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -4715,6 +4715,14 @@ declare module Immutable {
    *
    * A functional alternative to `collection.get(key)` which will also work on
    * plain Objects and Arrays as an alternative for `collection[key]`.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { get } = require('immutable@4.0.0-rc.7')
+   * get([ 'dog', 'frog', 'cat' ], 2) // 'frog'
+   * get({ x: 123, y: 456 }, 'x') // 123
+   * get({ x: 123, y: 456 }, 'z', 'ifNotSet') // 'ifNotSet'
+   * ```
    */
   export function get<K, V>(collection: Collection<K, V>, key: K): V | undefined;
   export function get<K, V, NSV>(collection: Collection<K, V>, key: K, notSetValue: NSV): V | NSV;
@@ -4731,6 +4739,15 @@ declare module Immutable {
    * A functional alternative to `collection.has(key)` which will also work with
    * plain Objects and Arrays as an alternative for
    * `collection.hasOwnProperty(key)`.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { has } = require('immutable@4.0.0-rc.7')
+   * has([ 'dog', 'frog', 'cat' ], 2) // true
+   * has([ 'dog', 'frog', 'cat' ], 5) // false
+   * has({ x: 123, y: 456 }, 'x') // true
+   * has({ x: 123, y: 456 }, 'z') // false
+   * ```
    */
   export function has(collection: Object, key: mixed): boolean;
 
@@ -4740,6 +4757,17 @@ declare module Immutable {
    * A functional alternative to `collection.remove(key)` which will also work
    * with plain Objects and Arrays as an alternative for
    * `delete collectionCopy[key]`.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { remove } = require('immutable@4.0.0-rc.7')
+   * const originalArray = [ 'dog', 'frog', 'cat' ]
+   * remove(originalArray, 1) // [ 'dog', 'cat' ]
+   * console.log(originalArray) // [ 'dog', 'frog', 'cat' ]
+   * const originalObject = { x: 123, y: 456 }
+   * remove(originalObject, 'x') // { y: 456 }
+   * console.log(originalObject) // { x: 123, y: 456 }
+   * ```
    */
   export function remove<K, C extends Collection<K, any>>(collection: C, key: K): C;
   export function remove<TProps, R extends Record<TProps>, K extends keyof TProps>(collection: C, key: K): C;
@@ -4754,6 +4782,17 @@ declare module Immutable {
    * A functional alternative to `collection.set(key, value)` which will also
    * work with plain Objects and Arrays as an alternative for
    * `collectionCopy[key] = value`.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { set } = require('immutable@4.0.0-rc.7')
+   * const originalArray = [ 'dog', 'frog', 'cat' ]
+   * set(originalArray, 1, 'cow') // [ 'dog', 'cow', 'cat' ]
+   * console.log(originalArray) // [ 'dog', 'frog', 'cat' ]
+   * const originalObject = { x: 123, y: 456 }
+   * set(originalObject, 'x', 789) // { x: 789, y: 456 }
+   * console.log(originalObject) // { x: 123, y: 456 }
+   * ```
    */
   export function set<K, V, C extends Collection<K, V>>(collection: C, key: K, value: V): C;
   export function set<TProps, C extends Record<TProps>, K extends keyof TProps>(record: C, key: K, value: TProps[K]): C;
@@ -4768,6 +4807,17 @@ declare module Immutable {
    * A functional alternative to `collection.update(key, fn)` which will also
    * work with plain Objects and Arrays as an alternative for
    * `collectionCopy[key] = fn(collection[key])`.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { update } = require('immutable@4.0.0-rc.7')
+   * const originalArray = [ 'dog', 'frog', 'cat' ]
+   * update(originalArray, 1, val => val.toUpperCase()) // [ 'dog', 'FROG', 'cat' ]
+   * console.log(originalArray) // [ 'dog', 'frog', 'cat' ]
+   * const originalObject = { x: 123, y: 456 }
+   * set(originalObject, 'x', val => val * 6) // { x: 738, y: 456 }
+   * console.log(originalObject) // { x: 123, y: 456 }
+   * ```
    */
   export function update<K, V, C extends Collection<K, V>>(collection: C, key: K, updater: (value: V) => V): C;
   export function update<K, V, C extends Collection<K, V>, NSV>(collection: C, key: K, notSetValue: NSV, updater: (value: V | NSV) => V): C;
@@ -4786,6 +4836,13 @@ declare module Immutable {
    *
    * A functional alternative to `collection.getIn(keypath)` which will also
    * work with plain Objects and Arrays.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { getIn } = require('immutable@4.0.0-rc.7')
+   * getIn({ x: { y: { z: 123 }}}, ['x', 'y', 'z']) // 123
+   * getIn({ x: { y: { z: 123 }}}, ['x', 'q', 'p'], 'ifNotSet') // 'ifNotSet'
+   * ```
    */
   export function getIn(collection: any, keyPath: Iterable<any>, notSetValue: any): any;
 
@@ -4794,6 +4851,13 @@ declare module Immutable {
    *
    * A functional alternative to `collection.hasIn(keypath)` which will also
    * work with plain Objects and Arrays.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { hasIn } = require('immutable@4.0.0-rc.7')
+   * hasIn({ x: { y: { z: 123 }}}, ['x', 'y', 'z']) // true
+   * hasIn({ x: { y: { z: 123 }}}, ['x', 'q', 'p']) // false
+   * ```
    */
   export function hasIn(collection: any, keyPath: Iterable<any>): boolean;
 
@@ -4802,6 +4866,14 @@ declare module Immutable {
    *
    * A functional alternative to `collection.removeIn(keypath)` which will also
    * work with plain Objects and Arrays.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { removeIn } = require('immutable@4.0.0-rc.7')
+   * const original = { x: { y: { z: 123 }}}
+   * removeIn(original, ['x', 'y', 'z']) // { x: { y: {}}}
+   * console.log(original) // { x: { y: { z: 123 }}}
+   * ```
    */
   export function removeIn<C>(collection: C, keyPath: Iterable<any>): C;
 
@@ -4811,6 +4883,14 @@ declare module Immutable {
    *
    * A functional alternative to `collection.setIn(keypath)` which will also
    * work with plain Objects and Arrays.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { setIn } = require('immutable@4.0.0-rc.7')
+   * const original = { x: { y: { z: 123 }}}
+   * setIn(original, ['x', 'y', 'z'], 456) // { x: { y: { z: 456 }}}
+   * console.log(original) // { x: { y: { z: 123 }}}
+   * ```
    */
   export function setIn<C>(collection: C, keyPath: Iterable<any>, value: any): C;
 
@@ -4820,6 +4900,14 @@ declare module Immutable {
    *
    * A functional alternative to `collection.updateIn(keypath)` which will also
    * work with plain Objects and Arrays.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { setIn } = require('immutable@4.0.0-rc.7')
+   * const original = { x: { y: { z: 123 }}}
+   * setIn(original, ['x', 'y', 'z'], val => val * 6) // { x: { y: { z: 738 }}}
+   * console.log(original) // { x: { y: { z: 123 }}}
+   * ```
    */
   export function updateIn<C>(collection: C, keyPath: Iterable<any>, updater: (value: any) => any): C;
 
@@ -4829,6 +4917,14 @@ declare module Immutable {
    *
    * A functional alternative to `collection.merge()` which will also work with
    * plain Objects and Arrays.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { merge } = require('immutable@4.0.0-rc.7')
+   * const original = { x: 123, y: 456 }
+   * merge(original, { y: 789, z: 'abc' }) // { x: 123, y: 789, z: 'abc' }
+   * console.log(original) // { x: { y: { z: 123 }}}
+   * ```
    */
   export function merge<C>(
     collection: C,
@@ -4841,6 +4937,18 @@ declare module Immutable {
    *
    * A functional alternative to `collection.mergeWith()` which will also work
    * with plain Objects and Arrays.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { mergeWith } = require('immutable@4.0.0-rc.7')
+   * const original = { x: 123, y: 456 }
+   * mergeWith(
+   *   (oldVal, newVal) => oldVal + newVal,
+   *   original,
+   *   { y: 789, z: 'abc' }
+   * ) // { x: 123, y: 1245, z: 'abc' }
+   * console.log(original) // { x: { y: { z: 123 }}}
+   * ```
    */
   export function mergeWith<C>(
     merger: (oldVal: any, newVal: any, key: any) => any,
@@ -4854,6 +4962,14 @@ declare module Immutable {
    *
    * A functional alternative to `collection.mergeDeep()` which will also work
    * with plain Objects and Arrays.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { merge } = require('immutable@4.0.0-rc.7')
+   * const original = { x: { y: 123 }}
+   * merge(original, { x: { z: 456 }}) // { x: { y: 123, z: 456 }}
+   * console.log(original) // { x: { y: 123 }}
+   * ```
    */
   export function mergeDeep<C>(
     collection: C,
@@ -4867,6 +4983,18 @@ declare module Immutable {
    *
    * A functional alternative to `collection.mergeDeepWith()` which will also
    * work with plain Objects and Arrays.
+   *
+   * <!-- runkit:activate -->
+   * ```js
+   * const { merge } = require('immutable@4.0.0-rc.7')
+   * const original = { x: { y: 123 }}
+   * mergeDeepWith(
+   *   (oldVal, newVal) => oldVal + newVal,
+   *   original,
+   *   { x: { y: 456 }}
+   * ) // { x: { y: 579 }}
+   * console.log(original) // { x: { y: 123 }}
+   * ```
    */
   export function mergeDeepWith<C>(
     merger: (oldVal: any, newVal: any, key: any) => mixed,

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -36,13 +36,15 @@ type PlainObjInput<K, V> = {[key: K]: V, __proto__: null};
 // Exported for experimental use only, may change.
 export type $KeyOf<C> = $Call<
   & (<K>(?_Collection<K, mixed>) => K)
-  & (<T>(?RecordInstance<T>) => $Keys<T>),
+  & (<T>(?$ReadOnlyArray<T>) => number)
+  & (<T>(?RecordInstance<T> | T) => $Keys<T>),
   C
 >;
 
 export type $ValOf<C, K = $KeyOf<C>> = $Call<
   & (<V>(?_Collection<any, V>) => V)
-  & (<T, K: $Keys<T>>(?RecordInstance<T>, K) => $ElementType<T, K>),
+  & (<T>(?$ReadOnlyArray<T>) => T)
+  & (<T, K: $Keys<T>>(?RecordInstance<T> | T, K) => $ElementType<T, K>),
   C,
   K
 >;
@@ -1484,6 +1486,62 @@ declare function fromJS(
 declare function is(first: mixed, second: mixed): boolean;
 declare function hash(value: mixed): number;
 
+declare function get<C, K: $KeyOf<C>, NSV>(collection: C, key: K, notSetValue: NSV): $ValOf<C, K> | NSV;
+declare function has(collection: Object, key: mixed): boolean;
+declare function remove<C>(collection: C, key: $KeyOf<C>): C;
+declare function set<C, K: $KeyOf<C>, V: $ValOf<C, K>>(collection: C, key: K, value: V): C;
+declare function update<C, K: $KeyOf<C>, V: $ValOf<C, K>, NSV>(collection: C, key: K, notSetValue: NSV, updater: ($ValOf<C, K> | NSV) => V): C;
+declare function update<C, K: $KeyOf<C>, V: $ValOf<C, K>>(collection: C, key: K, updater: ($ValOf<C, K>) => V): C;
+
+declare function getIn<C>(collection: C, keyPath: [], notSetValue?: mixed): C;
+declare function getIn<C, K: $KeyOf<C>, NSV>(collection: C, keyPath: [K], notSetValue: NSV): $ValOf<C, K> | NSV;
+declare function getIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, NSV>(collection: C, keyPath: [K, K2], notSetValue: NSV): $ValOf<$ValOf<C, K>, K2> | NSV;
+declare function getIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, NSV>(collection: C, keyPath: [K, K2, K3], notSetValue: NSV): $ValOf<$ValOf<$ValOf<C, K>, K2>, K3> | NSV;
+declare function getIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>>, NSV>(collection: C, keyPath: [K, K2, K3, K4], notSetValue: NSV): $ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4> | NSV;
+declare function getIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>>, NSV>(collection: C, keyPath: [K, K2, K3, K4, K5], notSetValue: NSV): $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>, K5> | NSV;
+
+declare function hasIn(collection: Object, keyPath: Iterable<mixed>): boolean;
+
+declare function removeIn<C>(collection: C, keyPath: []): void;
+declare function removeIn<C, K: $KeyOf<C>>(collection: C, keyPath: [K]): C;
+declare function removeIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C>>>(collection: C, keyPath: [K, K2]): C;
+declare function removeIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C>>, K3: $KeyOf<$ValOf<$ValOf<C>, K2>>>(collection: C, keyPath: [K, K2, K3]): C;
+declare function removeIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C>>, K3: $KeyOf<$ValOf<$ValOf<C>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<C>, K2>, K3>>>(collection: C, keyPath: [K, K2, K3, K4]): C;
+declare function removeIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C>>, K3: $KeyOf<$ValOf<$ValOf<C>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<C>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<C>, K2>, K3>, K4>>>(collection: C, keyPath: [K, K2, K3, K4, K5]): C;
+
+declare function setIn<S>(collection: Object, keyPath: [], value: S): S;
+declare function setIn<C, K: $KeyOf<C>, S: $ValOf<C, K>>(collection: C, keyPath: [K], value: S): C;
+declare function setIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, S: $ValOf<$ValOf<C, K>, K2>>(collection: C, keyPath: [K, K2], value: S): C;
+declare function setIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, S: $ValOf<$ValOf<$ValOf<C, K>, K2>, K3>>(collection: C, keyPath: [K, K2, K3], value: S): C;
+declare function setIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>>(collection: C, keyPath: [K, K2, K3, K4], value: S): C;
+declare function setIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>, K5>>(collection: C, keyPath: [K, K2, K3, K4, K5], value: S): C;
+
+declare function updateIn<C, S>(collection: C, keyPath: [], notSetValue: mixed, updater: (value: C) => S): S;
+declare function updateIn<C, S>(collection: C, keyPath: [], updater: (value: C) => S): S;
+declare function updateIn<C, K: $KeyOf<C>, S: $ValOf<C, K>, NSV>(collection: C, keyPath: [K], notSetValue: NSV, updater: (value: $ValOf<C, K> | NSV) => S): C;
+declare function updateIn<C, K: $KeyOf<C>, S: $ValOf<C, K>>(collection: C, keyPath: [K], updater: (value: $ValOf<C, K>) => S): C;
+declare function updateIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, S: $ValOf<$ValOf<C, K>, K2>, NSV>(collection: C, keyPath: [K, K2], notSetValue: NSV, updater: (value: $ValOf<$ValOf<C, K>, K2> | NSV) => S): C;
+declare function updateIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, S: $ValOf<$ValOf<C, K>, K2>>(collection: C, keyPath: [K, K2], updater: (value: $ValOf<$ValOf<C, K>, K2>) => S): C;
+declare function updateIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, S: $ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, NSV>(collection: C, keyPath: [K, K2, K3], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<C, K>, K2>, K3> | NSV) => S): C;
+declare function updateIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, S: $ValOf<$ValOf<$ValOf<C, K>, K2>, K3>>(collection: C, keyPath: [K, K2, K3], updater: (value: $ValOf<$ValOf<$ValOf<C, K>, K2>, K3>) => S): C;
+declare function updateIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>, NSV>(collection: C, keyPath: [K, K2, K3, K4], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4> | NSV) => S): C;
+declare function updateIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>>(collection: C, keyPath: [K, K2, K3, K4], updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>) => S): C;
+declare function updateIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>, K5>, NSV>(collection: C, keyPath: [K, K2, K3, K4, K5], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>, K5> | NSV) => S): C;
+declare function updateIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>, K5>>(collection: C, keyPath: [K, K2, K3, K4, K5], updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>, K5>) => S): C;
+
+declare function merge<C>(collection: C, ...collections: Array<Iterable<$ValOf<C>> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>): C;
+declare function mergeWith<C>(
+  merger: (oldVal: $ValOf<C>, newVal: $ValOf<C>, key: $KeyOf<C>) => $ValOf<C>,
+  collection: C,
+  ...collections: Array<Iterable<$ValOf<C>> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
+): C;
+declare function mergeDeep<C>(collection: C, ...collections: Array<Iterable<$ValOf<C>> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>): C;
+declare function mergeDeepWith<C>(
+  merger: (oldVal: any, newVal: any, key: any) => mixed,
+  collection: C,
+  ...collections: Array<Iterable<$ValOf<C>> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
+): C;
+
 export {
   Collection,
   Seq,
@@ -1510,6 +1568,21 @@ export {
   isOrdered,
   isRecord,
   isValueObject,
+
+  get,
+  has,
+  remove,
+  set,
+  update,
+  getIn,
+  hasIn,
+  removeIn,
+  setIn,
+  updateIn,
+  merge,
+  mergeWith,
+  mergeDeep,
+  mergeDeepWith,
 }
 
 export default {
@@ -1538,6 +1611,21 @@ export default {
   isOrdered,
   isRecord,
   isValueObject,
+
+  get,
+  has,
+  remove,
+  set,
+  update,
+  getIn,
+  hasIn,
+  removeIn,
+  setIn,
+  updateIn,
+  merge,
+  mergeWith,
+  mergeDeep,
+  mergeDeepWith,
 }
 
 export type {

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -43,7 +43,8 @@ type $KeyOf<C> = $Call<
 type $ValOf<C, K = $KeyOf<C>> = $Call<
   & (<V>(?_Collection<any, V>) => V)
   & (<T>(?$ReadOnlyArray<T>) => T)
-  & (<T, K: $Keys<T>>(?RecordInstance<T> | T, K) => $ElementType<T, K>),
+  & (<T, K: $Keys<T>>(?RecordInstance<T> | T, K) => $ElementType<T, K>)
+  & (<V>(?{[any]: V}) => V),
   C,
   K
 >;
@@ -1485,7 +1486,9 @@ declare function fromJS(
 declare function is(first: mixed, second: mixed): boolean;
 declare function hash(value: mixed): number;
 
+declare function get<C: Object, K: $Keys<C>>(collection: C, key: K, notSetValue: mixed): $ValOf<C, K>;
 declare function get<C, K: $KeyOf<C>, NSV>(collection: C, key: K, notSetValue: NSV): $ValOf<C, K> | NSV;
+
 declare function has(collection: Object, key: mixed): boolean;
 declare function remove<C>(collection: C, key: $KeyOf<C>): C;
 declare function set<C, K: $KeyOf<C>, V: $ValOf<C, K>>(collection: C, key: K, value: V): C;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -33,15 +33,14 @@
 type PlainObjInput<K, V> = {[key: K]: V, __proto__: null};
 
 // Helper types to extract the "keys" and "values" use by the *In() methods.
-// Exported for experimental use only, may change.
-export type $KeyOf<C> = $Call<
+type $KeyOf<C> = $Call<
   & (<K>(?_Collection<K, mixed>) => K)
   & (<T>(?$ReadOnlyArray<T>) => number)
   & (<T>(?RecordInstance<T> | T) => $Keys<T>),
   C
 >;
 
-export type $ValOf<C, K = $KeyOf<C>> = $Call<
+type $ValOf<C, K = $KeyOf<C>> = $Call<
   & (<V>(?_Collection<any, V>) => V)
   & (<T>(?$ReadOnlyArray<T>) => T)
   & (<T, K: $Keys<T>>(?RecordInstance<T> | T, K) => $ElementType<T, K>),
@@ -1529,17 +1528,23 @@ declare function updateIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<
 declare function updateIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>, K5>, NSV>(collection: C, keyPath: [K, K2, K3, K4, K5], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>, K5> | NSV) => S): C;
 declare function updateIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<$ValOf<$ValOf<C, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>, K5>>(collection: C, keyPath: [K, K2, K3, K4, K5], updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<C, K>, K2>, K3>, K4>, K5>) => S): C;
 
-declare function merge<C>(collection: C, ...collections: Array<Iterable<$ValOf<C>> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>): C;
+declare function merge<C>(
+  collection: C,
+  ...collections: Array<Iterable<$ValOf<C>> | Iterable<[$KeyOf<C>, $ValOf<C>]> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
+): C;
 declare function mergeWith<C>(
   merger: (oldVal: $ValOf<C>, newVal: $ValOf<C>, key: $KeyOf<C>) => $ValOf<C>,
   collection: C,
-  ...collections: Array<Iterable<$ValOf<C>> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
+  ...collections: Array<Iterable<$ValOf<C>> | Iterable<[$KeyOf<C>, $ValOf<C>]> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
 ): C;
-declare function mergeDeep<C>(collection: C, ...collections: Array<Iterable<$ValOf<C>> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>): C;
+declare function mergeDeep<C>(
+  collection: C,
+  ...collections: Array<Iterable<$ValOf<C>> | Iterable<[$KeyOf<C>, $ValOf<C>]> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
+): C;
 declare function mergeDeepWith<C>(
   merger: (oldVal: any, newVal: any, key: any) => mixed,
   collection: C,
-  ...collections: Array<Iterable<$ValOf<C>> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
+  ...collections: Array<Iterable<$ValOf<C>> | Iterable<[$KeyOf<C>, $ValOf<C>]> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
 ): C;
 
 export {
@@ -1638,4 +1643,7 @@ export type {
   RecordFactory,
   RecordOf,
   ValueObject,
+
+  $KeyOf,
+  $ValOf,
 }

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -1088,3 +1088,23 @@ updateIn(plainFriendlies, [0, 'friends', 0, 'name'], value => value.toUpperCase(
 // $ExpectError number is not a string
 updateIn(plainFriendlies, [0, 'friends', 0, 'name'], () => 123);
 updateIn(plainFriendlies, [0, 'friends', 0, 'name'], () => 'Whitney');
+
+// Plain JS values
+
+{ const success: number|void = get([1, 2, 3], 0); }
+{ const success: number|string = get([1, 2, 3], 0, 'missing'); }
+// $ExpectError - string is not an array index
+{ const success: number = get([1, 2, 3], 'z'); }
+// Note: does not return null since x is known to exist in {x,y}
+{ const success: number = get({x: 10, y: 10}, 'x'); }
+// $ExpectError - z is not in {x,y}
+{ const success: number|void = get({x: 10, y: 10}, 'z'); }
+{
+  const objMap: {[string]: number} = {x: 10, y: 10};
+  const success: number|void = get(objMap, 'z');
+}
+{ const success: number = get({x: 10, y: 10}, 'x', 'missing'); }
+{
+  const objMap: {[string]: number} = {x: 10, y: 10};
+  const success: number|string = get(objMap, 'z', 'missing');
+}

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -334,10 +334,8 @@ stringToNumberOrString = Map({'a': 1}).merge({'a': 'b'})
 stringToNumber = Map({a: 1}).merge({'a': 'b'})
 // $ExpectError
 stringToNumber = Map({a: 1}).merge([[1, 'a']])
-
-// FIXME: Simple `stringToNumber = ...` assignment shows an error at the declaration of stringToNumber and numberToString
 // $ExpectError
-{ const stringToNumber: Map<string, number> = Map({a: 1}).merge(numberToString) }
+stringToNumber = Map({a: 1}).merge(numberToString)
 
 // Functional API
 stringToNumber = merge(Map({'a': 1}), Map({'a': 1}))
@@ -347,9 +345,8 @@ stringToNumberOrString = merge(Map({'a': 1}), {'a': 'b'})
 stringToNumber = merge(Map({a: 1}), {'a': 'b'})
 // $ExpectError
 stringToNumber = merge(Map({a: 1}), [[1, 'a']])
-// FIXME: Simple `stringToNumber = ...` assignment shows an error at the declaration of stringToNumber and numberToString
 // $ExpectError
-{ const stringToNumber: Map<string, number> = merge(Map({a: 1}), numberToString) }
+stringToNumber = merge(Map({a: 1}), numberToString)
 
 stringToNumber = Map({'a': 1}).mergeWith((previous, next, key) => 1, {'a': 2, 'b': 2})
 // $ExpectError - this is actually a Map<string, number|string>

--- a/type-definitions/ts-tests/functional.ts
+++ b/type-definitions/ts-tests/functional.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  get,
+  has,
+  set,
+  remove,
+  update,
+} from '../../';
+
+{ // get
+
+  // $ExpectType number | undefined
+  get([1, 2, 3], 0);
+
+  // $ExpectType number | "a"
+  get([1, 2, 3], 0, 'a');
+
+  // $ExpectType number | undefined
+  get({ x: 10, y: 20 }, 'x');
+
+  // $ExpectType number | "missing"
+  get({ x: 10, y: 20 }, 'z', 'missing');
+}
+
+{ // has
+
+  // $ExpectType boolean
+  has([1, 2, 3], 0);
+
+  // $ExpectType boolean
+  has({ x: 10, y: 20 }, 'x');
+}
+
+{ // set
+
+  // $ExpectType number[]
+  set([1, 2, 3], 0, 10);
+
+  // $ExpectError
+  set([1, 2, 3], 0, 'a');
+
+  // $ExpectError
+  set([1, 2, 3], 'a', 0);
+
+  // $ExpectType { x: number; y: number; }
+  set({ x: 10, y: 20 }, 'x', 100);
+
+  // $ExpectError
+  set({ x: 10, y: 20 }, 'x', 'a');
+}
+
+{ // remove
+
+  // $ExpectType number[]
+  remove([1, 2, 3], 0);
+
+  // $ExpectType { x: number; y: number; }
+  remove({ x: 10, y: 20 }, 'x');
+}
+
+{ // update
+
+  // $ExpectType number[]
+  update([1, 2, 3], 0, (v: number) => v + 1);
+
+  // $ExpectError
+  update([1, 2, 3], 0, 1);
+
+  // $ExpectError
+  update([1, 2, 3], 0, (v: string) => v + 'a');
+
+  // $ExpectError
+  update([1, 2, 3], 'a', (v: number) => v + 1);
+
+  // $ExpectType { x: number; y: number; }
+  update({ x: 10, y: 20 }, 'x', (v: number) => v + 1);
+
+  // $ExpectError
+  update({ x: 10, y: 20 }, 'x', (v: string) => v + 'a');
+}

--- a/type-definitions/ts-tests/list.ts
+++ b/type-definitions/ts-tests/list.ts
@@ -5,7 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { List } from '../../';
+import {
+  List,
+  get,
+  has,
+  set,
+  remove,
+  update,
+  setIn,
+  removeIn,
+  updateIn,
+  merge,
+} from '../../';
 
 { // #constructor
 
@@ -59,6 +70,12 @@ import { List } from '../../';
 
   // $ExpectError
   List<number>().get<number>(4, 'a');
+
+  // $ExpectType number | undefined
+  get(List<number>(), 4);
+
+  // $ExpectType number | "a"
+  get(List<number>(), 4, 'a');
 }
 
 { // #set
@@ -77,12 +94,24 @@ import { List } from '../../';
 
   // $ExpectType List<string | number>
   List<number | string>().set(0, 'a');
+
+  // $ExpectType List<number>
+  set(List<number>(), 0, 0);
+
+  // $ExpectError
+  set(List<number>(), 1, 'a');
+
+  // $ExpectError
+  set(List<number>(), 'a', 1);
 }
 
 { // #setIn
 
   // $ExpectType List<number>
   List<number>().setIn([], 0);
+
+  // $ExpectType List<number>
+  setIn(List<number>(), [], 0);
 }
 
 { // #insert
@@ -161,12 +190,18 @@ import { List } from '../../';
 
   // $ExpectError
   List().remove('a');
+
+  // $ExpectType List<number>
+  remove(List<number>(), 0);
 }
 
 { // #removeIn
 
   // $ExpectType List<number>
   List<number>().removeIn([]);
+
+  // $ExpectType List<number>
+  removeIn(List<number>(), []);
 }
 
 { // #clear
@@ -218,6 +253,12 @@ import { List } from '../../';
 
   // $ExpectError
   List<number>().update(1, 10, (v: number) => v + 'a');
+
+  // $ExpectType List<number>
+  update(List<number>(), 0, (v: number) => 0);
+
+  // $ExpectError
+  update(List<number>(), 1, 10, (v: number) => v + 'a');
 }
 
 { // #updateIn
@@ -227,6 +268,9 @@ import { List } from '../../';
 
   // $ExpectError
   List<number>().updateIn([], 10);
+
+  // $ExpectType List<number>
+  updateIn(List<number>(), [], v => v);
 }
 
 { // #map
@@ -299,6 +343,9 @@ import { List } from '../../';
 
   // $ExpectType List<string | number>
   List<number | string>().merge(List<number>());
+
+  // $ExpectType List<number>
+  merge(List<number>(), List<number>());
 }
 
 { // #mergeIn


### PR DESCRIPTION
**BREAKING**: This changes the behavior of a few common methods with respect to Arrays and plain Objects:

- `.merge()` - where previously plain object or array values were considered opaque and replaced completely, they are now merged with the incoming value.

- `.getIn()`/`.setIn()`/`.updateIn()` - where previously key paths that encounter plain object or array values would throw an error, replace a value, or return undefined, they now key into the plain object or array values.

- `.toJS()` - where previously plain object and array values were considered opaque and returned by reference, toJS() will now return copies of such values, and recurse into them converting nested immutable collections to plain JS values.

---

This adds a functional API for the core read/write methods (get, set, update, merge) (originally proposed in #39). I don't believe that simply providing a functional alternative is enough value to warrant the increase in API surface area, but what this functional API enables is to use the immutable read/write API on typical Array and Object values, allowing for a combination of nesting Immutable Collections and typical Arrays and Objects while preserving the ability to use `getIn` and `setIn`.

As an example:

```js
import { getIn, setIn } from 'immutable';
const data = { x: { y: 'z' } }
const z = getIn(data, ['x', 'y'])
const data2 = setIn(data, ['x', 'y'], 'abc') // { x: { y: 'abc' } }
// Original is unchanged
console.log(data); // { x: { y: 'z' } }
```

I think that providing this flexibility will allow for a more reasoned use of Immutable collections based on best fit, rather than the "all or nothing" approach often taken. Specifically, I'm interested in supporting typical Objects as a viable alternative to Record for those that want to use Immutable collections but prefer not to use the Record API.

This does add some byte-weight to the library, but only marginally due to replacing existing implementations. Adds +209 gz-bytes, or +1167 raw-bytes.

Remaining tasks:

* [x] Fix existing tests
* [x] Add new tests for new use cases 
* [x] Add flow types
* [x] Add flow type tests
* [x] Add typescript types
* [x] Add typescript type tests
* [x] Documentation

Closes #1268 
Closes #1363
