### PR TITLE
BREAKING: isImmutable returns true for all immutable collections, eve…

### DIFF
--- a/__tests__/Predicates.ts
+++ b/__tests__/Predicates.ts
@@ -18,7 +18,7 @@ describe('isImmutable', () => {
     expect(isImmutable(List())).toBe(true);
     expect(isImmutable(Set())).toBe(true);
     expect(isImmutable(Stack())).toBe(true);
-    expect(isImmutable(Map().asMutable())).toBe(false);
+    expect(isImmutable(Map().asMutable())).toBe(true);
   });
 
 });

--- a/src/Predicates.js
+++ b/src/Predicates.js
@@ -6,10 +6,7 @@
  */
 
 export function isImmutable(maybeImmutable) {
-  return (
-    (isCollection(maybeImmutable) || isRecord(maybeImmutable)) &&
-    !maybeImmutable.__ownerID
-  );
+  return isCollection(maybeImmutable) || isRecord(maybeImmutable);
 }
 
 export function isCollection(maybeCollection) {

--- a/src/Seq.js
+++ b/src/Seq.js
@@ -8,6 +8,7 @@
 import { wrapIndex } from './TrieUtils';
 import { Collection } from './Collection';
 import {
+  isImmutable,
   isCollection,
   isKeyed,
   isAssociative,
@@ -29,9 +30,7 @@ export class Seq extends Collection {
   constructor(value) {
     return value === null || value === undefined
       ? emptySequence()
-      : isCollection(value) || isRecord(value)
-        ? value.toSeq()
-        : seqFromValue(value);
+      : isImmutable(value) ? value.toSeq() : seqFromValue(value);
   }
 
   toSeq() {

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -230,6 +230,8 @@ declare module Immutable {
   /**
    * True if `maybeImmutable` is an Immutable Collection or Record.
    *
+   * Note: Still returns true even if the collections is within a `withMutations()`.
+   *
    * <!-- runkit:activate -->
    * ```js
    * const { isImmutable, Map, List, Stack } = require('immutable@4.0.0-rc.7');
@@ -238,7 +240,7 @@ declare module Immutable {
    * isImmutable(Map()); // true
    * isImmutable(List()); // true
    * isImmutable(Stack()); // true
-   * isImmutable(Map().asMutable()); // false
+   * isImmutable(Map().asMutable()); // true
    * ```
    */
   export function isImmutable(maybeImmutable: any): maybeImmutable is Collection<any, any>;


### PR DESCRIPTION
…n within withMutations().

This method has been slightly confusing due to the dual purpose and ambiguous nature of the term. This better represents the behavior most have expected.