### PR TITLE
Flow types for setIn(), removeIn(), updateIn()

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -662,8 +662,44 @@ declare class SetSeq<+T> extends Seq<T, T> mixins SetCollection<T> {
   flatten(shallow?: boolean): SetSeq<any>;
 }
 
+declare class UpdatableInCollection<K, +V> {
+  setIn<S>(keyPath: [], value: S): S;
+  setIn(keyPath: [K], value: V): this;
+  setIn<K2: $KeyOf<V>, S: $ValOf<V, K2>>(keyPath: [K, K2], value: S): this;
+  setIn<K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, S: $ValOf<$ValOf<V, K2>, K3>>(keyPath: [K, K2, K3], value: S): this;
+  setIn<K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, K4: $KeyOf<$ValOf<$ValOf<V, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>>(keyPath: [K, K2, K3, K4], value: S): this;
+  setIn<K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, K4: $KeyOf<$ValOf<$ValOf<V, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>, K5>>(keyPath: [K, K2, K3, K4, K5], value: S): this;
+
+  deleteIn(keyPath: []): void;
+  deleteIn(keyPath: [K]): this;
+  deleteIn<K2: $KeyOf<V>>(keyPath: [K, K2]): this;
+  deleteIn<K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>>(keyPath: [K, K2, K3]): this;
+  deleteIn<K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, K4: $KeyOf<$ValOf<$ValOf<V, K2>, K3>>>(keyPath: [K, K2, K3, K4]): this;
+  deleteIn<K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, K4: $KeyOf<$ValOf<$ValOf<V, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>>>(keyPath: [K, K2, K3, K4, K5]): this;
+
+  removeIn(keyPath: []): void;
+  removeIn(keyPath: [K]): this;
+  removeIn<K2: $KeyOf<V>>(keyPath: [K, K2]): this;
+  removeIn<K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>>(keyPath: [K, K2, K3]): this;
+  removeIn<K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, K4: $KeyOf<$ValOf<$ValOf<V, K2>, K3>>>(keyPath: [K, K2, K3, K4]): this;
+  removeIn<K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, K4: $KeyOf<$ValOf<$ValOf<V, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>>>(keyPath: [K, K2, K3, K4, K5]): this;
+
+  updateIn<U>(keyPath: [], notSetValue: mixed, updater: (value: this) => U): U;
+  updateIn<U>(keyPath: [], updater: (value: this) => U): U;
+  updateIn<NSV>(keyPath: [K], notSetValue: NSV, updater: (value: V) => V): this;
+  updateIn(keyPath: [K], updater: (value: V) => V): this;
+  updateIn<NSV, K2: $KeyOf<V>, S: $ValOf<V, K2>>(keyPath: [K, K2], notSetValue: NSV, updater: (value: $ValOf<V, K2> | NSV) => S): this;
+  updateIn<K2: $KeyOf<V>, S: $ValOf<V, K2>>(keyPath: [K, K2], updater: (value: $ValOf<V, K2>) => S): this;
+  updateIn<NSV, K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, S: $ValOf<$ValOf<V, K2>, K3>>(keyPath: [K, K2, K3], notSetValue: NSV, updater: (value: $ValOf<$ValOf<V, K2>, K3> | NSV) => S): this;
+  updateIn<K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, S: $ValOf<$ValOf<V, K2>, K3>>(keyPath: [K, K2, K3], updater: (value: $ValOf<$ValOf<V, K2>, K3>) => S): this;
+  updateIn<NSV, K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, K4: $KeyOf<$ValOf<$ValOf<V, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>>(keyPath: [K, K2, K3, K4], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<V, K2>, K3>, K4> | NSV) => S): this;
+  updateIn<K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, K4: $KeyOf<$ValOf<$ValOf<V, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>>(keyPath: [K, K2, K3, K4], updater: (value: $ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>) => S): this;
+  updateIn<NSV, K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, K4: $KeyOf<$ValOf<$ValOf<V, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>, K5>>(keyPath: [K, K2, K3, K4, K5], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>, K5> | NSV) => S): this;
+  updateIn<K2: $KeyOf<V>, K3: $KeyOf<$ValOf<V, K2>>, K4: $KeyOf<$ValOf<$ValOf<V, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>, K5>>(keyPath: [K, K2, K3, K4, K5], updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<V, K2>, K3>, K4>, K5>) => S): this;
+}
+
 declare function isList(maybeList: mixed): boolean %checks(maybeList instanceof List);
-declare class List<+T> extends IndexedCollection<T> {
+declare class List<+T> extends IndexedCollection<T> mixins UpdatableInCollection<number, T> {
   static (collection?: Iterable<T>): List<T>;
 
   static of<T>(...values: T[]): List<T>;
@@ -689,19 +725,6 @@ declare class List<+T> extends IndexedCollection<T> {
   merge<U>(...collections: Iterable<U>[]): List<T | U>;
 
   setSize(size: number): this;
-  setIn(keyPath: Iterable<mixed>, value: mixed): this;
-  deleteIn(keyPath: Iterable<mixed>, value: mixed): this;
-  removeIn(keyPath: Iterable<mixed>, value: mixed): this;
-
-  updateIn(
-    keyPath: Iterable<mixed>,
-    notSetValue: mixed,
-    updater: (value: any) => mixed
-  ): this;
-  updateIn(
-    keyPath: Iterable<mixed>,
-    updater: (value: any) => mixed
-  ): this;
 
   mergeIn(keyPath: Iterable<mixed>, ...collections: Iterable<mixed>[]): this;
   mergeDeepIn(keyPath: Iterable<mixed>, ...collections: Iterable<mixed>[]): this;
@@ -834,7 +857,7 @@ declare class List<+T> extends IndexedCollection<T> {
 }
 
 declare function isMap(maybeMap: mixed): boolean %checks(maybeMap instanceof Map);
-declare class Map<K, +V> extends KeyedCollection<K, V> {
+declare class Map<K, +V> extends KeyedCollection<K, V> mixins UpdatableInCollection<K, V> {
   static <K, V>(collection: Iterable<[K, V]>): Map<K, V>;
   static <K, V>(obj?: PlainObjInput<K, V>): Map<K, V>;
 
@@ -874,20 +897,6 @@ declare class Map<K, +V> extends KeyedCollection<K, V> {
     merger: (oldVal: V, newVal: W, key: K) => X,
     ...collections: (Iterable<[K_, W]> | PlainObjInput<K_, W>)[]
   ): Map<K | K_, V | W | X>;
-
-  setIn(keyPath: Iterable<mixed>, value: mixed): this;
-  deleteIn(keyPath: Iterable<mixed>, value: mixed): this;
-  removeIn(keyPath: Iterable<mixed>, value: mixed): this;
-
-  updateIn(
-    keyPath: Iterable<mixed>,
-    notSetValue: mixed,
-    updater: (value: any) => mixed
-  ): this;
-  updateIn(
-    keyPath: Iterable<mixed>,
-    updater: (value: any) => mixed
-  ): this;
 
   mergeIn(
     keyPath: Iterable<mixed>,
@@ -938,7 +947,7 @@ declare class Map<K, +V> extends KeyedCollection<K, V> {
 }
 
 declare function isOrderedMap(maybeOrderedMap: mixed): boolean %checks(maybeOrderedMap instanceof OrderedMap);
-declare class OrderedMap<K, +V> extends Map<K, V> {
+declare class OrderedMap<K, +V> extends Map<K, V> mixins UpdatableInCollection<K, V> {
   static <K, V>(collection: Iterable<[K, V]>): OrderedMap<K, V>;
   static <K, V>(obj?: PlainObjInput<K, V>): OrderedMap<K, V>;
 
@@ -975,20 +984,6 @@ declare class OrderedMap<K, +V> extends Map<K, V> {
     merger: (oldVal: V, newVal: W, key: K) => X,
     ...collections: (Iterable<[K_, W]> | PlainObjInput<K_, W>)[]
   ): OrderedMap<K | K_, V | W | X>;
-
-  setIn(keyPath: Iterable<mixed>, value: mixed): this;
-  deleteIn(keyPath: Iterable<mixed>, value: mixed): this;
-  removeIn(keyPath: Iterable<mixed>, value: mixed): this;
-
-  updateIn(
-    keyPath: Iterable<mixed>,
-    notSetValue: mixed,
-    updater: (value: any) => mixed
-  ): this;
-  updateIn(
-    keyPath: Iterable<mixed>,
-    updater: (value: any) => mixed
-  ): this;
 
   mergeIn(
     keyPath: Iterable<mixed>,
@@ -1435,12 +1430,42 @@ declare class RecordInstance<T: Object> {
   remove<K: $Keys<T>>(key: K): this & T;
   clear(): this & T;
 
-  setIn(keyPath: Iterable<mixed>, value: any): this & T;
-  updateIn(keyPath: Iterable<mixed>, updater: (value: any) => any): this & T;
+  setIn<S>(keyPath: [], value: S): S;
+  setIn<K: $Keys<T>, S: $ElementType<T, K>>(keyPath: [K], value: S): this & T;
+  setIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, S: $ValOf<$ElementType<T, K>, K2>>(keyPath: [K, K2], value: S): this & T;
+  setIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, S: $ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>(keyPath: [K, K2, K3], value: S): this & T;
+  setIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>(keyPath: [K, K2, K3, K4], value: S): this & T;
+  setIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>, K5>>(keyPath: [K, K2, K3, K4, K5], value: S): this & T;
+
+  deleteIn(keyPath: []): void;
+  deleteIn<K: $Keys<T>>(keyPath: [K]): this & T;
+  deleteIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>>(keyPath: [K, K2]): this & T;
+  deleteIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>>(keyPath: [K, K2, K3]): this & T;
+  deleteIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>>(keyPath: [K, K2, K3, K4]): this & T;
+  deleteIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>>(keyPath: [K, K2, K3, K4, K5]): this & T;
+
+  removeIn(keyPath: []): void;
+  removeIn<K: $Keys<T>>(keyPath: [K]): this & T;
+  removeIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>>(keyPath: [K, K2]): this & T;
+  removeIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>>(keyPath: [K, K2, K3]): this & T;
+  removeIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>>(keyPath: [K, K2, K3, K4]): this & T;
+  removeIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>>(keyPath: [K, K2, K3, K4, K5]): this & T;
+
+  updateIn<U>(keyPath: [], notSetValue: mixed, updater: (value: this) => U): U;
+  updateIn<U>(keyPath: [], updater: (value: this) => U): U;
+  updateIn<NSV, K: $Keys<T>, S: $ElementType<T, K>>(keyPath: [K], notSetValue: NSV, updater: (value: $ElementType<T, K>) => S): this & T;
+  updateIn<K: $Keys<T>, S: $ElementType<T, K>>(keyPath: [K], updater: (value: $ElementType<T, K>) => S): this & T;
+  updateIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, S: $ValOf<$ElementType<T, K>, K2>>(keyPath: [K, K2], notSetValue: NSV, updater: (value: $ValOf<$ElementType<T, K>, K2> | NSV) => S): this & T;
+  updateIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, S: $ValOf<$ElementType<T, K>, K2>>(keyPath: [K, K2], updater: (value: $ValOf<$ElementType<T, K>, K2>) => S): this & T;
+  updateIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, S: $ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>(keyPath: [K, K2, K3], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ElementType<T, K>, K2>, K3> | NSV) => S): this & T;
+  updateIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, S: $ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>(keyPath: [K, K2, K3], updater: (value: $ValOf<$ValOf<$ElementType<T, K>, K2>, K3>) => S): this & T;
+  updateIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>(keyPath: [K, K2, K3, K4], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4> | NSV) => S): this & T;
+  updateIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>(keyPath: [K, K2, K3, K4], updater: (value: $ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>) => S): this & T;
+  updateIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>, K5>>(keyPath: [K, K2, K3, K4, K5], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>, K5> | NSV) => S): this & T;
+  updateIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>, K5>>(keyPath: [K, K2, K3, K4, K5], updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>, K5>) => S): this & T;
+
   mergeIn(keyPath: Iterable<mixed>, ...collections: Array<any>): this & T;
   mergeDeepIn(keyPath: Iterable<mixed>, ...collections: Array<any>): this & T;
-  deleteIn(keyPath: Iterable<mixed>): this & T;
-  removeIn(keyPath: Iterable<mixed>): this & T;
 
   toSeq(): KeyedSeq<$Keys<T>, any>;
 

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -165,18 +165,46 @@ numberList = List.of('a').merge(List.of(1))
 
 nullableNumberList = List.of(1).setSize(2)
 
-numberList = List.of(1).setIn([], 0)
+// $ExpectError setIn [] replaces the top-most value. number ~> List<number>
+numberList = List([1]).setIn([], 0)
+{ const x: number = List([1]).setIn([], 0) }
+// $ExpectError "a" is not a valid key for List.
+numberList = List([1]).setIn(['a'], 0)
+// $ExpectError "a" is not a valid value for List of number.
+numberList = List([1]).setIn([0], 'a')
+numberList = List([1]).setIn([0], 0)
 
-numberList = List.of(1).deleteIn([], 0)
-numberList = List.of(1).removeIn([], 0)
+// $ExpectError "a" is not a valid key for List.
+List([List([List([1])])]).setIn([0,0,'a'], 'a');
+// $ExpectError "a" is not a valid value for List of number.
+List([List([List([1])])]).setIn([0,0,0], 'a');
+List([List([List([1])])]).setIn([0,0,0], 123);
 
-numberList = List([1]).updateIn([0], val => val + 1)
+// $ExpectError deleteIn [] replaces the top-most value. void ~> List<number>
+numberList = List([1]).deleteIn([])
+{ const x: void = List([1]).deleteIn([]) }
+// $ExpectError
+numberList = List([1]).removeIn([])
+// $ExpectError "a" is not a valid key for List.
+numberList = List([1]).deleteIn(['a'])
+// $ExpectError
+numberList = List([1]).removeIn(['a'])
+numberList = List([1]).deleteIn([0])
+numberList = List([1]).removeIn([0])
+
+// $ExpectError updateIn [] replaces the top-most value. number ~> List<number>
+numberList = List([1]).updateIn([], () => 123)
+{ const x: number = List([1]).updateIn([], () => 123) }
+// $ExpectError - 'a' is not a number
+numberList = List([1]).updateIn([0], val => 'a')
+// $ExpectError
+numberList = List([1]).updateIn([0], 0, val => 'a')
 // $ExpectError - 'a' in an invalid argument
 numberList = List([1]).updateIn([0], 'a')
-
-numberList = List([1]).updateIn([0], 0, val => val + 1)
-// $ExpectError - 'a' is an invalid argument
+// $ExpectError
 numberList = List([1]).updateIn([0], 0, 'a')
+numberList = List([1]).updateIn([0], val => val + 1)
+numberList = List([1]).updateIn([0], 0, val => val + 1)
 
 numberList = List.of(1).mergeIn([], [])
 numberList = List.of(1).mergeDeepIn([], [])
@@ -288,10 +316,32 @@ stringToNumberOrString = Map({'a': 1}).mergeDeepWith((previous, next, key) => 1,
 // $ExpectError - the array [1] is not a valid argument
 stringToNumber = Map({'a': 1}).mergeDeepWith((previous, next, key) => 1, [1])
 
+// $ExpectError
 stringToNumber = Map({'a': 1}).setIn([], 0)
+// $ExpectError
+stringToNumber = Map({'a': 1}).setIn(['a'], 'a')
+stringToNumber = Map({'a': 1}).setIn(['a'], 0)
 
-stringToNumber = Map({'a': 1}).deleteIn([], 0)
-stringToNumber = Map({'a': 1}).removeIn([], 0)
+// $ExpectError
+stringToNumber = Map({'a': 1}).deleteIn([])
+// $ExpectError
+stringToNumber = Map({'a': 1}).removeIn([])
+stringToNumber = Map({'a': 1}).deleteIn(['a'])
+stringToNumber = Map({'a': 1}).removeIn(['a'])
+
+// $ExpectError
+stringToNumber = Map({'a': 1}).updateIn([], v => v + 1)
+// $ExpectError
+stringToNumber = Map({'a': 1}).updateIn(['a'], v => 'a')
+stringToNumber = Map({'a': 1}).updateIn(['a'], v => v + 1)
+stringToNumber = Map({'a': 1}).updateIn(['a'], 0, v => v + 1)
+
+// $ExpectError
+Map({x: Map({y: Map({z: 1})})}).updateIn(['x', 'y', 1], v => v + 1)
+// $ExpectError
+Map({x: Map({y: Map({z: 1})})}).updateIn(['x', 'y', 'z'], v => 'a')
+Map({x: Map({y: Map({z: 1})})}).updateIn(['x', 'y', 'z'], v => v + 1)
+Map({x: Map({y: Map({z: 1})})}).updateIn(['x', 'y', 'z'], 0, v => v + 1)
 
 stringToNumber = Map({'a': 1}).mergeIn([], [])
 stringToNumber = Map({'a': 1}).mergeDeepIn([], [])
@@ -433,17 +483,37 @@ orderedStringToNumberOrString = OrderedMap({'a': 1}).mergeDeepWith((prev, next) 
 // $ExpectError - the array [1] is an invalid argument
 orderedStringToNumber = OrderedMap({'a': 1}).mergeDeepWith((prev, next) => next, [1])
 
+// $ExpectError
 orderedStringToNumber = OrderedMap({'a': 1}).setIn([], 3)
+// $ExpectError
+orderedStringToNumber = OrderedMap({'a': 1}).setIn([1], 3)
+orderedStringToNumber = OrderedMap({'a': 1}).setIn(['a'], 3)
+// $ExpectError
 orderedStringToNumber = OrderedMap({'a': 1}).deleteIn([])
+// $ExpectError
 orderedStringToNumber = OrderedMap({'a': 1}).removeIn([])
+// $ExpectError
+orderedStringToNumber = OrderedMap({'a': 1}).deleteIn([1])
+// $ExpectError
+orderedStringToNumber = OrderedMap({'a': 1}).removeIn([1])
+orderedStringToNumber = OrderedMap({'a': 1}).deleteIn(['b'])
+orderedStringToNumber = OrderedMap({'a': 1}).removeIn(['b'])
 
-orderedStringToNumber = OrderedMap({'a': 1}).updateIn([], val => val + 1)
-// $ExpectError - 'a' in an invalid argument
-orderedStringToNumber = OrderedMap({'a': 1}).updateIn([], 'a')
+// $ExpectError
+orderedStringToNumber = OrderedMap({'a': 1}).updateIn([], v => v + 1)
+// $ExpectError
+orderedStringToNumber = OrderedMap({'a': 1}).updateIn([1], v => v + 1)
+// $ExpectError
+orderedStringToNumber = OrderedMap({'a': 1}).updateIn(['a'], v => 'a')
+orderedStringToNumber = OrderedMap({'a': 1}).updateIn(['a'], v => v + 1)
+orderedStringToNumber = OrderedMap({'a': 1}).updateIn(['a'], 0, v => v + 1)
 
-orderedStringToNumber = OrderedMap({'a': 1}).updateIn([], 0, val => val + 1)
-// $ExpectError - 'a' is an invalid argument
-orderedStringToNumber = OrderedMap({'a': 1}).updateIn([], 0, 'a')
+// $ExpectError
+OrderedMap({x: OrderedMap({y: 1})}).updateIn(['x', 1], v => v + 1)
+// $ExpectError
+OrderedMap({x: OrderedMap({y: 1})}).updateIn(['x', 'y'], v => 'a')
+OrderedMap({x: OrderedMap({y: 1})}).updateIn(['x', 'y'], v => v + 1)
+OrderedMap({x: OrderedMap({y: 1})}).updateIn(['x', 'y'], 0, v => v + 1)
 
 orderedStringToNumber = OrderedMap({'a': 1}).mergeIn([], {'b': 2})
 orderedStringToNumber = OrderedMap({'a': 1}).mergeDeepIn([], {'b': 2})
@@ -866,6 +936,13 @@ listOfPersonRecord.getIn(['wrong', 'age']);
 listOfPersonRecord.getIn([0, 'mispeld']);
 // $ExpectError - the second key is not an record key
 listOfPersonRecord.getIn([0, 0]);
+// $ExpectError
+listOfPersonRecord.setIn([0, 'age'], 'Thirteen');
+listOfPersonRecord.setIn([0, 'age'], 13);
+// $ExpectError
+listOfPersonRecord.updateIn([0, 'age'], value => value.unknownFunction());
+listOfPersonRecord.updateIn([0, 'age'], value => value + 1);
+listOfPersonRecord.updateIn([0, 'age'], 0, value => value + 1);
 
 // Recursive Records
 type PersonRecord2Fields = { name: string, friends: List<PersonRecord2> };
@@ -888,3 +965,10 @@ const friendlies: List<PersonRecord2> = List([makePersonRecord2()]);
 // notSetValue provided
 { const success: string = friendlies.getIn([0, 'friends', 0, 'name'], 'Abbie'); }
 { const success: ?string = friendlies.getIn([0, 'friends', 0, 'name']); }
+// $ExpectError
+friendlies.setIn([0, 'friends', 0, 'name'], 123);
+friendlies.setIn([0, 'friends', 0, 'name'], 'Sally');
+// $ExpectError
+friendlies.updateIn([0, 'friends', 0, 'name'], value => value.unknownFunction());
+friendlies.updateIn([0, 'friends', 0, 'name'], value => value.toUpperCase());
+friendlies.updateIn([0, 'friends', 0, 'name'], 'Unknown Name', value => value.toUpperCase());


### PR DESCRIPTION
Following up #1366, adds flow types aware of keypath for these three methods for List, Map, and Record