### PR TITLE
Add Record.get(v, notSetValue) to type defs

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2552,7 +2552,16 @@ declare module Immutable {
     // Reading values
 
     has(key: string): key is keyof TProps;
-    get<K extends keyof TProps>(key: K): TProps[K];
+
+    /**
+     * Returns the value associated with the provided key, which may be the
+     * default value defined when creating the Record factory function.
+     *
+     * If the requested key is not defined by this Record type, then
+     * notSetValue will be returned if provided. Note that this scenario would
+     * produce an error when using Flow or TypeScript.
+     */
+    get<K extends keyof TProps>(key: K, notSetValue: any): TProps[K];
 
     // Reading deep values
 

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1403,7 +1403,7 @@ declare class RecordInstance<T: Object> {
   size: number;
 
   has(key: string): boolean;
-  get<K: $Keys<T>>(key: K): $ElementType<T, K>;
+  get<K: $Keys<T>>(key: K, notSetValue: mixed): $ElementType<T, K>;
 
   hasIn(keyPath: Iterable<mixed>): boolean;
 


### PR DESCRIPTION
notSetValue was accidentally missing from type definition for Record. Also include some documentation explaining when this value is used.

Fixes #1359 