### PR TITLE
Simplify toJS()

### DIFF
--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -48,6 +48,7 @@ import deepEqual from './utils/deepEqual';
 import mixin from './utils/mixin';
 import quoteString from './utils/quoteString';
 
+import { toJS } from './toJS';
 import { Map } from './Map';
 import { OrderedMap } from './OrderedMap';
 import { List } from './List';
@@ -118,9 +119,7 @@ mixin(Collection, {
   },
 
   toJS() {
-    return this.toSeq()
-      .map(toJS)
-      .toJSON();
+    return toJS(this);
   },
 
   toKeyedSeq() {
@@ -766,10 +765,6 @@ function keyMapper(v, k) {
 
 function entryMapper(v, k) {
   return [k, v];
-}
-
-function toJS(value) {
-  return value && typeof value.toJS === 'function' ? value.toJS() : value;
 }
 
 function not(predicate) {

--- a/src/Record.js
+++ b/src/Record.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { toJS } from './toJS';
 import { KeyedCollection } from './Collection';
 import { keyedSeqFromValue } from './Seq';
 import { MapPrototype } from './Map';
@@ -144,7 +145,7 @@ export class Record {
   }
 
   toJS() {
-    return recordSeq(this).toJS();
+    return toJS(this);
   }
 
   __iterator(type, reverse) {

--- a/src/toJS.js
+++ b/src/toJS.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Collection } from './Collection';
+import { isImmutable } from './Predicates';
+
+export function toJS(value) {
+  return isImmutable(value)
+    ? Collection(value)
+        .map(toJS)
+        .toJSON()
+    : value;
+}


### PR DESCRIPTION
This factors toJS() into its own function and simplifies the implementation to recurse within only toJS() instead of between toJS() and value.toJS(). Also, instead of sniffing for a .toJS function existing on the value, uses isImmutable() which consolidates this logic and makes it more predictable.