### PR TITLE
Factor out common methods to avoid prototype sharing.

### DIFF
--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -24,9 +24,6 @@ import {
 } from './Predicates';
 
 import { is } from './is';
-import { getIn } from './functional/getIn';
-import { hasIn } from './functional/hasIn';
-
 import {
   NOT_SET,
   ensureSize,
@@ -82,6 +79,9 @@ import {
   maxFactory,
   zipWithFactory
 } from './Operations';
+import { getIn } from './methods/getIn';
+import { hasIn } from './methods/hasIn';
+import { toObject } from './methods/toObject';
 
 export {
   Collection,
@@ -133,14 +133,7 @@ mixin(Collection, {
     return Map(this.toKeyedSeq());
   },
 
-  toObject() {
-    assertNotInfinite(this.size);
-    const object = {};
-    this.__iterate((v, k) => {
-      object[k] = v;
-    });
-    return object;
-  },
+  toObject: toObject,
 
   toOrderedMap() {
     // Use Late Binding here to solve the circular dependency.
@@ -396,9 +389,7 @@ mixin(Collection, {
     return this.find((_, key) => is(key, searchKey), undefined, notSetValue);
   },
 
-  getIn(searchKeyPath, notSetValue) {
-    return getIn(this, searchKeyPath, notSetValue);
-  },
+  getIn: getIn,
 
   groupBy(grouper, context) {
     return groupByFactory(this, grouper, context);
@@ -408,9 +399,7 @@ mixin(Collection, {
     return this.get(searchKey, NOT_SET) !== NOT_SET;
   },
 
-  hasIn(searchKeyPath) {
-    return hasIn(this, searchKeyPath);
-  },
+  hasIn: hasIn,
 
   isSubset(iter) {
     iter = typeof iter.includes === 'function' ? iter : Collection(iter);
@@ -570,7 +559,7 @@ mixin(KeyedCollection, {
 const KeyedCollectionPrototype = KeyedCollection.prototype;
 KeyedCollectionPrototype[IS_KEYED_SENTINEL] = true;
 KeyedCollectionPrototype[ITERATOR_SYMBOL] = CollectionPrototype.entries;
-KeyedCollectionPrototype.toJSON = CollectionPrototype.toObject;
+KeyedCollectionPrototype.toJSON = toObject;
 KeyedCollectionPrototype.__toStringMapper = (v, k) =>
   quoteString(k) + ': ' + quoteString(v);
 

--- a/src/List.js
+++ b/src/List.js
@@ -20,9 +20,17 @@ import {
   resolveEnd
 } from './TrieUtils';
 import { IndexedCollection } from './Collection';
-import { MapPrototype } from './Map';
 import { hasIterator, Iterator, iteratorValue, iteratorDone } from './Iterator';
-
+import { setIn } from './methods/setIn';
+import { deleteIn } from './methods/deleteIn';
+import { update } from './methods/update';
+import { updateIn } from './methods/updateIn';
+import { mergeIn } from './methods/mergeIn';
+import { mergeDeepIn } from './methods/mergeDeepIn';
+import { withMutations } from './methods/withMutations';
+import { asMutable } from './methods/asMutable';
+import { asImmutable } from './methods/asImmutable';
+import { wasAltered } from './methods/wasAltered';
 import assertNotInfinite from './utils/assertNotInfinite';
 
 export class List extends IndexedCollection {
@@ -236,21 +244,22 @@ export const ListPrototype = List.prototype;
 ListPrototype[IS_LIST_SENTINEL] = true;
 ListPrototype[DELETE] = ListPrototype.remove;
 ListPrototype.merge = ListPrototype.concat;
-ListPrototype.setIn = MapPrototype.setIn;
-ListPrototype.deleteIn = ListPrototype.removeIn = MapPrototype.removeIn;
-ListPrototype.update = MapPrototype.update;
-ListPrototype.updateIn = MapPrototype.updateIn;
-ListPrototype.mergeIn = MapPrototype.mergeIn;
-ListPrototype.mergeDeepIn = MapPrototype.mergeDeepIn;
-ListPrototype.withMutations = MapPrototype.withMutations;
-ListPrototype.asMutable = MapPrototype.asMutable;
-ListPrototype.asImmutable = MapPrototype.asImmutable;
-ListPrototype.wasAltered = MapPrototype.wasAltered;
-ListPrototype['@@transducer/init'] = ListPrototype.asMutable;
+ListPrototype.setIn = setIn;
+ListPrototype.deleteIn = ListPrototype.removeIn = deleteIn;
+ListPrototype.update = update;
+ListPrototype.updateIn = updateIn;
+ListPrototype.mergeIn = mergeIn;
+ListPrototype.mergeDeepIn = mergeDeepIn;
+ListPrototype.withMutations = withMutations;
+ListPrototype.wasAltered = wasAltered;
+ListPrototype.asImmutable = asImmutable;
+ListPrototype['@@transducer/init'] = ListPrototype.asMutable = asMutable;
 ListPrototype['@@transducer/step'] = function(result, arr) {
   return result.push(arr);
 };
-ListPrototype['@@transducer/result'] = MapPrototype['@@transducer/result'];
+ListPrototype['@@transducer/result'] = function(obj) {
+  return obj.asImmutable();
+};
 
 class VNode {
   constructor(array, ownerID) {

--- a/src/Record.js
+++ b/src/Record.js
@@ -8,12 +8,23 @@
 import { toJS } from './toJS';
 import { KeyedCollection } from './Collection';
 import { keyedSeqFromValue } from './Seq';
-import { MapPrototype } from './Map';
 import { List } from './List';
-import { ITERATOR_SYMBOL } from './Iterator';
+import { ITERATE_ENTRIES, ITERATOR_SYMBOL } from './Iterator';
 import { isRecord, IS_RECORD_SENTINEL } from './Predicates';
 import { CollectionPrototype } from './CollectionImpl';
 import { DELETE } from './TrieUtils';
+import { getIn } from './methods/getIn';
+import { setIn } from './methods/setIn';
+import { deleteIn } from './methods/deleteIn';
+import { update } from './methods/update';
+import { updateIn } from './methods/updateIn';
+import { merge, mergeWith } from './methods/merge';
+import { mergeDeep, mergeDeepWith } from './methods/mergeDeep';
+import { mergeIn } from './methods/mergeIn';
+import { mergeDeepIn } from './methods/mergeDeepIn';
+import { withMutations } from './methods/withMutations';
+import { asMutable } from './methods/asMutable';
+import { asImmutable } from './methods/asImmutable';
 
 import invariant from './utils/invariant';
 import quoteString from './utils/quoteString';
@@ -148,6 +159,10 @@ export class Record {
     return toJS(this);
   }
 
+  entries() {
+    return this.__iterator(ITERATE_ENTRIES);
+  }
+
   __iterator(type, reverse) {
     return recordSeq(this).__iterator(type, reverse);
   }
@@ -175,26 +190,27 @@ Record.getDescriptiveName = recordName;
 const RecordPrototype = Record.prototype;
 RecordPrototype[IS_RECORD_SENTINEL] = true;
 RecordPrototype[DELETE] = RecordPrototype.remove;
-RecordPrototype.deleteIn = RecordPrototype.removeIn = MapPrototype.removeIn;
-RecordPrototype.getIn = CollectionPrototype.getIn;
+RecordPrototype.deleteIn = RecordPrototype.removeIn = deleteIn;
+RecordPrototype.getIn = getIn;
 RecordPrototype.hasIn = CollectionPrototype.hasIn;
-RecordPrototype.merge = MapPrototype.merge;
-RecordPrototype.mergeWith = MapPrototype.mergeWith;
-RecordPrototype.mergeIn = MapPrototype.mergeIn;
-RecordPrototype.mergeDeep = MapPrototype.mergeDeep;
-RecordPrototype.mergeDeepWith = MapPrototype.mergeDeepWith;
-RecordPrototype.mergeDeepIn = MapPrototype.mergeDeepIn;
-RecordPrototype.setIn = MapPrototype.setIn;
-RecordPrototype.update = MapPrototype.update;
-RecordPrototype.updateIn = MapPrototype.updateIn;
-RecordPrototype.withMutations = MapPrototype.withMutations;
-RecordPrototype.asMutable = MapPrototype.asMutable;
-RecordPrototype.asImmutable = MapPrototype.asImmutable;
-RecordPrototype[ITERATOR_SYMBOL] = CollectionPrototype.entries;
+RecordPrototype.merge = merge;
+RecordPrototype.mergeWith = mergeWith;
+RecordPrototype.mergeIn = mergeIn;
+RecordPrototype.mergeDeep = mergeDeep;
+RecordPrototype.mergeDeepWith = mergeDeepWith;
+RecordPrototype.mergeDeepIn = mergeDeepIn;
+RecordPrototype.setIn = setIn;
+RecordPrototype.update = update;
+RecordPrototype.updateIn = updateIn;
+RecordPrototype.withMutations = withMutations;
+RecordPrototype.asMutable = asMutable;
+RecordPrototype.asImmutable = asImmutable;
+RecordPrototype[ITERATOR_SYMBOL] = RecordPrototype.entries;
 RecordPrototype.toJSON = RecordPrototype.toObject =
   CollectionPrototype.toObject;
-RecordPrototype.inspect = RecordPrototype.toSource =
-  CollectionPrototype.toSource;
+RecordPrototype.inspect = RecordPrototype.toSource = function() {
+  return this.toString();
+};
 
 function makeRecord(likeRecord, values, ownerID) {
   const record = Object.create(Object.getPrototypeOf(likeRecord));

--- a/src/Set.js
+++ b/src/Set.js
@@ -7,10 +7,13 @@
 
 import { Collection, SetCollection, KeyedCollection } from './Collection';
 import { isOrdered } from './Predicates';
-import { emptyMap, MapPrototype } from './Map';
+import { emptyMap } from './Map';
 import { DELETE } from './TrieUtils';
 import { sortFactory } from './Operations';
 import assertNotInfinite from './utils/assertNotInfinite';
+import { asImmutable } from './methods/asImmutable';
+import { asMutable } from './methods/asMutable';
+import { withMutations } from './methods/withMutations';
 
 import { OrderedSet } from './OrderedSet';
 
@@ -179,14 +182,15 @@ const SetPrototype = Set.prototype;
 SetPrototype[IS_SET_SENTINEL] = true;
 SetPrototype[DELETE] = SetPrototype.remove;
 SetPrototype.merge = SetPrototype.concat = SetPrototype.union;
-SetPrototype.withMutations = MapPrototype.withMutations;
-SetPrototype.asMutable = MapPrototype.asMutable;
-SetPrototype.asImmutable = MapPrototype.asImmutable;
-SetPrototype['@@transducer/init'] = SetPrototype.asMutable;
+SetPrototype.withMutations = withMutations;
+SetPrototype.asImmutable = asImmutable;
+SetPrototype['@@transducer/init'] = SetPrototype.asMutable = asMutable;
 SetPrototype['@@transducer/step'] = function(result, arr) {
   return result.add(arr);
 };
-SetPrototype['@@transducer/result'] = MapPrototype['@@transducer/result'];
+SetPrototype['@@transducer/result'] = function(obj) {
+  return obj.asImmutable();
+};
 
 SetPrototype.__empty = emptySet;
 SetPrototype.__make = makeSet;

--- a/src/Stack.js
+++ b/src/Stack.js
@@ -7,10 +7,13 @@
 
 import { wholeSlice, resolveBegin, resolveEnd, wrapIndex } from './TrieUtils';
 import { IndexedCollection } from './Collection';
-import { MapPrototype } from './Map';
 import { ArraySeq } from './Seq';
 import { Iterator, iteratorValue, iteratorDone } from './Iterator';
 import assertNotInfinite from './utils/assertNotInfinite';
+import { asImmutable } from './methods/asImmutable';
+import { asMutable } from './methods/asMutable';
+import { wasAltered } from './methods/wasAltered';
+import { withMutations } from './methods/withMutations';
 
 export class Stack extends IndexedCollection {
   // @pragma Construction
@@ -203,18 +206,19 @@ const IS_STACK_SENTINEL = '@@__IMMUTABLE_STACK__@@';
 
 const StackPrototype = Stack.prototype;
 StackPrototype[IS_STACK_SENTINEL] = true;
-StackPrototype.withMutations = MapPrototype.withMutations;
-StackPrototype.asMutable = MapPrototype.asMutable;
-StackPrototype.asImmutable = MapPrototype.asImmutable;
-StackPrototype.wasAltered = MapPrototype.wasAltered;
 StackPrototype.shift = StackPrototype.pop;
 StackPrototype.unshift = StackPrototype.push;
 StackPrototype.unshiftAll = StackPrototype.pushAll;
-StackPrototype['@@transducer/init'] = StackPrototype.asMutable;
+StackPrototype.withMutations = withMutations;
+StackPrototype.wasAltered = wasAltered;
+StackPrototype.asImmutable = asImmutable;
+StackPrototype['@@transducer/init'] = StackPrototype.asMutable = asMutable;
 StackPrototype['@@transducer/step'] = function(result, arr) {
   return result.unshift(arr);
 };
-StackPrototype['@@transducer/result'] = MapPrototype['@@transducer/result'];
+StackPrototype['@@transducer/result'] = function(obj) {
+  return obj.asImmutable();
+};
 
 function makeStack(size, head, ownerID, hash) {
   const map = Object.create(StackPrototype);

--- a/src/methods/README.md
+++ b/src/methods/README.md
@@ -1,0 +1,5 @@
+These files represent common methods on Collection types, each will contain
+references to "this" - expecting to be called as a prototypal method.
+
+They are separated into individual files to avoid circular dependencies when
+possible, and to allow their use in multiple different Collections.

--- a/src/methods/asImmutable.js
+++ b/src/methods/asImmutable.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export function asImmutable() {
+  return this.__ensureOwner();
+}

--- a/src/methods/asMutable.js
+++ b/src/methods/asMutable.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { OwnerID } from '../TrieUtils';
+
+export function asMutable() {
+  return this.__ownerID ? this : this.__ensureOwner(new OwnerID());
+}

--- a/src/methods/deleteIn.js
+++ b/src/methods/deleteIn.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { removeIn } from '../functional/removeIn';
+
+export function deleteIn(keyPath) {
+  return removeIn(this, keyPath);
+}

--- a/src/methods/getIn.js
+++ b/src/methods/getIn.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { getIn as _getIn } from '../functional/getIn';
+
+export function getIn(searchKeyPath, notSetValue) {
+  return _getIn(this, searchKeyPath, notSetValue);
+}

--- a/src/methods/hasIn.js
+++ b/src/methods/hasIn.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { hasIn as _hasIn } from '../functional/hasIn';
+
+export function hasIn(searchKeyPath) {
+  return _hasIn(this, searchKeyPath);
+}

--- a/src/methods/merge.js
+++ b/src/methods/merge.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { KeyedCollection } from '../Collection';
+import { NOT_SET } from '../TrieUtils';
+import { update } from '../functional/update';
+
+export function merge(...iters) {
+  return mergeIntoKeyedWith(this, undefined, iters);
+}
+
+export function mergeWith(merger, ...iters) {
+  return mergeIntoKeyedWith(this, merger, iters);
+}
+
+function mergeIntoKeyedWith(collection, merger, collections) {
+  const iters = [];
+  for (let ii = 0; ii < collections.length; ii++) {
+    const collection = KeyedCollection(collections[ii]);
+    if (collection.size !== 0) {
+      iters.push(collection);
+    }
+  }
+  if (iters.length === 0) {
+    return collection;
+  }
+  if (collection.size === 0 && !collection.__ownerID && iters.length === 1) {
+    return collection.constructor(iters[0]);
+  }
+  return collection.withMutations(collection => {
+    const mergeIntoCollection = merger
+      ? (value, key) => {
+          update(
+            collection,
+            key,
+            NOT_SET,
+            oldVal => (oldVal === NOT_SET ? value : merger(oldVal, value, key))
+          );
+        }
+      : (value, key) => {
+          collection.set(key, value);
+        };
+    for (let ii = 0; ii < iters.length; ii++) {
+      iters[ii].forEach(mergeIntoCollection);
+    }
+  });
+}

--- a/src/methods/mergeDeep.js
+++ b/src/methods/mergeDeep.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  mergeDeep as _mergeDeep,
+  mergeDeepWith as _mergeDeepWith
+} from '../functional/merge';
+
+export function mergeDeep(...iters) {
+  return _mergeDeep(this, ...iters);
+}
+
+export function mergeDeepWith(merger, ...iters) {
+  return _mergeDeepWith(merger, this, ...iters);
+}

--- a/src/methods/mergeDeepIn.js
+++ b/src/methods/mergeDeepIn.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { mergeDeep } from '../functional/merge';
+import { updateIn } from '../functional/updateIn';
+import { emptyMap } from '../Map';
+
+export function mergeDeepIn(keyPath, ...iters) {
+  return updateIn(this, keyPath, emptyMap(), m => mergeDeep(m, ...iters));
+}

--- a/src/methods/mergeIn.js
+++ b/src/methods/mergeIn.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { merge } from '../functional/merge';
+import { updateIn } from '../functional/updateIn';
+import { emptyMap } from '../Map';
+
+export function mergeIn(keyPath, ...iters) {
+  return updateIn(this, keyPath, emptyMap(), m => merge(m, ...iters));
+}

--- a/src/methods/setIn.js
+++ b/src/methods/setIn.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { setIn as _setIn } from '../functional/setIn';
+
+export function setIn(keyPath, v) {
+  return _setIn(this, keyPath, v);
+}

--- a/src/methods/toObject.js
+++ b/src/methods/toObject.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import assertNotInfinite from '../utils/assertNotInfinite';
+
+export function toObject() {
+  assertNotInfinite(this.size);
+  const object = {};
+  this.__iterate((v, k) => {
+    object[k] = v;
+  });
+  return object;
+}

--- a/src/methods/update.js
+++ b/src/methods/update.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { update as _update } from '../functional/update';
+
+export function update(key, notSetValue, updater) {
+  return arguments.length === 1
+    ? key(this)
+    : _update(this, key, notSetValue, updater);
+}

--- a/src/methods/updateIn.js
+++ b/src/methods/updateIn.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { updateIn as _updateIn } from '../functional/updateIn';
+
+export function updateIn(keyPath, notSetValue, updater) {
+  return _updateIn(this, keyPath, notSetValue, updater);
+}

--- a/src/methods/wasAltered.js
+++ b/src/methods/wasAltered.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export function wasAltered() {
+  return this.__altered;
+}

--- a/src/methods/withMutations.js
+++ b/src/methods/withMutations.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export function withMutations(fn) {
+  const mutable = this.asMutable();
+  fn(mutable);
+  return mutable.wasAltered() ? mutable.__ensureOwner(this.__ownerID) : this;
+}


### PR DESCRIPTION
Currently all collection types refer to MapPrototype to access common methods. This not only makes Map a bottleneck in dependency analysis, but it also makes minification more challenging.

This proposes creating a `methods/` subdir that contains these shared methods - split up into files to avoid the same dependency bottleneck issue. Saves 325 minified bytes (modest 17 gz-bytes).