### PR TITLE
BREAKING: Use === for deep merge equality.

### DIFF
--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -43,12 +43,22 @@ describe('merge', () => {
     expect(m1.mergeDeep(m2)).toEqual(fromJS({a: {b: {c: 10, d: 2, e: 20}, f: 30}, g: 40}));
   });
 
-  it('deep merge uses is() for return-self optimization', () =>  {
+  it('merge uses === for return-self optimization', () =>  {
     const date1 = new Date(1234567890000);
+    // Value equal, but different reference.
+    const date2 = new Date(1234567890000);
+    const m = Map().set('a', date1);
+    expect(m.merge({a: date2})).not.toBe(m);
+    expect(m.merge({a: date1})).toBe(m);
+  });
+
+  it('deep merge uses === for return-self optimization', () =>  {
+    const date1 = new Date(1234567890000);
+    // Value equal, but different reference.
     const date2 = new Date(1234567890000);
     const m = Map().setIn(['a', 'b', 'c'], date1);
-    const m2 = m.mergeDeep({a: {b: {c: date2 }}});
-    expect(m2 === m).toBe(true);
+    expect(m.mergeDeep({a: {b: {c: date2}}})).not.toBe(m);
+    expect(m.mergeDeep({a: {b: {c: date1}}})).toBe(m);
   });
 
   it('deep merges raw JS', () => {

--- a/src/methods/merge.js
+++ b/src/methods/merge.js
@@ -10,14 +10,14 @@ import { NOT_SET } from '../TrieUtils';
 import { update } from '../functional/update';
 
 export function merge(...iters) {
-  return mergeIntoKeyedWith(this, undefined, iters);
+  return mergeIntoKeyedWith(this, iters);
 }
 
 export function mergeWith(merger, ...iters) {
-  return mergeIntoKeyedWith(this, merger, iters);
+  return mergeIntoKeyedWith(this, iters, merger);
 }
 
-function mergeIntoKeyedWith(collection, merger, collections) {
+function mergeIntoKeyedWith(collection, collections, merger) {
   const iters = [];
   for (let ii = 0; ii < collections.length; ii++) {
     const collection = KeyedCollection(collections[ii]);

--- a/src/methods/mergeDeep.js
+++ b/src/methods/mergeDeep.js
@@ -5,15 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  mergeDeep as _mergeDeep,
-  mergeDeepWith as _mergeDeepWith
-} from '../functional/merge';
+import { mergeDeepWithSources } from '../functional/merge';
 
 export function mergeDeep(...iters) {
-  return _mergeDeep(this, ...iters);
+  return mergeDeepWithSources(this, iters);
 }
 
 export function mergeDeepWith(merger, ...iters) {
-  return _mergeDeepWith(merger, this, ...iters);
+  return mergeDeepWithSources(this, iters, merger);
 }

--- a/src/methods/mergeDeepIn.js
+++ b/src/methods/mergeDeepIn.js
@@ -5,10 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { mergeDeep } from '../functional/merge';
+import { mergeDeepWithSources } from '../functional/merge';
 import { updateIn } from '../functional/updateIn';
 import { emptyMap } from '../Map';
 
 export function mergeDeepIn(keyPath, ...iters) {
-  return updateIn(this, keyPath, emptyMap(), m => mergeDeep(m, ...iters));
+  return updateIn(this, keyPath, emptyMap(), m =>
+    mergeDeepWithSources(m, iters)
+  );
 }

--- a/src/methods/mergeIn.js
+++ b/src/methods/mergeIn.js
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { merge } from '../functional/merge';
+import { mergeWithSources } from '../functional/merge';
 import { updateIn } from '../functional/updateIn';
 import { emptyMap } from '../Map';
 
 export function mergeIn(keyPath, ...iters) {
-  return updateIn(this, keyPath, emptyMap(), m => merge(m, ...iters));
+  return updateIn(this, keyPath, emptyMap(), m => mergeWithSources(m, iters));
 }


### PR DESCRIPTION
This rectifies an inconsistent behavior between `x.merge(y)` and `x.mergeDeep(y)` where merge would use === on leaf values to determine return-self optimizations, while mergeDeep would use is(). Not only was this inconsistent, it was the only place in the library this behavior existed - where everwhere else `===` is used to determine return-self optimization.

Also minor refactor to save a handful of gz-bytes and reduce overhead.