### PR TITLE
BREAKING: Create new List instead of new Map in updateIn keypath.

### DIFF
--- a/__tests__/updateIn.ts
+++ b/__tests__/updateIn.ts
@@ -7,7 +7,7 @@
 
 ///<reference path='../resources/jest.d.ts'/>
 
-import { fromJS, List, Map, removeIn, Seq, Set, setIn, updateIn } from '../';
+import { fromJS, List, Map, removeIn, Seq, Set, set, setIn, updateIn } from '../';
 
 describe('updateIn', () => {
 
@@ -128,22 +128,34 @@ describe('updateIn', () => {
     );
   });
 
-  it('creates new maps if path contains gaps', () => {
+  it('creates new maps and lists if path contains gaps', () => {
     const m = fromJS({a: {b: {c: 10}}});
     expect(
-      m.updateIn(['a', 'q', 'z'], Map(), map => map.set('d', 20)).toJS(),
+      m.updateIn(['a', 'q', 0, 'z'], Map(), map => map.set('d', 20)),
     ).toEqual(
-      {a: {b: {c: 10}, q: {z: {d: 20}}}},
+      Map({
+        a: Map({
+          b: Map({c: 10}),
+          q: List([
+            Map({z: Map({d: 20})}),
+          ]),
+        }),
+      }),
     );
   });
 
-  it('creates new objects if path contains gaps within raw JS', () => {
+  it('creates new objects and lists if path contains gaps within raw JS', () => {
     const m = {a: {b: {c: 10}}};
     expect(
-      updateIn(m, ['a', 'b', 'z'], Map(), map => map.set('d', 20)),
-    ).toEqual(
-      {a: {b: {c: 10, z: Map({d: 20})}}},
-    );
+      updateIn(m, ['a', 'q', 0, 'z'], {}, obj => set(obj, 'd', 20)),
+    ).toEqual({
+      a: {
+        b: {c: 10},
+        q: [
+          {z: {d: 20}},
+        ],
+      },
+    });
   });
 
   it('throws if path cannot be set', () => {

--- a/src/functional/updateIn.js
+++ b/src/functional/updateIn.js
@@ -10,6 +10,7 @@ import coerceKeyPath from '../utils/coerceKeyPath';
 import isDataStructure from '../utils/isDataStructure';
 import quoteString from '../utils/quoteString';
 import { NOT_SET } from '../TrieUtils';
+import { emptyList } from '../List';
 import { emptyMap } from '../Map';
 import { get } from './get';
 import { remove } from './remove';
@@ -68,7 +69,11 @@ function updateInDeeply(
     : nextUpdated === NOT_SET
       ? remove(existing, key)
       : set(
-          wasNotSet ? (inImmutable ? emptyMap() : {}) : existing,
+          wasNotSet
+            ? typeof key === 'number'
+              ? inImmutable ? emptyList() : []
+              : inImmutable ? emptyMap() : {}
+            : existing,
           key,
           nextUpdated
         );

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -1415,9 +1415,17 @@ declare module Immutable {
      * Returns a new Map having applied the `updater` to the entry found at the
      * keyPath.
      *
-     * This is most commonly used to call methods on collections nested within a
-     * structure of data. For example, in order to `.push()` onto a nested `List`,
-     * `updateIn` and `push` can be used together:
+     * <!-- runkit:activate -->
+     * ```js
+     * const { Map } = require('immutable@4.0.0-rc.7')
+     * const map = Map({ a: Map({ b: Map({ c: 10 }) }) })
+     * const newMap = map.updateIn(['a', 'b', 'c'], val => val * 2)
+     * // Map { "a": Map { "b": Map { "c": 20 } } }
+     * ```
+     *
+     * This is often used to call methods on collections nested within a
+     *  structure of data. For example, in order to `.push()` onto a nested
+     * `List`, `updateIn` and `push` can be used together:
      *
      * <!-- runkit:activate -->
      * ```js
@@ -1427,18 +1435,16 @@ declare module Immutable {
      * // Map { "inMap": Map { "inList": List [ 1, 2, 3, 4 ] } }
      * ```
      *
-     * If any keys in `keyPath` do not exist, new Immutable `Map`s will
-     * be created at those keys. If the `keyPath` does not already contain a
-     * value, the `updater` function will be called with `notSetValue`, if
-     * provided, otherwise `undefined`.
+     * If any keys in `keyPath` do not exist, new Immutable `Map`s or `List`s
+     * will be created at those keys.
      *
      * <!-- runkit:activate
      *      { "preamble": "const { Map } = require('immutable@4.0.0-rc.7')" }
      * -->
      * ```js
-     * const map = Map({ a: Map({ b: Map({ c: 10 }) }) })
-     * const newMap = map.updateIn(['a', 'b', 'c'], val => val * 2)
-     * // Map { "a": Map { "b": Map { "c": 20 } } }
+     * const emptyMap = Map()
+     * const newMap = map.updateIn(['a', 0, 'c'], () => 'whoa')
+     * // Map { "a": List [ Map { "c": "whoa" } ] }
      * ```
      *
      * If the `updater` function returns the same value it was called with, then
@@ -1454,8 +1460,10 @@ declare module Immutable {
      * assert.strictEqual(newMap, aMap)
      * ```
      *
-     * For code using ES2015 or later, using `notSetValue` is discourged in
-     * favor of function parameter default values. This helps to avoid any
+     * If the `keyPath` does not already contain a value, the `updater` function
+     * will be called with `notSetValue`, if provided, otherwise `undefined`.
+     * For code written in ES2015 or later, using `notSetValue` is discouraged
+     * in favor of function parameter default values. This helps to avoid any
      * potential confusion with identify functions as described above.
      *
      * The previous example behaves differently when written with default values:


### PR DESCRIPTION
If any keys in `keyPath` do not exist, a new Map is created. This is often confusing when using numeric keys - which typically imply using a List instead of a Map.

This now looks at the key, if it is a number then a List is created instead of a Map.

This is breaking since previously this would have created a Map instead of a List. Existing code relying on creating `Map<number, *>` should convert code to explicitly create missing Maps before calling `updateIn()`.