### PR TITLE
Adds test to demo key Symbol in Map.set()

### DIFF
--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -192,11 +192,14 @@ describe('Map', () => {
   });
 
   it('can use weird keys', () => {
+    const symbol = Symbol('A');
     const m: Map<any, any> = Map()
       .set(NaN, 1)
       .set(Infinity, 2)
+      .set(symbol, 'A')
       .set(-Infinity, 3);
 
+    expect(m.get(symbol)).toBe('A');
     expect(m.get(NaN)).toBe(1);
     expect(m.get(Infinity)).toBe(2);
     expect(m.get(-Infinity)).toBe(3);


### PR DESCRIPTION
Adds test to demonstrate usage of Symbol primitive data type as Map key via set method, which does not work upon Map instantiation.

Split from https://github.com/facebook/immutable-js/pull/1392