### PR TITLE
Fix flow types for Record setIn/getIn deep values.

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1397,10 +1397,10 @@ declare class RecordInstance<T: Object> {
 
   getIn(keyPath: [], notSetValue?: mixed): this & T;
   getIn<K: $Keys<T>>(keyPath: [K], notSetValue?: mixed): $ElementType<T, K>;
-  getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>>(keyPath: [K, K2], notSetValue: NSV): $ValOf<$ElementType<T, K>, K2> | NSV;
-  getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>>(keyPath: [K, K2, K3], notSetValue: NSV): $ValOf<$ValOf<$ElementType<T, K>, K2>, K3> | NSV;
-  getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>>(keyPath: [K, K2, K3, K4], notSetValue: NSV): $ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4> | NSV;
-  getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>>(keyPath: [K, K2, K3, K4, K5], notSetValue: NSV): $ValOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>, K5> | NSV;
+  getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>>(keyPath: [K, K2], notSetValue: NSV): $ValOf<$ValOf<T, K>, K2> | NSV;
+  getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>>(keyPath: [K, K2, K3], notSetValue: NSV): $ValOf<$ValOf<$ValOf<T, K>, K2>, K3> | NSV;
+  getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>>(keyPath: [K, K2, K3, K4], notSetValue: NSV): $ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4> | NSV;
+  getIn<NSV, K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>>>(keyPath: [K, K2, K3, K4, K5], notSetValue: NSV): $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>, K5> | NSV;
 
   equals(other: any): boolean;
   hashCode(): number;
@@ -1424,38 +1424,38 @@ declare class RecordInstance<T: Object> {
   clear(): this & T;
 
   setIn<S>(keyPath: [], value: S): S;
-  setIn<K: $Keys<T>, S: $ElementType<T, K>>(keyPath: [K], value: S): this & T;
-  setIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, S: $ValOf<$ElementType<T, K>, K2>>(keyPath: [K, K2], value: S): this & T;
-  setIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, S: $ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>(keyPath: [K, K2, K3], value: S): this & T;
-  setIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>(keyPath: [K, K2, K3, K4], value: S): this & T;
-  setIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>, K5>>(keyPath: [K, K2, K3, K4, K5], value: S): this & T;
+  setIn<K: $Keys<T>, S: $ValOf<T, K>>(keyPath: [K], value: S): this & T;
+  setIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, S: $ValOf<$ValOf<T, K>, K2>>(keyPath: [K, K2], value: S): this & T;
+  setIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, S: $ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>(keyPath: [K, K2, K3], value: S): this & T;
+  setIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>>(keyPath: [K, K2, K3, K4], value: S): this & T;
+  setIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>, K5>>(keyPath: [K, K2, K3, K4, K5], value: S): this & T;
 
   deleteIn(keyPath: []): void;
   deleteIn<K: $Keys<T>>(keyPath: [K]): this & T;
-  deleteIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>>(keyPath: [K, K2]): this & T;
-  deleteIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>>(keyPath: [K, K2, K3]): this & T;
-  deleteIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>>(keyPath: [K, K2, K3, K4]): this & T;
-  deleteIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>>(keyPath: [K, K2, K3, K4, K5]): this & T;
+  deleteIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>>(keyPath: [K, K2]): this & T;
+  deleteIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>>(keyPath: [K, K2, K3]): this & T;
+  deleteIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>>(keyPath: [K, K2, K3, K4]): this & T;
+  deleteIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>>>(keyPath: [K, K2, K3, K4, K5]): this & T;
 
   removeIn(keyPath: []): void;
   removeIn<K: $Keys<T>>(keyPath: [K]): this & T;
-  removeIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>>(keyPath: [K, K2]): this & T;
-  removeIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>>(keyPath: [K, K2, K3]): this & T;
-  removeIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>>(keyPath: [K, K2, K3, K4]): this & T;
-  removeIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>>(keyPath: [K, K2, K3, K4, K5]): this & T;
+  removeIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>>(keyPath: [K, K2]): this & T;
+  removeIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>>(keyPath: [K, K2, K3]): this & T;
+  removeIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>>(keyPath: [K, K2, K3, K4]): this & T;
+  removeIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>>>(keyPath: [K, K2, K3, K4, K5]): this & T;
 
   updateIn<U>(keyPath: [], notSetValue: mixed, updater: (value: this) => U): U;
   updateIn<U>(keyPath: [], updater: (value: this) => U): U;
-  updateIn<NSV, K: $Keys<T>, S: $ElementType<T, K>>(keyPath: [K], notSetValue: NSV, updater: (value: $ElementType<T, K>) => S): this & T;
-  updateIn<K: $Keys<T>, S: $ElementType<T, K>>(keyPath: [K], updater: (value: $ElementType<T, K>) => S): this & T;
-  updateIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, S: $ValOf<$ElementType<T, K>, K2>>(keyPath: [K, K2], notSetValue: NSV, updater: (value: $ValOf<$ElementType<T, K>, K2> | NSV) => S): this & T;
-  updateIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, S: $ValOf<$ElementType<T, K>, K2>>(keyPath: [K, K2], updater: (value: $ValOf<$ElementType<T, K>, K2>) => S): this & T;
-  updateIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, S: $ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>(keyPath: [K, K2, K3], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ElementType<T, K>, K2>, K3> | NSV) => S): this & T;
-  updateIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, S: $ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>(keyPath: [K, K2, K3], updater: (value: $ValOf<$ValOf<$ElementType<T, K>, K2>, K3>) => S): this & T;
-  updateIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>(keyPath: [K, K2, K3, K4], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4> | NSV) => S): this & T;
-  updateIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>(keyPath: [K, K2, K3, K4], updater: (value: $ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>) => S): this & T;
-  updateIn<NSV, K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>, K5>>(keyPath: [K, K2, K3, K4, K5], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>, K5> | NSV) => S): this & T;
-  updateIn<K: $Keys<T>, K2: $KeyOf<$ElementType<T, K>>, K3: $KeyOf<$ValOf<$ElementType<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>, K5>>(keyPath: [K, K2, K3, K4, K5], updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<$ElementType<T, K>, K2>, K3>, K4>, K5>) => S): this & T;
+  updateIn<NSV, K: $Keys<T>, S: $ValOf<T, K>>(keyPath: [K], notSetValue: NSV, updater: (value: $ValOf<T, K>) => S): this & T;
+  updateIn<K: $Keys<T>, S: $ValOf<T, K>>(keyPath: [K], updater: (value: $ValOf<T, K>) => S): this & T;
+  updateIn<NSV, K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, S: $ValOf<$ValOf<T, K>, K2>>(keyPath: [K, K2], notSetValue: NSV, updater: (value: $ValOf<$ValOf<T, K>, K2> | NSV) => S): this & T;
+  updateIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, S: $ValOf<$ValOf<T, K>, K2>>(keyPath: [K, K2], updater: (value: $ValOf<$ValOf<T, K>, K2>) => S): this & T;
+  updateIn<NSV, K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, S: $ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>(keyPath: [K, K2, K3], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<T, K>, K2>, K3> | NSV) => S): this & T;
+  updateIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, S: $ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>(keyPath: [K, K2, K3], updater: (value: $ValOf<$ValOf<$ValOf<T, K>, K2>, K3>) => S): this & T;
+  updateIn<NSV, K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>>(keyPath: [K, K2, K3, K4], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4> | NSV) => S): this & T;
+  updateIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>, S: $ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>>(keyPath: [K, K2, K3, K4], updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>) => S): this & T;
+  updateIn<NSV, K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>, K5>>(keyPath: [K, K2, K3, K4, K5], notSetValue: NSV, updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>, K5> | NSV) => S): this & T;
+  updateIn<K: $Keys<T>, K2: $KeyOf<$ValOf<T, K>>, K3: $KeyOf<$ValOf<$ValOf<T, K>, K2>>, K4: $KeyOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>>, K5: $KeyOf<$ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>>, S: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>, K5>>(keyPath: [K, K2, K3, K4, K5], updater: (value: $ValOf<$ValOf<$ValOf<$ValOf<$ValOf<T, K>, K2>, K3>, K4>, K5>) => S): this & T;
 
   mergeIn(keyPath: Iterable<mixed>, ...collections: Array<any>): this & T;
   mergeDeepIn(keyPath: Iterable<mixed>, ...collections: Array<any>): this & T;

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -1109,3 +1109,36 @@ updateIn(plainFriendlies, [0, 'friends', 0, 'name'], () => 'Whitney');
   const objMap: {[string]: number} = {x: 10, y: 10};
   const success: number|string = get(objMap, 'z', 'missing');
 }
+
+// Deeply nested records
+
+type DeepNestFields = {
+  foo: number,
+};
+type DeepNest = RecordOf<DeepNestFields>;
+const deepNest: RecordFactory<DeepNestFields> = Record({
+  foo: 0,
+});
+
+type NestFields = {
+  deepNest: DeepNest,
+};
+type Nest = RecordOf<NestFields>;
+const nest: RecordFactory<NestFields> = Record({
+  deepNest: deepNest(),
+});
+
+type StateFields = {
+  nest: Nest,
+};
+type State = RecordOf<StateFields>;
+const initialState: RecordFactory<StateFields> = Record({
+  nest: nest(),
+});
+
+const state = initialState();
+(state.setIn(['nest', 'deepNest', 'foo'], 5): State);
+// $ExpectError
+(state.setIn(['nest', 'deepNest', 'foo'], 'string'): State);
+// $ExpectError
+(state.setIn(['nest', 'deepNest', 'unknownField'], 5): State);


### PR DESCRIPTION
Unsure what the root issue was, but key types were being incorrectly derived for deeply nested values. Replacing $ElementType with $ValOf seems to fix the issue.

Added the original reported test case that failed before, now passes

Fixes #1398 