### PR TITLE
Improve flow types for functional merge() definitions.

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -49,6 +49,12 @@ type $ValOf<C, K = $KeyOf<C>> = $Call<
   K
 >;
 
+type $IterableOf<C> = $Call<
+  & (<V: Array<any> | IndexedCollection<any> | SetCollection<any>>(V) => Iterable<$ValOf<V>>)
+  & (<V: KeyedCollection<any, any> | RecordInstance<any> | PlainObjInput<any, any>>(V) => Iterable<[$KeyOf<V>, $ValOf<V>]>),
+  C
+>;
+
 declare class _Collection<K, +V> /*implements ValueObject*/ {
   equals(other: mixed): boolean;
   hashCode(): number;
@@ -1372,6 +1378,10 @@ type RecordFactory<Values: Object> = Class<RecordInstance<Values>>;
 // The type of runtime Record instances.
 type RecordOf<Values: Object> = RecordInstance<Values> & Values;
 
+// The values of a Record instance.
+type _RecordValues<T, R: RecordInstance<T> | T> = R;
+type RecordValues<R> = _RecordValues<*, R>;
+
 declare function isRecord(maybeRecord: any): boolean %checks(maybeRecord instanceof RecordInstance);
 declare class Record {
   static <Values: Object>(spec: Values, name?: string): RecordFactory<Values>;
@@ -1383,10 +1393,10 @@ declare class Record {
 }
 
 declare class RecordInstance<T: Object> {
-  static (values?: $Shape<T> | Iterable<[$Keys<T>, any]>): RecordOf<T>;
+  static (values?: Iterable<[$Keys<T>, $ValOf<T>]> | $Shape<T>): RecordOf<T>;
   // Note: a constructor can only create an instance of RecordInstance<T>,
   // it's encouraged to not use `new` when creating Records.
-  constructor (values?: $Shape<T> | Iterable<[$Keys<T>, any]>): void;
+  constructor (values?: Iterable<[$Keys<T>, $ValOf<T>]> | $Shape<T>): void;
 
   size: number;
 
@@ -1407,16 +1417,16 @@ declare class RecordInstance<T: Object> {
 
   set<K: $Keys<T>>(key: K, value: $ElementType<T, K>): this & T;
   update<K: $Keys<T>>(key: K, updater: (value: $ElementType<T, K>) => $ElementType<T, K>): this & T;
-  merge(...collections: Array<$Shape<T> | Iterable<[$Keys<T>, any]>>): this & T;
-  mergeDeep(...collections: Array<$Shape<T> | Iterable<[$Keys<T>, any]>>): this & T;
+  merge(...collections: Array<Iterable<[$Keys<T>, $ValOf<T>]> | $Shape<T>>): this & T;
+  mergeDeep(...collections: Array<Iterable<[$Keys<T>, $ValOf<T>]> | $Shape<T>>): this & T;
 
   mergeWith(
-    merger: (oldVal: any, newVal: any, key: $Keys<T>) => any,
-    ...collections: Array<$Shape<T> | Iterable<[$Keys<T>, any]>>
+    merger: (oldVal: $ValOf<T>, newVal: $ValOf<T>, key: $Keys<T>) => $ValOf<T>,
+    ...collections: Array<Iterable<[$Keys<T>, $ValOf<T>]> | $Shape<T>>
   ): this & T;
   mergeDeepWith(
     merger: (oldVal: any, newVal: any, key: any) => any,
-    ...collections: Array<$Shape<T> | Iterable<[$Keys<T>, any]>>
+    ...collections: Array<Iterable<[$Keys<T>, $ValOf<T>]> | $Shape<T>>
   ): this & T;
 
   delete<K: $Keys<T>>(key: K): this & T;
@@ -1471,7 +1481,7 @@ declare class RecordInstance<T: Object> {
   wasAltered(): boolean;
   asImmutable(): this & T;
 
-  @@iterator(): Iterator<[$Keys<T>, any]>;
+  @@iterator(): Iterator<[$Keys<T>, $ValOf<T>]>;
 }
 
 declare function fromJS(
@@ -1533,21 +1543,21 @@ declare function updateIn<C, K: $KeyOf<C>, K2: $KeyOf<$ValOf<C, K>>, K3: $KeyOf<
 
 declare function merge<C>(
   collection: C,
-  ...collections: Array<Iterable<$ValOf<C>> | Iterable<[$KeyOf<C>, $ValOf<C>]> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
+  ...collections: Array<$IterableOf<C> | $Shape<RecordValues<C>> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
 ): C;
 declare function mergeWith<C>(
   merger: (oldVal: $ValOf<C>, newVal: $ValOf<C>, key: $KeyOf<C>) => $ValOf<C>,
   collection: C,
-  ...collections: Array<Iterable<$ValOf<C>> | Iterable<[$KeyOf<C>, $ValOf<C>]> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
+  ...collections: Array<$IterableOf<C> | $Shape<RecordValues<C>> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
 ): C;
 declare function mergeDeep<C>(
   collection: C,
-  ...collections: Array<Iterable<$ValOf<C>> | Iterable<[$KeyOf<C>, $ValOf<C>]> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
+  ...collections: Array<$IterableOf<C> | $Shape<RecordValues<C>> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
 ): C;
 declare function mergeDeepWith<C>(
   merger: (oldVal: any, newVal: any, key: any) => mixed,
   collection: C,
-  ...collections: Array<Iterable<$ValOf<C>> | Iterable<[$KeyOf<C>, $ValOf<C>]> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
+  ...collections: Array<$IterableOf<C> | $Shape<RecordValues<C>> | PlainObjInput<$KeyOf<C>, $ValOf<C>>>
 ): C;
 
 export {

--- a/type-definitions/tests/merge.js
+++ b/type-definitions/tests/merge.js
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {
+  List,
+  Map,
+  Record,
+  type RecordOf,
+  type RecordFactory,
+  get,
+  getIn,
+  has,
+  hasIn,
+  merge,
+  mergeDeep,
+  mergeWith,
+  mergeDeepWith,
+  remove,
+  removeIn,
+  set,
+  setIn,
+  update,
+  updateIn,
+} from '../../';
+
+// merge: Records
+
+type XYPoint = { x: number, y: number };
+type XYPointRecord = RecordOf<XYPoint>;
+const xyRecord: RecordFactory<XYPoint> = Record({ x: 0, y: 0 });
+const record = xyRecord();
+(merge(record, { x: 321 }): XYPointRecord);
+(merge(record, xyRecord({ x: 321 })): XYPointRecord);
+// $ExpectError
+(merge(record, { z: 321 }): XYPointRecord);
+// $ExpectError
+(merge(record, { x: 'abc' }): XYPointRecord);
+(merge(record, [['x', 321]]): XYPointRecord);
+// $ExpectError
+(merge(record, [['z', 321]]): XYPointRecord);
+// $ExpectError
+(merge(record, [['x', 'abc']]): XYPointRecord);
+// $ExpectError
+(merge(record, [321]): XYPointRecord);
+(merge(record, Map({x: 123})): XYPointRecord);
+// $ExpectError
+(merge(record, Map({z: 123})): XYPointRecord);
+(merge(record, Map([['x', 123]])): XYPointRecord);
+// $ExpectError
+(merge(record, Map([['z', 123]])): XYPointRecord);
+// $ExpectError
+(merge(record, List([123])): XYPointRecord);
+
+// merge: Maps
+
+const map = Map({ key: 'value' });
+(merge(map, { key: 'alternate' }): Map<string, string>);
+(merge(map, { otherKey: 'value' }): Map<string, string>);
+(merge(map, Map({ key: 'alternate' })): Map<string, string>);
+(merge(map, Map({ otherKey: 'value' })): Map<string, string>);
+(merge(map, [['otherKey', 'value']]): Map<string, string>);
+// $ExpectError (functional merge cannot return union value types)
+(merge(map, Map({ otherKey: 123 })): Map<string, string|number>);
+// $ExpectError
+(merge(map, [ 4, 5, 6 ]): Map<string, string>);
+// $ExpectError
+(merge(map, 123): Map<string, string>);
+// $ExpectError
+(merge(map, { 0: 123 }): Map<string, string>);
+// $ExpectError
+(merge(map, [[0, 4], [1, 5], [1, 6]]): Map<string, string>);
+
+// merge: Lists
+
+const list = List([ 1, 2, 3 ]);
+(merge(list, [ 4, 5, 6 ]): List<number>);
+(merge(list, List([ 4, 5, 6 ])): List<number>);
+// $ExpectError (functional merge cannot return union value types)
+(merge(list, [ 'a', 'b', 'c' ]): List<number|string>);
+// $ExpectError (functional merge cannot return union value types)
+(merge(list, List([ 'a', 'b', 'c' ])): List<number|string>);
+// $ExpectError
+(merge(list, 123): List<number>);
+// $ExpectError
+(merge(list, { 0: 123 }): List<number>);
+// $ExpectError
+(merge(list, Map({ 0: 123 })): List<number>);
+// $ExpectError
+(merge(list, [[0, 4], [1, 5], [1, 6]]): List<number>);
+
+// merge: Objects as Records
+
+const objRecord: XYPoint = { x: 12, y: 34 };
+(merge(objRecord, { x: 321 }): XYPoint);
+(merge(objRecord, xyRecord({ x: 321 })): XYPoint);
+// $ExpectError
+(merge(objRecord, { z: 321 }): XYPoint);
+// $ExpectError
+(merge(objRecord, { x: 'abc' }): XYPoint);
+(merge(objRecord, [['x', 321]]): XYPoint);
+// $ExpectError
+(merge(objRecord, [['z', 321]]): XYPoint);
+// $ExpectError
+(merge(objRecord, [['x', 'abc']]): XYPoint);
+// $ExpectError
+(merge(objRecord, [321]): XYPoint);
+(merge(objRecord, Map({x: 123})): XYPoint);
+// $ExpectError
+(merge(objRecord, Map({z: 123})): XYPoint);
+(merge(objRecord, Map([['x', 123]])): XYPoint);
+// $ExpectError
+(merge(objRecord, Map([['z', 123]])): XYPoint);
+// $ExpectError
+(merge(objRecord, List([123])): XYPoint);
+
+// merge: Objects as Maps
+
+type ObjMap<T> = { [key: string]: T };
+const objMap: ObjMap<number> = { x: 12, y: 34 };
+(merge(objMap, { x: 321 }): ObjMap<number>);
+(merge(objMap, { z: 321 }): ObjMap<number>);
+// $ExpectError
+(merge(objMap, { x: 'abc' }): ObjMap<number>);
+(merge(objMap, [['x', 321]]): ObjMap<number>);
+(merge(objMap, [['z', 321]]): ObjMap<number>);
+// $ExpectError
+(merge(objMap, [['x', 'abc']]): ObjMap<number>);
+// $ExpectError
+(merge(objMap, [321]): ObjMap<number>);
+(merge(objMap, Map({x: 123})): ObjMap<number>);
+(merge(objMap, Map({z: 123})): ObjMap<number>);
+(merge(objMap, Map([['x', 123]])): ObjMap<number>);
+(merge(objMap, Map([['z', 123]])): ObjMap<number>);
+// $ExpectError
+(merge(objMap, List([123])): ObjMap<number>);
+
+// merge: Arrays
+
+const arr = [ 1, 2, 3 ];
+(merge(arr, [ 4, 5, 6 ]): Array<number>);
+(merge(arr, List([ 4, 5, 6 ])): Array<number>);
+// $ExpectError (functional merge cannot return union value types)
+(merge(arr, [ 'a', 'b', 'c' ]): Array<number|string>);
+// $ExpectError (functional merge cannot return union value types)
+(merge(arr, List([ 'a', 'b', 'c' ])): Array<number|string>);
+// $ExpectError
+(merge(arr, 123): Array<number>);
+// $ExpectError
+(merge(arr, { 0: 123 }): Array<number>);
+// $ExpectError
+(merge(arr, Map({ 0: 123 })): Array<number>);
+// $ExpectError
+(merge(arr, [[0, 4], [1, 5], [1, 6]]): Array<number>);


### PR DESCRIPTION
These previously did not include $Shape and dubiously allowed incorrect Iterables. Added some helper types to make defining the merge() family more robust, and lift some of those improvements into `record.merge()` as well.

Fixes #1396