### PR TITLE
test(ts-definitions): test Immutable.d.ts validity using tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "testonly": "./resources/jest",
     "test": "run-s format build lint testonly test:types:*",
     "test:travis": "npm run test && ./resources/check-changes",
-    "test:types:ts": "dtslint type-definitions/ts-tests",
+    "test:types:ts": "tsc ./type-definitions/Immutable.d.ts --lib es2015 && dtslint type-definitions/ts-tests",
     "test:types:flow": "flow check type-definitions/tests --include-warnings",
     "perf": "node ./resources/bench.js",
     "start": "gulp --gulpfile gulpfile.js dev",


### PR DESCRIPTION
It seems the current setup for ts-tests doesn't include Immutable.d.ts in the compilation. This is the only way I could find to test Immutable.d.ts for validity.