### PR TITLE
Use prettier for tests

### DIFF
--- a/__tests__/ArraySeq.ts
+++ b/__tests__/ArraySeq.ts
@@ -10,7 +10,6 @@
 import { Seq } from '../';
 
 describe('ArraySequence', () => {
-
   it('every is true when predicate is true for all entries', () => {
     expect(Seq([]).every(() => false)).toBe(true);
     expect(Seq([1, 2, 3]).every(v => v > 0)).toBe(true);
@@ -42,7 +41,14 @@ describe('ArraySequence', () => {
     function studly(letter, index) {
       return index % 2 === 0 ? letter : letter.toUpperCase();
     }
-    const result = i.reverse().take(10).reverse().take(5).map(studly).toArray().join('');
+    const result = i
+      .reverse()
+      .take(10)
+      .reverse()
+      .take(5)
+      .map(studly)
+      .toArray()
+      .join('');
     expect(result).toBe('qRsTu');
   });
 
@@ -67,8 +73,19 @@ describe('ArraySequence', () => {
     expect(seq.take(5).toArray().length).toBe(5);
     expect(seq.filter(x => x % 2 === 1).toArray().length).toBe(2);
     expect(seq.toKeyedSeq().flip().size).toBe(10);
-    expect(seq.toKeyedSeq().flip().flip().size).toBe(10);
-    expect(seq.toKeyedSeq().flip().flip().toArray().length).toBe(10);
+    expect(
+      seq
+        .toKeyedSeq()
+        .flip()
+        .flip().size
+    ).toBe(10);
+    expect(
+      seq
+        .toKeyedSeq()
+        .flip()
+        .flip()
+        .toArray().length
+    ).toBe(10);
   });
 
   it('can be iterated', () => {

--- a/__tests__/Conversion.ts
+++ b/__tests__/Conversion.ts
@@ -7,8 +7,8 @@
 
 ///<reference path='../resources/jest.d.ts'/>
 
-import * as jasmineCheck from "jasmine-check";
-import {fromJS, is, List, Map, OrderedMap, Record} from "../";
+import * as jasmineCheck from 'jasmine-check';
+import { fromJS, is, List, Map, OrderedMap, Record } from '../';
 jasmineCheck.install();
 
 // Symbols
@@ -19,72 +19,73 @@ describe('Conversion', () => {
   const js = {
     deepList: [
       {
-        position: "first",
+        position: 'first'
       },
       {
-        position: "second",
+        position: 'second'
       },
       {
-        position: "third",
-      },
+        position: 'third'
+      }
     ],
     deepMap: {
-      a: "A",
-      b: "B",
+      a: 'A',
+      b: 'B'
     },
     emptyMap: Object.create(null),
-    point: {x: 10, y: 20},
-    string: "Hello",
-    list: [1, 2, 3],
+    point: { x: 10, y: 20 },
+    string: 'Hello',
+    list: [1, 2, 3]
   };
 
-  const Point = Record({x: 0, y: 0}, 'Point');
+  const Point = Record({ x: 0, y: 0 }, 'Point');
 
   const immutableData = Map({
     deepList: List.of(
       Map({
-        position: "first",
+        position: 'first'
       }),
       Map({
-        position: "second",
+        position: 'second'
       }),
       Map({
-        position: "third",
-      }),
+        position: 'third'
+      })
     ),
     deepMap: Map({
-      a: "A",
-      b: "B",
+      a: 'A',
+      b: 'B'
     }),
     emptyMap: Map(),
-    point: Map({x: 10, y: 20}),
-    string: "Hello",
-    list: List.of(1, 2, 3),
+    point: Map({ x: 10, y: 20 }),
+    string: 'Hello',
+    list: List.of(1, 2, 3)
   });
 
   const immutableOrderedData = OrderedMap({
     deepList: List.of(
       OrderedMap({
-        position: "first",
+        position: 'first'
       }),
       OrderedMap({
-        position: "second",
+        position: 'second'
       }),
       OrderedMap({
-        position: "third",
-      }),
+        position: 'third'
+      })
     ),
     deepMap: OrderedMap({
-      a: "A",
-      b: "B",
+      a: 'A',
+      b: 'B'
     }),
     emptyMap: OrderedMap(),
-    point: new Point({x: 10, y: 20}),
-    string: "Hello",
-    list: List.of(1, 2, 3),
+    point: new Point({ x: 10, y: 20 }),
+    string: 'Hello',
+    list: List.of(1, 2, 3)
   });
 
-  const immutableOrderedDataString = 'OrderedMap { ' +
+  const immutableOrderedDataString =
+    'OrderedMap { ' +
     '"deepList": List [ ' +
     'OrderedMap { ' +
     '"position": "first"' +
@@ -106,7 +107,9 @@ describe('Conversion', () => {
     '"list": List [ 1, 2, 3 ]' +
     ' }';
 
-  const nonStringKeyMap = OrderedMap().set(1, true).set(false, "foo");
+  const nonStringKeyMap = OrderedMap()
+    .set(1, true)
+    .set(false, 'foo');
   const nonStringKeyMapString = 'OrderedMap { 1: true, false: "foo" }';
 
   it('Converts deep JS to deep immutable sequences', () => {
@@ -114,10 +117,10 @@ describe('Conversion', () => {
   });
 
   it('Throws when provided circular reference', () => {
-    const o = {a: {b: {c: null as any}}};
+    const o = { a: { b: { c: null as any } } };
     o.a.b.c = o;
     expect(() => fromJS(o)).toThrow(
-      'Cannot convert circular structure to Immutable',
+      'Cannot convert circular structure to Immutable'
     );
   });
 
@@ -126,7 +129,9 @@ describe('Conversion', () => {
       if (key === 'point') {
         return new Point(sequence);
       }
-      return Array.isArray(this[key]) ? sequence.toList() : sequence.toOrderedMap();
+      return Array.isArray(this[key])
+        ? sequence.toList()
+        : sequence.toOrderedMap();
     });
     expect(seq).toEqual(immutableOrderedData);
     expect(seq.toString()).toEqual(immutableOrderedDataString);
@@ -137,7 +142,9 @@ describe('Conversion', () => {
     const seq1 = fromJS(js, function(key, sequence, keypath) {
       expect(arguments.length).toBe(3);
       paths.push(keypath);
-      return Array.isArray(this[key]) ? sequence.toList() : sequence.toOrderedMap();
+      return Array.isArray(this[key])
+        ? sequence.toList()
+        : sequence.toOrderedMap();
     });
     expect(paths).toEqual([
       [],
@@ -148,12 +155,11 @@ describe('Conversion', () => {
       ['deepMap'],
       ['emptyMap'],
       ['point'],
-      ['list'],
+      ['list']
     ]);
     const seq2 = fromJS(js, function(key, sequence) {
       expect(arguments[2]).toBe(undefined);
     });
-
   });
 
   it('Prints keys as JS values', () => {
@@ -181,36 +187,35 @@ describe('Conversion', () => {
     Model.prototype.toJSON = function() {
       return 'model';
     };
-    expect(
-      Map({a: new Model()}).toJS(),
-    ).toEqual({a: {}});
-    expect(
-      JSON.stringify(Map({a: new Model()})),
-    ).toEqual('{"a":"model"}');
+    expect(Map({ a: new Model() }).toJS()).toEqual({ a: {} });
+    expect(JSON.stringify(Map({ a: new Model() }))).toEqual('{"a":"model"}');
   });
 
   it('is conservative with array-likes, only accepting true Arrays.', () => {
-    expect(fromJS({1: 2, length: 3})).toEqual(
-      Map().set('1', 2).set('length', 3),
+    expect(fromJS({ 1: 2, length: 3 })).toEqual(
+      Map()
+        .set('1', 2)
+        .set('length', 3)
     );
     expect(fromJS('string')).toEqual('string');
   });
 
-  check.it('toJS isomorphic value', {maxSize: 30}, [gen.JSONValue], v => {
+  check.it('toJS isomorphic value', { maxSize: 30 }, [gen.JSONValue], v => {
     const imm = fromJS(v);
     expect(imm && imm.toJS ? imm.toJS() : imm).toEqual(v);
   });
 
   it('Explicitly convert values to string using String constructor', () => {
-    expect(() => fromJS({foo: Symbol('bar')}) + '').not.toThrow();
+    expect(() => fromJS({ foo: Symbol('bar') }) + '').not.toThrow();
     expect(() => Map().set('foo', Symbol('bar')) + '').not.toThrow();
     expect(() => Map().set(Symbol('bar'), 'foo') + '').not.toThrow();
   });
 
   it('Converts an immutable value of an entry correctly', () => {
-    const arr = [{key: "a"}];
-    const result = fromJS(arr).entrySeq().toJS();
-    expect(result).toEqual([[0, {key: "a"}]]);
+    const arr = [{ key: 'a' }];
+    const result = fromJS(arr)
+      .entrySeq()
+      .toJS();
+    expect(result).toEqual([[0, { key: 'a' }]]);
   });
-
 });

--- a/__tests__/Equality.ts
+++ b/__tests__/Equality.ts
@@ -13,7 +13,6 @@ jasmineCheck.install();
 import { is, List, Map, Seq, Set } from '../';
 
 describe('Equality', () => {
-
   function expectIs(left, right) {
     const comparison = is(left, right);
     expect(comparison).toBe(true);
@@ -47,29 +46,30 @@ describe('Equality', () => {
     expectIs(0, -0);
     expectIs(NaN, 0 / 0);
 
-    const str = "hello";
+    const str = 'hello';
     expectIs(str, str);
-    expectIs(str, "hello");
-    expectIsNot("hello", "HELLO");
-    expectIsNot("hello", "goodbye");
+    expectIs(str, 'hello');
+    expectIsNot('hello', 'HELLO');
+    expectIsNot('hello', 'goodbye');
 
     const array = [1, 2, 3];
     expectIs(array, array);
     expectIsNot(array, [1, 2, 3]);
 
-    const object = {key: 'value'};
+    const object = { key: 'value' };
     expectIs(object, object);
-    expectIsNot(object, {key: 'value'});
+    expectIsNot(object, { key: 'value' });
   });
 
   it('dereferences things', () => {
-    const ptrA = {foo: 1}, ptrB = {foo: 2};
+    const ptrA = { foo: 1 },
+      ptrB = { foo: 2 };
     expectIsNot(ptrA, ptrB);
     ptrA.valueOf = ptrB.valueOf = function() {
       return 5;
     };
     expectIs(ptrA, ptrB);
-    const object = {key: 'value'};
+    const object = { key: 'value' };
     ptrA.valueOf = ptrB.valueOf = function() {
       return object;
     };
@@ -125,29 +125,27 @@ describe('Equality', () => {
   const genVal = gen.oneOf([
     gen.map(List, gen.array(genSimpleVal, 0, 4)),
     gen.map(Set, gen.array(genSimpleVal, 0, 4)),
-    gen.map(Map, gen.array(gen.array(genSimpleVal, 2), 0, 4)),
+    gen.map(Map, gen.array(gen.array(genSimpleVal, 2), 0, 4))
   ]);
 
-  check.it('has symmetric equality', {times: 1000}, [genVal, genVal], (a, b) => {
-    expect(is(a, b)).toBe(is(b, a));
-  });
+  check.it(
+    'has symmetric equality',
+    { times: 1000 },
+    [genVal, genVal],
+    (a, b) => {
+      expect(is(a, b)).toBe(is(b, a));
+    }
+  );
 
-  check.it('has hash equality', {times: 1000}, [genVal, genVal], (a, b) => {
+  check.it('has hash equality', { times: 1000 }, [genVal, genVal], (a, b) => {
     if (is(a, b)) {
       expect(a.hashCode()).toBe(b.hashCode());
     }
   });
 
   describe('hash', () => {
-
     it('differentiates decimals', () => {
-      expect(
-        Seq([1.5]).hashCode(),
-      ).not.toBe(
-        Seq([1.6]).hashCode(),
-      );
+      expect(Seq([1.5]).hashCode()).not.toBe(Seq([1.6]).hashCode());
     });
-
   });
-
 });

--- a/__tests__/IndexedSeq.ts
+++ b/__tests__/IndexedSeq.ts
@@ -13,7 +13,6 @@ jasmineCheck.install();
 import { Seq } from '../';
 
 describe('IndexedSequence', () => {
-
   it('maintains skipped offset', () => {
     const seq = Seq(['A', 'B', 'C', 'D', 'E']);
 
@@ -23,7 +22,7 @@ describe('IndexedSequence', () => {
       [0, 'B'],
       [1, 'C'],
       [2, 'D'],
-      [3, 'E'],
+      [3, 'E']
     ]);
 
     expect(operated.first()).toEqual('B');

--- a/__tests__/IterableSeq.ts
+++ b/__tests__/IterableSeq.ts
@@ -11,20 +11,24 @@ declare var Symbol: any;
 import { Seq } from '../';
 
 describe('Sequence', () => {
-
   it('creates a sequence from an iterable', () => {
     const i = new SimpleIterable();
     const s = Seq(i);
-    expect(s.take(5).toArray()).toEqual([ 0, 1, 2, 3, 4 ]);
+    expect(s.take(5).toArray()).toEqual([0, 1, 2, 3, 4]);
   });
 
   it('is stable', () => {
     const i = new SimpleIterable();
     const s = Seq(i);
-    expect(s.take(5).toArray()).toEqual([ 0, 1, 2, 3, 4 ]);
-    expect(s.take(5).toArray()).toEqual([ 0, 1, 2, 3, 4 ]);
-    expect(s.take(5).take(Infinity).toArray()).toEqual([ 0, 1, 2, 3, 4 ]);
-    expect(s.take(5).toArray()).toEqual([ 0, 1, 2, 3, 4 ]);
+    expect(s.take(5).toArray()).toEqual([0, 1, 2, 3, 4]);
+    expect(s.take(5).toArray()).toEqual([0, 1, 2, 3, 4]);
+    expect(
+      s
+        .take(5)
+        .take(Infinity)
+        .toArray()
+    ).toEqual([0, 1, 2, 3, 4]);
+    expect(s.take(5).toArray()).toEqual([0, 1, 2, 3, 4]);
   });
 
   it('counts iterations', () => {
@@ -39,10 +43,10 @@ describe('Sequence', () => {
     const mockFn = jest.genMockFunction();
     const i = new SimpleIterable(3, mockFn);
     const s = Seq(i);
-    expect(s.toArray()).toEqual([ 0, 1, 2 ]);
+    expect(s.toArray()).toEqual([0, 1, 2]);
     expect(mockFn.mock.calls).toEqual([[0], [1], [2]]);
     // The iterator is recreated for the second time.
-    expect(s.toArray()).toEqual([ 0, 1, 2 ]);
+    expect(s.toArray()).toEqual([0, 1, 2]);
     expect(mockFn.mock.calls).toEqual([[0], [1], [2], [0], [1], [2]]);
   });
 
@@ -92,19 +96,18 @@ describe('Sequence', () => {
   });
 
   describe('IteratorSequence', () => {
-
     it('creates a sequence from a raw iterable', () => {
       const i = new SimpleIterable(10);
       const s = Seq(i[ITERATOR_SYMBOL]());
-      expect(s.take(5).toArray()).toEqual([ 0, 1, 2, 3, 4 ]);
+      expect(s.take(5).toArray()).toEqual([0, 1, 2, 3, 4]);
     });
 
     it('is stable', () => {
       const i = new SimpleIterable(10);
       const s = Seq(i[ITERATOR_SYMBOL]());
-      expect(s.take(5).toArray()).toEqual([ 0, 1, 2, 3, 4 ]);
-      expect(s.take(5).toArray()).toEqual([ 0, 1, 2, 3, 4 ]);
-      expect(s.take(5).toArray()).toEqual([ 0, 1, 2, 3, 4 ]);
+      expect(s.take(5).toArray()).toEqual([0, 1, 2, 3, 4]);
+      expect(s.take(5).toArray()).toEqual([0, 1, 2, 3, 4]);
+      expect(s.take(5).toArray()).toEqual([0, 1, 2, 3, 4]);
     });
 
     it('counts iterations', () => {
@@ -119,15 +122,15 @@ describe('Sequence', () => {
       const mockFn = jest.genMockFunction();
       const i = new SimpleIterable(10, mockFn);
       const s = Seq(i[ITERATOR_SYMBOL]());
-      expect(s.take(3).toArray()).toEqual([ 0, 1, 2 ]);
+      expect(s.take(3).toArray()).toEqual([0, 1, 2]);
       expect(mockFn.mock.calls).toEqual([[0], [1], [2]]);
 
       // Second call uses memoized values
-      expect(s.take(3).toArray()).toEqual([ 0, 1, 2 ]);
+      expect(s.take(3).toArray()).toEqual([0, 1, 2]);
       expect(mockFn.mock.calls).toEqual([[0], [1], [2]]);
 
       // Further ahead in the iterator yields more results.
-      expect(s.take(5).toArray()).toEqual([ 0, 1, 2, 3, 4 ]);
+      expect(s.take(5).toArray()).toEqual([0, 1, 2, 3, 4]);
       expect(mockFn.mock.calls).toEqual([[0], [1], [2], [3], [4]]);
     });
 
@@ -165,12 +168,11 @@ describe('Sequence', () => {
       expect(iter.next()).toEqual({ value: undefined, done: true });
     });
   });
-
 });
 
 // Helper for this test
 const ITERATOR_SYMBOL =
-  typeof Symbol === 'function' && Symbol.iterator || '@@iterator';
+  (typeof Symbol === 'function' && Symbol.iterator) || '@@iterator';
 
 function SimpleIterable(max?: number, watcher?: any) {
   this.max = max;

--- a/__tests__/KeyedSeq.ts
+++ b/__tests__/KeyedSeq.ts
@@ -13,7 +13,6 @@ jasmineCheck.install();
 import { Range, Seq } from '../';
 
 describe('KeyedSeq', () => {
-
   check.it('it iterates equivalently', [gen.array(gen.int)], ints => {
     const seq = Seq(ints);
     const keyed = seq.toKeyedSeq();
@@ -34,24 +33,30 @@ describe('KeyedSeq', () => {
     const seq = Range(0, 100);
 
     // This is what we expect for IndexedSequences
-    const operated = seq.filter(isEven).skip(10).take(5);
+    const operated = seq
+      .filter(isEven)
+      .skip(10)
+      .take(5);
     expect(operated.entrySeq().toArray()).toEqual([
       [0, 20],
       [1, 22],
       [2, 24],
       [3, 26],
-      [4, 28],
+      [4, 28]
     ]);
 
     // Where Keyed Sequences maintain keys.
     const keyed = seq.toKeyedSeq();
-    const keyedOperated = keyed.filter(isEven).skip(10).take(5);
+    const keyedOperated = keyed
+      .filter(isEven)
+      .skip(10)
+      .take(5);
     expect(keyedOperated.entrySeq().toArray()).toEqual([
       [20, 20],
       [22, 22],
       [24, 24],
       [26, 26],
-      [28, 28],
+      [28, 28]
     ]);
   });
 
@@ -59,44 +64,49 @@ describe('KeyedSeq', () => {
     const seq = Range(0, 100);
 
     // This is what we expect for IndexedSequences
-    expect(seq.reverse().take(5).entrySeq().toArray()).toEqual([
-      [0, 99],
-      [1, 98],
-      [2, 97],
-      [3, 96],
-      [4, 95],
-    ]);
+    expect(
+      seq
+        .reverse()
+        .take(5)
+        .entrySeq()
+        .toArray()
+    ).toEqual([[0, 99], [1, 98], [2, 97], [3, 96], [4, 95]]);
 
     // Where Keyed Sequences maintain keys.
-    expect(seq.toKeyedSeq().reverse().take(5).entrySeq().toArray()).toEqual([
-      [99, 99],
-      [98, 98],
-      [97, 97],
-      [96, 96],
-      [95, 95],
-    ]);
+    expect(
+      seq
+        .toKeyedSeq()
+        .reverse()
+        .take(5)
+        .entrySeq()
+        .toArray()
+    ).toEqual([[99, 99], [98, 98], [97, 97], [96, 96], [95, 95]]);
   });
 
   it('works with double reverse', () => {
     const seq = Range(0, 100);
 
     // This is what we expect for IndexedSequences
-    expect(seq.reverse().skip(10).take(5).reverse().entrySeq().toArray()).toEqual([
-      [0, 85],
-      [1, 86],
-      [2, 87],
-      [3, 88],
-      [4, 89],
-    ]);
+    expect(
+      seq
+        .reverse()
+        .skip(10)
+        .take(5)
+        .reverse()
+        .entrySeq()
+        .toArray()
+    ).toEqual([[0, 85], [1, 86], [2, 87], [3, 88], [4, 89]]);
 
     // Where Keyed Sequences maintain keys.
-    expect(seq.reverse().toKeyedSeq().skip(10).take(5).reverse().entrySeq().toArray()).toEqual([
-      [14, 85],
-      [13, 86],
-      [12, 87],
-      [11, 88],
-      [10, 89],
-    ]);
+    expect(
+      seq
+        .reverse()
+        .toKeyedSeq()
+        .skip(10)
+        .take(5)
+        .reverse()
+        .entrySeq()
+        .toArray()
+    ).toEqual([[14, 85], [13, 86], [12, 87], [11, 88], [10, 89]]);
   });
-
 });

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -21,14 +21,13 @@ function arrayOfSize(s) {
 }
 
 describe('List', () => {
-
   it('determines assignment of unspecified value types', () => {
     interface Test {
       list: List<string>;
     }
 
     const t: Test = {
-      list: List(),
+      list: List()
     };
 
     expect(t.list.size).toBe(0);
@@ -77,7 +76,7 @@ describe('List', () => {
   });
 
   it('accepts a keyed Seq as a list of entries', () => {
-    const seq = Seq({a: null, b: null, c: null}).flip();
+    const seq = Seq({ a: null, b: null, c: null }).flip();
     const v = List(seq);
     expect(v.toArray()).toEqual([[null, 'a'], [null, 'b'], [null, 'c']]);
     // Explicitly getting the values sequence
@@ -98,15 +97,12 @@ describe('List', () => {
   it('can setIn and getIn a deep value', () => {
     let v = List([
       Map({
-        aKey: List([
-          "bad",
-          "good",
-        ]),
-      }),
+        aKey: List(['bad', 'good'])
+      })
     ]);
-    expect(v.getIn([0, 'aKey', 1])).toBe("good");
-    v = v.setIn([0, 'aKey', 1], "great");
-    expect(v.getIn([0, 'aKey', 1])).toBe("great");
+    expect(v.getIn([0, 'aKey', 1])).toBe('good');
+    v = v.setIn([0, 'aKey', 1], 'great');
+    expect(v.getIn([0, 'aKey', 1])).toBe('great');
   });
 
   it('can update a value', () => {
@@ -117,20 +113,14 @@ describe('List', () => {
   it('can updateIn a deep value', () => {
     let l = List([
       Map({
-        aKey: List([
-          "bad",
-          "good",
-        ]),
-      }),
+        aKey: List(['bad', 'good'])
+      })
     ]);
     l = l.updateIn([0, 'aKey', 1], v => v + v);
     expect(l.toJS()).toEqual([
       {
-        aKey: [
-          'bad',
-          'goodgood',
-        ],
-      },
+        aKey: ['bad', 'goodgood']
+      }
     ]);
   });
 
@@ -276,15 +266,23 @@ describe('List', () => {
   });
 
   it('describes a dense list', () => {
-    const v = List.of<string | undefined>('a', 'b', 'c').push('d').set(14, 'o').set(6, undefined).remove(1);
+    const v = List.of<string | undefined>('a', 'b', 'c')
+      .push('d')
+      .set(14, 'o')
+      .set(6, undefined)
+      .remove(1);
     expect(v.size).toBe(14);
-    expect(v.toJS()).toEqual(
-      ['a', 'c', 'd', , , , , , , , , , , 'o'],
-    );
+    expect(v.toJS()).toEqual(['a', 'c', 'd', , , , , , , , , , , 'o']);
   });
 
   it('iterates a dense list', () => {
-    const v = List().setSize(11).set(1, 1).set(3, 3).set(5, 5).set(7, 7).set(9, 9);
+    const v = List()
+      .setSize(11)
+      .set(1, 1)
+      .set(3, 3)
+      .set(5, 5)
+      .set(7, 7)
+      .set(9, 9);
     expect(v.size).toBe(11);
 
     const forEachResults: Array<any> = [];
@@ -300,7 +298,7 @@ describe('List', () => {
       [7, 7],
       [8, undefined],
       [9, 9],
-      [10, undefined],
+      [10, undefined]
     ]);
 
     const arrayResults = v.toArray();
@@ -315,7 +313,7 @@ describe('List', () => {
       7,
       undefined,
       9,
-      undefined,
+      undefined
     ]);
 
     const iteratorResults: Array<any> = [];
@@ -335,7 +333,7 @@ describe('List', () => {
       [7, 7],
       [8, undefined],
       [9, 9],
-      [10, undefined],
+      [10, undefined]
     ]);
   });
 
@@ -347,8 +345,11 @@ describe('List', () => {
     expect(v1.toArray()).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
   });
 
-  check.it('pushes multiple values to the end', {maxSize: 2000},
-    [gen.posInt, gen.posInt], (s1, s2) => {
+  check.it(
+    'pushes multiple values to the end',
+    { maxSize: 2000 },
+    [gen.posInt, gen.posInt],
+    (s1, s2) => {
       const a1 = arrayOfSize(s1);
       const a2 = arrayOfSize(s2);
 
@@ -360,7 +361,7 @@ describe('List', () => {
 
       expect(v3.size).toEqual(a3.length);
       expect(v3.toArray()).toEqual(a3);
-    },
+    }
   );
 
   it('pop removes the highest index, decrementing size', () => {
@@ -378,8 +379,11 @@ describe('List', () => {
     expect(v.last()).toBe('X');
   });
 
-  check.it('pop removes the highest index, just like array', {maxSize: 2000},
-    [gen.posInt], len => {
+  check.it(
+    'pop removes the highest index, just like array',
+    { maxSize: 2000 },
+    [gen.posInt],
+    len => {
       const a = arrayOfSize(len);
       let v = List(a);
 
@@ -391,11 +395,14 @@ describe('List', () => {
       }
       expect(v.size).toBe(a.length);
       expect(v.toArray()).toEqual(a);
-    },
+    }
   );
 
-  check.it('push adds the next highest index, just like array', {maxSize: 2000},
-    [gen.posInt], len => {
+  check.it(
+    'push adds the next highest index, just like array',
+    { maxSize: 2000 },
+    [gen.posInt],
+    len => {
       const a: Array<any> = [];
       let v = List();
 
@@ -407,20 +414,27 @@ describe('List', () => {
       }
       expect(v.size).toBe(a.length);
       expect(v.toArray()).toEqual(a);
-    },
+    }
   );
 
   it('allows popping an empty list', () => {
     let v = List.of('a').pop();
     expect(v.size).toBe(0);
     expect(v.toArray()).toEqual([]);
-    v = v.pop().pop().pop().pop().pop();
+    v = v
+      .pop()
+      .pop()
+      .pop()
+      .pop()
+      .pop();
     expect(v.size).toBe(0);
     expect(v.toArray()).toEqual([]);
   });
 
   it('remove removes any index', () => {
-    let v = List.of('a', 'b', 'c').remove(2).remove(0);
+    let v = List.of('a', 'b', 'c')
+      .remove(2)
+      .remove(0);
     expect(v.size).toBe(1);
     expect(v.get(0)).toBe('b');
     expect(v.get(1)).toBe(undefined);
@@ -445,8 +459,11 @@ describe('List', () => {
     expect(v.toArray()).toEqual(['x', 'y', 'z', 'a', 'b', 'c']);
   });
 
-  check.it('unshifts multiple values to the front', {maxSize: 2000},
-    [gen.posInt, gen.posInt], (s1, s2) => {
+  check.it(
+    'unshifts multiple values to the front',
+    { maxSize: 2000 },
+    [gen.posInt, gen.posInt],
+    (s1, s2) => {
       const a1 = arrayOfSize(s1);
       const a2 = arrayOfSize(s2);
 
@@ -458,7 +475,7 @@ describe('List', () => {
 
       expect(v3.size).toEqual(a3.length);
       expect(v3.toArray()).toEqual(a3);
-    },
+    }
   );
 
   it('finds values using indexOf', () => {
@@ -483,7 +500,10 @@ describe('List', () => {
 
   it('finds values using findEntry', () => {
     const v = List.of('a', 'b', 'c', 'B', 'a');
-    expect(v.findEntry(value => value.toUpperCase() === value)).toEqual([3, 'B']);
+    expect(v.findEntry(value => value.toUpperCase() === value)).toEqual([
+      3,
+      'B'
+    ]);
     expect(v.findEntry(value => value.length > 1)).toBe(undefined);
   });
 
@@ -502,12 +522,16 @@ describe('List', () => {
   it('filters values based on type', () => {
     class A {}
     class B extends A {
-      b(): void { return; }
+      b(): void {
+        return;
+      }
     }
     class C extends A {
-      c(): void { return; }
+      c(): void {
+        return;
+      }
     }
-    const l1 = List<A>([ new B(), new C(), new B(), new C() ]);
+    const l1 = List<A>([new B(), new C(), new B(), new C()]);
     // tslint:disable-next-line:arrow-parens
     const l2: List<C> = l1.filter((v): v is C => v instanceof C);
     expect(l2.size).toEqual(2);
@@ -587,7 +611,9 @@ describe('List', () => {
 
   it('ensures equality', () => {
     // Make a sufficiently long list.
-    const a = Array(100).join('abcdefghijklmnopqrstuvwxyz').split('');
+    const a = Array(100)
+      .join('abcdefghijklmnopqrstuvwxyz')
+      .split('');
     const v1 = List(a);
     const v2 = List(a);
     // tslint:disable-next-line: triple-equals
@@ -643,7 +669,14 @@ describe('List', () => {
 
   it('concat works like Array.prototype.concat', () => {
     const v1 = List([1, 2, 3]);
-    const v2 = v1.concat(4, List([ 5, 6 ]), [7, 8], Seq([ 9, 10 ]), Set.of(11, 12), null as any);
+    const v2 = v1.concat(
+      4,
+      List([5, 6]),
+      [7, 8],
+      Seq([9, 10]),
+      Set.of(11, 12),
+      null as any
+    );
     expect(v1.toArray()).toEqual([1, 2, 3]);
     expect(v2.toArray()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, null]);
   });
@@ -675,7 +708,12 @@ describe('List', () => {
   it('allows chained mutations', () => {
     const v1 = List();
     const v2 = v1.push(1);
-    const v3 = v2.withMutations(v => v.push(2).push(3).push(4));
+    const v3 = v2.withMutations(v =>
+      v
+        .push(2)
+        .push(3)
+        .push(4)
+    );
     const v4 = v3.push(5);
 
     expect(v1.toArray()).toEqual([]);
@@ -687,7 +725,12 @@ describe('List', () => {
   it('allows chained mutations using alternative API', () => {
     const v1 = List();
     const v2 = v1.push(1);
-    const v3 = v2.asMutable().push(2).push(3).push(4).asImmutable();
+    const v3 = v2
+      .asMutable()
+      .push(2)
+      .push(3)
+      .push(4)
+      .asImmutable();
     const v4 = v3.push(5);
 
     expect(v1.toArray()).toEqual([]);
@@ -698,7 +741,12 @@ describe('List', () => {
 
   it('chained mutations does not result in new empty list instance', () => {
     const v1 = List(['x']);
-    const v2 = v1.withMutations(v => v.push('y').pop().pop());
+    const v2 = v1.withMutations(v =>
+      v
+        .push('y')
+        .pop()
+        .pop()
+    );
     expect(v2).toBe(List());
   });
 
@@ -728,7 +776,7 @@ describe('List', () => {
 
     expect(v2.toArray()).toEqual(list.slice(0, 3));
     expect(v3.toArray()).toEqual(
-      list.slice(0, 3).concat([undefined, undefined, undefined] as any),
+      list.slice(0, 3).concat([undefined, undefined, undefined] as any)
     );
   });
 
@@ -740,7 +788,7 @@ describe('List', () => {
 
     expect(v2.toArray()).toEqual(list.slice(0, 3));
     expect(v3.toArray()).toEqual(
-      list.slice(0, 3).concat([undefined, undefined, undefined] as any),
+      list.slice(0, 3).concat([undefined, undefined, undefined] as any)
     );
   });
 
@@ -772,7 +820,9 @@ describe('List', () => {
   });
 
   it('Accepts NaN for slice and concat #602', () => {
-    const list = List().slice(0, NaN).concat(NaN);
+    const list = List()
+      .slice(0, NaN)
+      .concat(NaN);
     // toEqual([ NaN ])
     expect(list.size).toBe(1);
     expect(isNaNValue(list.get(0))).toBe(true);
@@ -805,7 +855,6 @@ describe('List', () => {
   });
 
   describe('Iterator', () => {
-
     const pInt = gen.posInt;
 
     check.it('iterates through List', [pInt, pInt], (start, len) => {
@@ -836,7 +885,5 @@ describe('List', () => {
         expect(entryIter.next().value).toEqual([ii, start + len - 1 - ii]);
       }
     });
-
   });
-
 });

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -13,9 +13,8 @@ jasmineCheck.install();
 import { is, List, Map, Range, Record, Seq } from '../';
 
 describe('Map', () => {
-
   it('converts from object', () => {
-    const m = Map({a: 'A', b: 'B', c: 'C'});
+    const m = Map({ a: 'A', b: 'B', c: 'C' });
     expect(m.size).toBe(3);
     expect(m.get('a')).toBe('A');
     expect(m.get('b')).toBe('B');
@@ -23,7 +22,7 @@ describe('Map', () => {
   });
 
   it('constructor provides initial values', () => {
-    const m = Map({a: 'A', b: 'B', c: 'C'});
+    const m = Map({ a: 'A', b: 'B', c: 'C' });
     expect(m.size).toBe(3);
     expect(m.get('a')).toBe('A');
     expect(m.get('b')).toBe('B');
@@ -39,7 +38,7 @@ describe('Map', () => {
   });
 
   it('constructor provides initial values as sequence', () => {
-    const s = Seq({a: 'A', b: 'B', c: 'C'});
+    const s = Seq({ a: 'A', b: 'B', c: 'C' });
     const m = Map(s);
     expect(m.size).toBe(3);
     expect(m.get('a')).toBe('A');
@@ -48,11 +47,7 @@ describe('Map', () => {
   });
 
   it('constructor provides initial values as list of lists', () => {
-    const l = List([
-      List(['a', 'A']),
-      List(['b', 'B']),
-      List(['c', 'C']),
-    ]);
+    const l = List([List(['a', 'A']), List(['b', 'B']), List(['c', 'C'])]);
     const m = Map(l);
     expect(m.size).toBe(3);
     expect(m.get('a')).toBe('A');
@@ -61,7 +56,7 @@ describe('Map', () => {
   });
 
   it('constructor is identity when provided map', () => {
-    const m1 = Map({a: 'A', b: 'B', c: 'C'});
+    const m1 = Map({ a: 'A', b: 'B', c: 'C' });
     const m2 = Map(m1);
     expect(m2).toBe(m1);
   });
@@ -69,7 +64,9 @@ describe('Map', () => {
   it('does not accept a scalar', () => {
     expect(() => {
       Map(3 as any);
-    }).toThrow('Expected Array or collection object of [k, v] entries, or keyed object: 3');
+    }).toThrow(
+      'Expected Array or collection object of [k, v] entries, or keyed object: 3'
+    );
   });
 
   it('does not accept strings (collection, but scalar)', () => {
@@ -106,27 +103,33 @@ describe('Map', () => {
   });
 
   it('converts back to JS object', () => {
-    const m = Map({a: 'A', b: 'B', c: 'C'});
-    expect(m.toObject()).toEqual({a: 'A', b: 'B', c: 'C'});
+    const m = Map({ a: 'A', b: 'B', c: 'C' });
+    expect(m.toObject()).toEqual({ a: 'A', b: 'B', c: 'C' });
   });
 
   it('iterates values', () => {
-    const m = Map({a: 'A', b: 'B', c: 'C'});
+    const m = Map({ a: 'A', b: 'B', c: 'C' });
     const iterator = jest.genMockFunction();
     m.forEach(iterator);
     expect(iterator.mock.calls).toEqual([
       ['A', 'a', m],
       ['B', 'b', m],
-      ['C', 'c', m],
+      ['C', 'c', m]
     ]);
   });
 
   it('merges two maps', () => {
-    const m1 = Map({a: 'A', b: 'B', c: 'C'});
-    const m2 = Map({wow: 'OO', d: 'DD', b: 'BB'});
-    expect(m2.toObject()).toEqual({wow: 'OO', d: 'DD', b: 'BB'});
+    const m1 = Map({ a: 'A', b: 'B', c: 'C' });
+    const m2 = Map({ wow: 'OO', d: 'DD', b: 'BB' });
+    expect(m2.toObject()).toEqual({ wow: 'OO', d: 'DD', b: 'BB' });
     const m3 = m1.merge(m2);
-    expect(m3.toObject()).toEqual({a: 'A', b: 'BB', c: 'C', wow: 'OO', d: 'DD'});
+    expect(m3.toObject()).toEqual({
+      a: 'A',
+      b: 'BB',
+      c: 'C',
+      wow: 'OO',
+      d: 'DD'
+    });
   });
 
   it('accepts null as a key', () => {
@@ -185,7 +188,7 @@ describe('Map', () => {
   it('can map many items', () => {
     let m = Map();
     for (let ii = 0; ii < 2000; ii++) {
-       m = m.set('thing:' + ii, ii);
+      m = m.set('thing:' + ii, ii);
     }
     expect(m.size).toBe(2000);
     expect(m.get('thing:1234')).toBe(1234);
@@ -227,41 +230,48 @@ describe('Map', () => {
   });
 
   it('maps values', () => {
-    const m = Map({a: 'a', b: 'b', c: 'c'});
+    const m = Map({ a: 'a', b: 'b', c: 'c' });
     const r = m.map(value => value.toUpperCase());
-    expect(r.toObject()).toEqual({a: 'A', b: 'B', c: 'C'});
+    expect(r.toObject()).toEqual({ a: 'A', b: 'B', c: 'C' });
   });
 
   it('maps keys', () => {
-    const m = Map({a: 'a', b: 'b', c: 'c'});
+    const m = Map({ a: 'a', b: 'b', c: 'c' });
     const r = m.mapKeys(key => key.toUpperCase());
-    expect(r.toObject()).toEqual({A: 'a', B: 'b', C: 'c'});
+    expect(r.toObject()).toEqual({ A: 'a', B: 'b', C: 'c' });
   });
 
   it('filters values', () => {
-    const m = Map({a: 1, b: 2, c: 3, d: 4, e: 5, f: 6});
+    const m = Map({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 });
     const r = m.filter(value => value % 2 === 1);
-    expect(r.toObject()).toEqual({a: 1, c: 3, e: 5});
+    expect(r.toObject()).toEqual({ a: 1, c: 3, e: 5 });
   });
 
   it('filterNots values', () => {
-    const m = Map({a: 1, b: 2, c: 3, d: 4, e: 5, f: 6});
+    const m = Map({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 });
     const r = m.filterNot(value => value % 2 === 1);
-    expect(r.toObject()).toEqual({b: 2, d: 4, f: 6});
+    expect(r.toObject()).toEqual({ b: 2, d: 4, f: 6 });
   });
 
   it('derives keys', () => {
-    const v = Map({a: 1, b: 2, c: 3, d: 4, e: 5, f: 6});
+    const v = Map({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 });
     expect(v.keySeq().toArray()).toEqual(['a', 'b', 'c', 'd', 'e', 'f']);
   });
 
   it('flips keys and values', () => {
-    const v = Map({a: 1, b: 2, c: 3, d: 4, e: 5, f: 6});
-    expect(v.flip().toObject()).toEqual({1: 'a', 2: 'b', 3: 'c', 4: 'd', 5: 'e', 6: 'f'});
+    const v = Map({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 });
+    expect(v.flip().toObject()).toEqual({
+      1: 'a',
+      2: 'b',
+      3: 'c',
+      4: 'd',
+      5: 'e',
+      6: 'f'
+    });
   });
 
   it('can convert to a list', () => {
-    const m = Map({a: 1, b: 2, c: 3});
+    const m = Map({ a: 1, b: 2, c: 3 });
     const v = m.toList();
     const k = m.keySeq().toList();
     expect(v.size).toBe(3);
@@ -272,22 +282,27 @@ describe('Map', () => {
     expect(k.get(1)).toBe('b');
   });
 
-  check.it('works like an object', {maxSize: 50}, [gen.object(gen.JSONPrimitive)], obj => {
-    let map = Map(obj);
-    Object.keys(obj).forEach(key => {
-      expect(map.get(key)).toBe(obj[key]);
-      expect(map.has(key)).toBe(true);
-    });
-    Object.keys(obj).forEach(key => {
-      expect(map.get(key)).toBe(obj[key]);
-      expect(map.has(key)).toBe(true);
-      map = map.remove(key);
-      expect(map.get(key)).toBe(undefined);
-      expect(map.has(key)).toBe(false);
-    });
-  });
+  check.it(
+    'works like an object',
+    { maxSize: 50 },
+    [gen.object(gen.JSONPrimitive)],
+    obj => {
+      let map = Map(obj);
+      Object.keys(obj).forEach(key => {
+        expect(map.get(key)).toBe(obj[key]);
+        expect(map.has(key)).toBe(true);
+      });
+      Object.keys(obj).forEach(key => {
+        expect(map.get(key)).toBe(obj[key]);
+        expect(map.has(key)).toBe(true);
+        map = map.remove(key);
+        expect(map.get(key)).toBe(undefined);
+        expect(map.has(key)).toBe(false);
+      });
+    }
+  );
 
-  check.it('sets', {maxSize: 5000}, [gen.posInt], len => {
+  check.it('sets', { maxSize: 5000 }, [gen.posInt], len => {
     let map = Map();
     for (let ii = 0; ii < len; ii++) {
       expect(map.size).toBe(ii);
@@ -297,15 +312,18 @@ describe('Map', () => {
     expect(is(map.toSet(), Range(0, len).toSet())).toBe(true);
   });
 
-  check.it('has and get', {maxSize: 5000}, [gen.posInt], len => {
-    const map = Range(0, len).toKeyedSeq().mapKeys(x => '' + x).toMap();
+  check.it('has and get', { maxSize: 5000 }, [gen.posInt], len => {
+    const map = Range(0, len)
+      .toKeyedSeq()
+      .mapKeys(x => '' + x)
+      .toMap();
     for (let ii = 0; ii < len; ii++) {
       expect(map.get('' + ii)).toBe(ii);
       expect(map.has('' + ii)).toBe(true);
     }
   });
 
-  check.it('deletes', {maxSize: 5000}, [gen.posInt], len => {
+  check.it('deletes', { maxSize: 5000 }, [gen.posInt], len => {
     let map = Range(0, len).toMap();
     for (let ii = 0; ii < len; ii++) {
       expect(map.size).toBe(len - ii);
@@ -315,8 +333,10 @@ describe('Map', () => {
     expect(map.toObject()).toEqual({});
   });
 
-  check.it('deletes from transient', {maxSize: 5000}, [gen.posInt], len => {
-    const map = Range(0, len).toMap().asMutable();
+  check.it('deletes from transient', { maxSize: 5000 }, [gen.posInt], len => {
+    const map = Range(0, len)
+      .toMap()
+      .asMutable();
     for (let ii = 0; ii < len; ii++) {
       expect(map.size).toBe(len - ii);
       map.remove(ii);
@@ -330,7 +350,7 @@ describe('Map', () => {
     const a = v.toArray();
     const iter = v.entries();
     for (let ii = 0; ii < len; ii++) {
-      delete a[ iter.next().value[0] ];
+      delete a[iter.next().value[0]];
     }
     expect(a).toEqual(new Array(len));
   });
@@ -342,14 +362,19 @@ describe('Map', () => {
     const m4 = m3.set('d', 4);
 
     expect(m1.toObject()).toEqual({});
-    expect(m2.toObject()).toEqual({a: 1});
-    expect(m3.toObject()).toEqual({a: 1, b: 2, c: 3});
-    expect(m4.toObject()).toEqual({a: 1, b: 2, c: 3, d: 4});
+    expect(m2.toObject()).toEqual({ a: 1 });
+    expect(m3.toObject()).toEqual({ a: 1, b: 2, c: 3 });
+    expect(m4.toObject()).toEqual({ a: 1, b: 2, c: 3, d: 4 });
   });
 
   it('chained mutations does not result in new empty map instance', () => {
-    const v1 = Map({x: 1});
-    const v2 = v1.withMutations(v => v.set('y', 2).delete('x').delete('y'));
+    const v1 = Map({ x: 1 });
+    const v2 = v1.withMutations(v =>
+      v
+        .set('y', 2)
+        .delete('x')
+        .delete('y')
+    );
     expect(v2).toBe(Map());
   });
 
@@ -362,10 +387,10 @@ describe('Map', () => {
   it('deletes all the provided keys', () => {
     const NOT_SET = undefined;
     const m1 = Map({ A: 1, B: 2, C: 3 });
-    const m2 = m1.deleteAll(["A", "B"]);
-    expect(m2.get("A")).toBe(NOT_SET);
-    expect(m2.get("B")).toBe(NOT_SET);
-    expect(m2.get("C")).toBe(3);
+    const m2 = m1.deleteAll(['A', 'B']);
+    expect(m2.get('A')).toBe(NOT_SET);
+    expect(m2.get('B')).toBe(NOT_SET);
+    expect(m2.get('C')).toBe(3);
     expect(m2.size).toBe(1);
   });
 
@@ -376,15 +401,14 @@ describe('Map', () => {
   });
 
   it('uses toString on keys and values', () => {
-    class A extends Record({x: null as number | null}) {
+    class A extends Record({ x: null as number | null }) {
       toString() {
         return this.x;
       }
     }
 
-    const r = new A({x: 2});
+    const r = new A({ x: 2 });
     const map = Map([[r, r]]);
     expect(map.toString()).toEqual('Map { 2: 2 }');
   });
-
 });

--- a/__tests__/ObjectSeq.ts
+++ b/__tests__/ObjectSeq.ts
@@ -10,34 +10,36 @@
 import { Seq } from '../';
 
 describe('ObjectSequence', () => {
-
   it('maps', () => {
-    const i = Seq({a: 'A', b: 'B', c: 'C'});
+    const i = Seq({ a: 'A', b: 'B', c: 'C' });
     const m = i.map(x => x + x).toObject();
-    expect(m).toEqual({a: 'AA', b: 'BB', c: 'CC'});
+    expect(m).toEqual({ a: 'AA', b: 'BB', c: 'CC' });
   });
 
   it('reduces', () => {
-    const i = Seq({a: 'A', b: 'B', c: 'C'});
+    const i = Seq({ a: 'A', b: 'B', c: 'C' });
     const r = i.reduce<string>((acc, x) => acc + x, '');
     expect(r).toEqual('ABC');
   });
 
   it('extracts keys', () => {
-    const i = Seq({a: 'A', b: 'B', c: 'C'});
+    const i = Seq({ a: 'A', b: 'B', c: 'C' });
     const k = i.keySeq().toArray();
     expect(k).toEqual(['a', 'b', 'c']);
   });
 
   it('is reversable', () => {
-    const i = Seq({a: 'A', b: 'B', c: 'C'});
+    const i = Seq({ a: 'A', b: 'B', c: 'C' });
     const k = i.reverse().toArray();
     expect(k).toEqual([['c', 'C'], ['b', 'B'], ['a', 'A']]);
   });
 
   it('is double reversable', () => {
-    const i = Seq({a: 'A', b: 'B', c: 'C'});
-    const k = i.reverse().reverse().toArray();
+    const i = Seq({ a: 'A', b: 'B', c: 'C' });
+    const k = i
+      .reverse()
+      .reverse()
+      .toArray();
     expect(k).toEqual([['a', 'A'], ['b', 'B'], ['c', 'C']]);
   });
 

--- a/__tests__/OrderedMap.ts
+++ b/__tests__/OrderedMap.ts
@@ -10,9 +10,8 @@
 import { OrderedMap, Seq } from '../';
 
 describe('OrderedMap', () => {
-
   it('converts from object', () => {
-    const m = OrderedMap({c: 'C', b: 'B', a: 'A'});
+    const m = OrderedMap({ c: 'C', b: 'B', a: 'A' });
     expect(m.get('a')).toBe('A');
     expect(m.get('b')).toBe('B');
     expect(m.get('c')).toBe('C');
@@ -20,7 +19,7 @@ describe('OrderedMap', () => {
   });
 
   it('constructor provides initial values', () => {
-    const m = OrderedMap({a: 'A', b: 'B', c: 'C'});
+    const m = OrderedMap({ a: 'A', b: 'B', c: 'C' });
     expect(m.get('a')).toBe('A');
     expect(m.get('b')).toBe('B');
     expect(m.get('c')).toBe('C');
@@ -29,7 +28,7 @@ describe('OrderedMap', () => {
   });
 
   it('provides initial values in a mixed order', () => {
-    const m = OrderedMap({c: 'C', b: 'B', a: 'A'});
+    const m = OrderedMap({ c: 'C', b: 'B', a: 'A' });
     expect(m.get('a')).toBe('A');
     expect(m.get('b')).toBe('B');
     expect(m.get('c')).toBe('C');
@@ -38,7 +37,7 @@ describe('OrderedMap', () => {
   });
 
   it('constructor accepts sequences', () => {
-    const s = Seq({c: 'C', b: 'B', a: 'A'});
+    const s = Seq({ c: 'C', b: 'B', a: 'A' });
     const m = OrderedMap(s);
     expect(m.get('a')).toBe('A');
     expect(m.get('b')).toBe('B');
@@ -69,7 +68,7 @@ describe('OrderedMap', () => {
   it('removes correctly', () => {
     const m = OrderedMap({
       A: 'aardvark',
-      Z: 'zebra',
+      Z: 'zebra'
     }).remove('A');
     expect(m.size).toBe(1);
     expect(m.get('A')).toBe(undefined);
@@ -77,21 +76,40 @@ describe('OrderedMap', () => {
   });
 
   it('respects order for equality', () => {
-    const m1 = OrderedMap().set('A', 'aardvark').set('Z', 'zebra');
-    const m2 = OrderedMap().set('Z', 'zebra').set('A', 'aardvark');
+    const m1 = OrderedMap()
+      .set('A', 'aardvark')
+      .set('Z', 'zebra');
+    const m2 = OrderedMap()
+      .set('Z', 'zebra')
+      .set('A', 'aardvark');
     expect(m1.equals(m2)).toBe(false);
     expect(m1.equals(m2.reverse())).toBe(true);
   });
 
   it('respects order when merging', () => {
-    const m1 = OrderedMap({A: 'apple', B: 'banana', C: 'coconut'});
-    const m2 = OrderedMap({C: 'chocolate', B: 'butter', D: 'donut'});
-    expect(m1.merge(m2).entrySeq().toArray()).toEqual(
-      [['A', 'apple'], ['B', 'butter'], ['C', 'chocolate'], ['D', 'donut']],
-    );
-    expect(m2.merge(m1).entrySeq().toArray()).toEqual(
-      [['C', 'coconut'], ['B', 'banana'], ['D', 'donut'], ['A', 'apple']],
-    );
+    const m1 = OrderedMap({ A: 'apple', B: 'banana', C: 'coconut' });
+    const m2 = OrderedMap({ C: 'chocolate', B: 'butter', D: 'donut' });
+    expect(
+      m1
+        .merge(m2)
+        .entrySeq()
+        .toArray()
+    ).toEqual([
+      ['A', 'apple'],
+      ['B', 'butter'],
+      ['C', 'chocolate'],
+      ['D', 'donut']
+    ]);
+    expect(
+      m2
+        .merge(m1)
+        .entrySeq()
+        .toArray()
+    ).toEqual([
+      ['C', 'coconut'],
+      ['B', 'banana'],
+      ['D', 'donut'],
+      ['A', 'apple']
+    ]);
   });
-
 });

--- a/__tests__/OrderedSet.ts
+++ b/__tests__/OrderedSet.ts
@@ -10,7 +10,6 @@
 import { OrderedSet } from '../';
 
 describe('OrderedSet', () => {
-
   it('provides initial values in a mixed order', () => {
     const s = OrderedSet.of('C', 'B', 'A');
     expect(s.has('A')).toBe(true);
@@ -40,7 +39,7 @@ describe('OrderedSet', () => {
   });
 
   it('removes correctly', () => {
-    const s = OrderedSet([ 'A', 'Z' ]).remove('A');
+    const s = OrderedSet(['A', 'Z']).remove('A');
     expect(s.size).toBe(1);
     expect(s.has('A')).toBe(false);
     expect(s.has('Z')).toBe(true);
@@ -64,7 +63,10 @@ describe('OrderedSet', () => {
     const s1 = OrderedSet.of('A', 'B', 'C');
     const s2 = OrderedSet.of('C', 'B', 'D');
     expect(s1.zip(s2).toArray()).toEqual([['A', 'C'], ['B', 'B'], ['C', 'D']]);
-    expect(s1.zipWith((c1, c2) => c1 + c2, s2).toArray()).toEqual(['AC', 'BB', 'CD']);
+    expect(s1.zipWith((c1, c2) => c1 + c2, s2).toArray()).toEqual([
+      'AC',
+      'BB',
+      'CD'
+    ]);
   });
-
 });

--- a/__tests__/Predicates.ts
+++ b/__tests__/Predicates.ts
@@ -10,7 +10,6 @@
 import { is, isImmutable, isValueObject, List, Map, Set, Stack } from '../';
 
 describe('isImmutable', () => {
-
   it('behaves as advertised', () => {
     expect(isImmutable([])).toBe(false);
     expect(isImmutable({})).toBe(false);
@@ -20,15 +19,13 @@ describe('isImmutable', () => {
     expect(isImmutable(Stack())).toBe(true);
     expect(isImmutable(Map().asMutable())).toBe(true);
   });
-
 });
 
 describe('isValueObject', () => {
-
   it('behaves as advertised', () => {
     expect(isValueObject(null)).toBe(false);
     expect(isValueObject(123)).toBe(false);
-    expect(isValueObject("abc")).toBe(false);
+    expect(isValueObject('abc')).toBe(false);
     expect(isValueObject([])).toBe(false);
     expect(isValueObject({})).toBe(false);
     expect(isValueObject(Map())).toBe(true);
@@ -57,7 +54,10 @@ describe('isValueObject', () => {
 
     expect(isValueObject(new MyValueType(123))).toBe(true);
     expect(is(new MyValueType(123), new MyValueType(123))).toBe(true);
-    expect(Set().add(new MyValueType(123)).add(new MyValueType(123)).size).toBe(1);
+    expect(
+      Set()
+        .add(new MyValueType(123))
+        .add(new MyValueType(123)).size
+    ).toBe(1);
   });
-
 });

--- a/__tests__/Range.ts
+++ b/__tests__/Range.ts
@@ -13,7 +13,6 @@ jasmineCheck.install();
 import { Range } from '../';
 
 describe('Range', () => {
-
   it('fixed range', () => {
     const v = Range(0, 3);
     expect(v.size).toBe(3);
@@ -42,9 +41,15 @@ describe('Range', () => {
     expect(v.last()).toBe(Infinity);
     expect(v.butLast().first()).toBe(10);
     expect(v.butLast().last()).toBe(Infinity);
-    expect(() => v.rest().toArray()).toThrow('Cannot perform this action with an infinite size.');
-    expect(() => v.butLast().toArray()).toThrow('Cannot perform this action with an infinite size.');
-    expect(() => v.toArray()).toThrow('Cannot perform this action with an infinite size.');
+    expect(() => v.rest().toArray()).toThrow(
+      'Cannot perform this action with an infinite size.'
+    );
+    expect(() => v.butLast().toArray()).toThrow(
+      'Cannot perform this action with an infinite size.'
+    );
+    expect(() => v.toArray()).toThrow(
+      'Cannot perform this action with an infinite size.'
+    );
   });
 
   it('backwards range', () => {
@@ -83,13 +88,14 @@ describe('Range', () => {
 
   const shrinkInt = gen.shrink(gen.int);
 
-  check.it('slices the same as array slices',
+  check.it(
+    'slices the same as array slices',
     [shrinkInt, shrinkInt, shrinkInt, shrinkInt],
     (from, to, begin, end) => {
       const r = Range(from, to);
       const a = r.toArray();
       expect(r.slice(begin, end).toArray()).toEqual(a.slice(begin, end));
-    },
+    }
   );
 
   it('slices range', () => {
@@ -165,10 +171,11 @@ describe('Range', () => {
 
   it('can describe lazy operations', () => {
     expect(
-      Range(1, Infinity).map(n => -n).take(5).toArray(),
-    ).toEqual(
-      [ -1, -2, -3, -4, -5 ],
-    );
+      Range(1, Infinity)
+        .map(n => -n)
+        .take(5)
+        .toArray()
+    ).toEqual([-1, -2, -3, -4, -5]);
   });
 
   it('efficiently chains array methods', () => {
@@ -182,5 +189,4 @@ describe('Range', () => {
 
     expect(r).toEqual(200);
   });
-
 });

--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -10,9 +10,8 @@
 import { isKeyed, Record, Seq } from '../';
 
 describe('Record', () => {
-
   it('defines a constructor', () => {
-    const MyType = Record({a: 1, b: 2, c: 3});
+    const MyType = Record({ a: 1, b: 2, c: 3 });
 
     const t1 = MyType();
     const t2 = t1.set('a', 10);
@@ -28,7 +27,7 @@ describe('Record', () => {
   });
 
   it('allows for a descriptive name', () => {
-    const Person = Record({name: null as string | null}, 'Person');
+    const Person = Record({ name: null as string | null }, 'Person');
 
     const me = Person({ name: 'My Name' });
     expect(me.toString()).toEqual('Person { name: "My Name" }');
@@ -47,9 +46,9 @@ describe('Record', () => {
   });
 
   it('setting an unknown key is a no-op', () => {
-    const MyType = Record({a: 1, b: 2, c: 3});
+    const MyType = Record({ a: 1, b: 2, c: 3 });
 
-    const t1 = new MyType({a: 10, b: 20});
+    const t1 = new MyType({ a: 10, b: 20 });
     const t2 = t1.set('d' as any, 4);
 
     expect(t2).toBe(t1);
@@ -83,7 +82,7 @@ describe('Record', () => {
   });
 
   it('is a value type and equals other similar Records', () => {
-    const MyType = Record({a: 1, b: 2, c: 3});
+    const MyType = Record({ a: 1, b: 2, c: 3 });
     const t1 = MyType({ a: 10 });
     const t2 = MyType({ a: 10, b: 2 });
     expect(t1.equals(t2));
@@ -97,35 +96,39 @@ describe('Record', () => {
   });
 
   it('merges in Objects and other Records', () => {
-    const Point2 = Record({x: 0, y: 0});
-    const Point3 = Record({x: 0, y: 0, z: 0});
+    const Point2 = Record({ x: 0, y: 0 });
+    const Point3 = Record({ x: 0, y: 0, z: 0 });
 
-    const p2 = Point2({x: 20, y: 20});
-    const p3 = Point3({x: 10, y: 10, z: 10});
+    const p2 = Point2({ x: 20, y: 20 });
+    const p3 = Point3({ x: 10, y: 10, z: 10 });
 
-    expect(p3.merge(p2).toObject()).toEqual({x: 20, y: 20, z: 10});
+    expect(p3.merge(p2).toObject()).toEqual({ x: 20, y: 20, z: 10 });
 
-    expect(p2.merge({y: 30}).toObject()).toEqual({x: 20, y: 30});
-    expect(p3.merge({y: 30, z: 30}).toObject()).toEqual({x: 10, y: 30, z: 30});
+    expect(p2.merge({ y: 30 }).toObject()).toEqual({ x: 20, y: 30 });
+    expect(p3.merge({ y: 30, z: 30 }).toObject()).toEqual({
+      x: 10,
+      y: 30,
+      z: 30
+    });
   });
 
   it('converts sequences to records', () => {
-    const MyType = Record({a: 1, b: 2, c: 3});
-    const seq = Seq({a: 10, b: 20});
+    const MyType = Record({ a: 1, b: 2, c: 3 });
+    const seq = Seq({ a: 10, b: 20 });
     const t = new MyType(seq);
-    expect(t.toObject()).toEqual({a: 10, b: 20, c: 3});
+    expect(t.toObject()).toEqual({ a: 10, b: 20, c: 3 });
   });
 
   it('allows for functional construction', () => {
-    const MyType = Record({a: 1, b: 2, c: 3});
-    const seq = Seq({a: 10, b: 20});
+    const MyType = Record({ a: 1, b: 2, c: 3 });
+    const seq = Seq({ a: 10, b: 20 });
     const t = MyType(seq);
-    expect(t.toObject()).toEqual({a: 10, b: 20, c: 3});
+    expect(t.toObject()).toEqual({ a: 10, b: 20, c: 3 });
   });
 
   it('skips unknown keys', () => {
-    const MyType = Record({a: 1, b: 2});
-    const seq = Seq({b: 20, c: 30});
+    const MyType = Record({ a: 1, b: 2 });
+    const seq = Seq({ b: 20, c: 30 });
     const t = new MyType(seq);
 
     expect(t.get('a')).toEqual(1);
@@ -134,9 +137,9 @@ describe('Record', () => {
   });
 
   it('returns itself when setting identical values', () => {
-    const MyType = Record({a: 1, b: 2});
+    const MyType = Record({ a: 1, b: 2 });
     const t1 = new MyType();
-    const t2 = new MyType({a: 1});
+    const t2 = new MyType({ a: 1 });
     const t3 = t1.set('a', 1);
     const t4 = t2.set('a', 1);
     expect(t3).toBe(t1);
@@ -144,9 +147,9 @@ describe('Record', () => {
   });
 
   it('returns new record when setting new values', () => {
-    const MyType = Record({a: 1, b: 2});
+    const MyType = Record({ a: 1, b: 2 });
     const t1 = new MyType();
-    const t2 = new MyType({a: 1});
+    const t2 = new MyType({ a: 1 });
     const t3 = t1.set('a', 3);
     const t4 = t2.set('a', 3);
     expect(t3).not.toBe(t1);
@@ -154,17 +157,19 @@ describe('Record', () => {
   });
 
   it('allows for readonly property access', () => {
-    const MyType = Record({a: 1, b: 'foo'});
+    const MyType = Record({ a: 1, b: 'foo' });
     const t1 = new MyType();
     const a: number = t1.a;
     const b: string = t1.b;
     expect(a).toEqual(1);
     expect(b).toEqual('foo');
-    expect(() => (t1 as any).a = 2).toThrow("Cannot set on an immutable record.");
+    expect(() => ((t1 as any).a = 2)).toThrow(
+      'Cannot set on an immutable record.'
+    );
   });
 
   it('allows for class extension', () => {
-    class ABClass extends Record({a: 1, b: 2}) {
+    class ABClass extends Record({ a: 1, b: 2 }) {
       setA(aVal: number) {
         return this.set('a', aVal);
       }
@@ -174,13 +179,13 @@ describe('Record', () => {
       }
     }
 
-    const t1 = new ABClass({a: 1});
+    const t1 = new ABClass({ a: 1 });
     const t2 = t1.setA(3);
     const t3 = t2.setB(10);
 
     const a: number = t3.a;
     expect(a).toEqual(3);
-    expect(t3.toObject()).toEqual({a: 3, b: 10});
+    expect(t3.toObject()).toEqual({ a: 3, b: 10 });
   });
 
   it('does not allow overwriting property names', () => {
@@ -191,17 +196,17 @@ describe('Record', () => {
       console.warn = w => warnings.push(w);
 
       // size is a safe key to use
-      const MyType1 = Record({size: 123});
+      const MyType1 = Record({ size: 123 });
       const t1 = MyType1();
       expect(warnings.length).toBe(0);
       expect(t1.size).toBe(123);
 
       // get() is not safe to use
-      const MyType2 = Record({get: 0});
+      const MyType2 = Record({ get: 0 });
       const t2 = MyType2();
       expect(warnings.length).toBe(1);
       expect(warnings[0]).toBe(
-        'Cannot define Record with property "get" since that property name is part of the Record API.',
+        'Cannot define Record with property "get" since that property name is part of the Record API.'
       );
     } finally {
       console.warn = realWarn;
@@ -209,20 +214,20 @@ describe('Record', () => {
   });
 
   it('can be converted to a keyed sequence', () => {
-    const MyType = Record({a: 0, b: 0});
-    const t1 = MyType({a: 10, b: 20});
+    const MyType = Record({ a: 0, b: 0 });
+    const t1 = MyType({ a: 10, b: 20 });
 
     const seq1 = t1.toSeq();
     expect(isKeyed(seq1)).toBe(true);
-    expect(seq1.toJS()).toEqual({a: 10, b: 20});
+    expect(seq1.toJS()).toEqual({ a: 10, b: 20 });
 
     const seq2 = Seq(t1);
     expect(isKeyed(seq2)).toBe(true);
-    expect(seq2.toJS()).toEqual({a: 10, b: 20});
+    expect(seq2.toJS()).toEqual({ a: 10, b: 20 });
 
     const seq3 = Seq.Keyed(t1);
     expect(isKeyed(seq3)).toBe(true);
-    expect(seq3.toJS()).toEqual({a: 10, b: 20});
+    expect(seq3.toJS()).toEqual({ a: 10, b: 20 });
 
     const seq4 = Seq.Indexed(t1);
     expect(isKeyed(seq4)).toBe(false);
@@ -230,18 +235,14 @@ describe('Record', () => {
   });
 
   it('can be iterated over', () => {
-    const MyType = Record({a: 0, b: 0});
-    const t1 = MyType({a: 10, b: 20});
+    const MyType = Record({ a: 0, b: 0 });
+    const t1 = MyType({ a: 10, b: 20 });
 
     const entries: Array<any> = [];
     for (const entry of t1) {
       entries.push(entry);
     }
 
-    expect(entries).toEqual([
-      [ 'a', 10 ],
-      [ 'b', 20 ],
-    ]);
+    expect(entries).toEqual([['a', 10], ['b', 20]]);
   });
-
 });

--- a/__tests__/Repeat.ts
+++ b/__tests__/Repeat.ts
@@ -10,7 +10,6 @@
 import { Repeat } from '../';
 
 describe('Repeat', () => {
-
   it('fixed repeat', () => {
     const v = Repeat('wtf', 3);
     expect(v.size).toBe(3);
@@ -21,5 +20,4 @@ describe('Repeat', () => {
     expect(v.toArray()).toEqual(['wtf', 'wtf', 'wtf']);
     expect(v.join()).toEqual('wtf,wtf,wtf');
   });
-
 });

--- a/__tests__/Seq.ts
+++ b/__tests__/Seq.ts
@@ -10,7 +10,6 @@
 import { isCollection, isIndexed, Seq } from '../';
 
 describe('Seq', () => {
-
   it('can be empty', () => {
     expect(Seq().size).toBe(0);
   });
@@ -20,7 +19,7 @@ describe('Seq', () => {
   });
 
   it('accepts an object', () => {
-    expect(Seq({a: 1, b: 2, c: 3}).size).toBe(3);
+    expect(Seq({ a: 1, b: 2, c: 3 }).size).toBe(3);
   });
 
   it('accepts a collection string', () => {
@@ -58,7 +57,9 @@ describe('Seq', () => {
   it('does not accept a scalar', () => {
     expect(() => {
       Seq(3 as any);
-    }).toThrow('Expected Array or collection object of values, or keyed object: 3');
+    }).toThrow(
+      'Expected Array or collection object of values, or keyed object: 3'
+    );
   });
 
   it('detects sequences', () => {
@@ -86,15 +87,10 @@ describe('Seq', () => {
   });
 
   it('Converts deeply toJS after converting to entries', () => {
-    const list = Seq([Seq([1, 2]), Seq({a: 'z'})]);
-    expect(list.entrySeq().toJS()).toEqual(
-      [[0, [1, 2]], [1, {a: 'z'}]],
-    );
+    const list = Seq([Seq([1, 2]), Seq({ a: 'z' })]);
+    expect(list.entrySeq().toJS()).toEqual([[0, [1, 2]], [1, { a: 'z' }]]);
 
-    const map = Seq({x: Seq([1, 2]), y: Seq({a: 'z'})});
-    expect(map.entrySeq().toJS()).toEqual(
-      [['x', [1, 2]], ['y', {a: 'z'}]],
-    );
+    const map = Seq({ x: Seq([1, 2]), y: Seq({ a: 'z' }) });
+    expect(map.entrySeq().toJS()).toEqual([['x', [1, 2]], ['y', { a: 'z' }]]);
   });
-
 });

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -46,7 +46,7 @@ describe('Set', () => {
   });
 
   it('accepts a keyed Seq as a set of entries', () => {
-    const seq = Seq({a: null, b: null, c: null}).flip();
+    const seq = Seq({ a: null, b: null, c: null }).flip();
     const s = Set(seq);
     expect(s.toArray()).toEqual([[null, 'a'], [null, 'b'], [null, 'c']]);
     // Explicitly getting the values sequence
@@ -58,7 +58,7 @@ describe('Set', () => {
   });
 
   it('accepts object keys', () => {
-    const s = Set.fromKeys({a: null, b: null, c: null});
+    const s = Set.fromKeys({ a: null, b: null, c: null });
     expect(s.has('a')).toBe(true);
     expect(s.has('b')).toBe(true);
     expect(s.has('c')).toBe(true);
@@ -66,7 +66,7 @@ describe('Set', () => {
   });
 
   it('accepts sequence keys', () => {
-    const seq = Seq({a: null, b: null, c: null});
+    const seq = Seq({ a: null, b: null, c: null });
     const s = Set.fromKeys(seq);
     expect(s.has('a')).toBe(true);
     expect(s.has('b')).toBe(true);
@@ -89,7 +89,7 @@ describe('Set', () => {
 
   it('converts back to JS object', () => {
     const s = Set.of('a', 'b', 'c');
-    expect(s.toObject()).toEqual({a: 'a', b: 'b', c: 'c'});
+    expect(s.toObject()).toEqual({ a: 'a', b: 'b', c: 'c' });
   });
 
   it('unions an unknown collection of Sets', () => {
@@ -112,11 +112,7 @@ describe('Set', () => {
     const s = Set([1, 2, 3]);
     const iterator = jest.genMockFunction();
     s.forEach(iterator);
-    expect(iterator.mock.calls).toEqual([
-      [1, 1, s],
-      [2, 2, s],
-      [3, 3, s],
-    ]);
+    expect(iterator.mock.calls).toEqual([[1, 1, s], [2, 2, s], [3, 3, s]]);
   });
 
   it('unions two sets', () => {
@@ -189,17 +185,26 @@ describe('Set', () => {
   });
 
   it('unions multiple sets', () => {
-    const s = Set.of('A', 'B', 'C').union(Set.of('C', 'D', 'E'), Set.of('D', 'B', 'F'));
+    const s = Set.of('A', 'B', 'C').union(
+      Set.of('C', 'D', 'E'),
+      Set.of('D', 'B', 'F')
+    );
     expect(s).toEqual(Set.of('A', 'B', 'C', 'D', 'E', 'F'));
   });
 
   it('intersects multiple sets', () => {
-    const s = Set.of('A', 'B', 'C').intersect(Set.of('B', 'C', 'D'), Set.of('A', 'C', 'E'));
+    const s = Set.of('A', 'B', 'C').intersect(
+      Set.of('B', 'C', 'D'),
+      Set.of('A', 'C', 'E')
+    );
     expect(s).toEqual(Set.of('C'));
   });
 
   it('diffs multiple sets', () => {
-    const s = Set.of('A', 'B', 'C').subtract(Set.of('C', 'D', 'E'), Set.of('D', 'B', 'F'));
+    const s = Set.of('A', 'B', 'C').subtract(
+      Set.of('C', 'D', 'E'),
+      Set.of('D', 'B', 'F')
+    );
     expect(s).toEqual(Set.of('A'));
   });
 
@@ -218,10 +223,12 @@ describe('Set', () => {
   });
 
   it('can use union in a withMutation', () => {
-    const js = Set().withMutations(set => {
-      set.union([ 'a' ]);
-      set.add('b');
-    }).toJS();
+    const js = Set()
+      .withMutations(set => {
+        set.union(['a']);
+        set.add('b');
+      })
+      .toJS();
     expect(js).toEqual(['a', 'b']);
   });
 
@@ -246,7 +253,7 @@ describe('Set', () => {
       const b = Symbol();
       const c = Symbol();
 
-      const symbolSet = Set([ a, b, c, a, b, c, a, b, c, a, b, c ]);
+      const symbolSet = Set([a, b, c, a, b, c, a, b, c, a, b, c]);
       expect(symbolSet.size).toBe(3);
       expect(symbolSet.has(b)).toBe(true);
       expect(symbolSet.get(c)).toEqual(c);
@@ -254,10 +261,18 @@ describe('Set', () => {
 
     it('operates on a large number of symbols, maintaining obj uniqueness', () => {
       const manySymbols = [
-        Symbol('a'), Symbol('b'), Symbol('c'),
-        Symbol('a'), Symbol('b'), Symbol('c'),
-        Symbol('a'), Symbol('b'), Symbol('c'),
-        Symbol('a'), Symbol('b'), Symbol('c'),
+        Symbol('a'),
+        Symbol('b'),
+        Symbol('c'),
+        Symbol('a'),
+        Symbol('b'),
+        Symbol('c'),
+        Symbol('a'),
+        Symbol('b'),
+        Symbol('c'),
+        Symbol('a'),
+        Symbol('b'),
+        Symbol('c')
       ];
 
       const symbolSet = Set(manySymbols);
@@ -265,7 +280,6 @@ describe('Set', () => {
       expect(symbolSet.has(manySymbols[10])).toBe(true);
       expect(symbolSet.get(manySymbols[10])).toEqual(manySymbols[10]);
     });
-
   });
 
   it('can use intersect after add or union in a withMutation', () => {
@@ -278,11 +292,10 @@ describe('Set', () => {
   });
 
   it('can count entries that satisfy a predicate', () => {
-    const set = Set( [1, 2, 3, 4, 5 ]);
+    const set = Set([1, 2, 3, 4, 5]);
     expect(set.size).toEqual(5);
     expect(set.count()).toEqual(5);
     expect(set.count(x => x % 2 === 0)).toEqual(2);
     expect(set.count(x => true)).toEqual(5);
   });
-
 });

--- a/__tests__/Stack.ts
+++ b/__tests__/Stack.ts
@@ -21,7 +21,6 @@ function arrayOfSize(s) {
 }
 
 describe('Stack', () => {
-
   it('constructor provides initial values', () => {
     const s = Stack.of('a', 'b', 'c');
     expect(s.get(0)).toBe('a');
@@ -46,7 +45,7 @@ describe('Stack', () => {
   });
 
   it('accepts a keyed Seq', () => {
-    const seq = Seq({a: null, b: null, c: null}).flip();
+    const seq = Seq({ a: null, b: null, c: null }).flip();
     const s = Stack(seq);
     expect(s.toArray()).toEqual([[null, 'a'], [null, 'b'], [null, 'c']]);
     // Explicit values
@@ -85,15 +84,11 @@ describe('Stack', () => {
     expect(forEachResults).toEqual([
       [0, 'a', 'a'],
       [1, 'b', 'b'],
-      [2, 'c', 'c'],
+      [2, 'c', 'c']
     ]);
 
     // map will cause reverse iterate
-    expect(s.map(val => val + val).toArray()).toEqual([
-      'aa',
-      'bb',
-      'cc',
-    ]);
+    expect(s.map(val => val + val).toArray()).toEqual(['aa', 'bb', 'cc']);
 
     let iteratorResults: Array<any> = [];
     let iterator = s.entries();
@@ -101,22 +96,17 @@ describe('Stack', () => {
     while (!(step = iterator.next()).done) {
       iteratorResults.push(step.value);
     }
-    expect(iteratorResults).toEqual([
-      [0, 'a'],
-      [1, 'b'],
-      [2, 'c'],
-    ]);
+    expect(iteratorResults).toEqual([[0, 'a'], [1, 'b'], [2, 'c']]);
 
     iteratorResults = [];
-    iterator = s.toSeq().reverse().entries();
+    iterator = s
+      .toSeq()
+      .reverse()
+      .entries();
     while (!(step = iterator.next()).done) {
       iteratorResults.push(step.value);
     }
-    expect(iteratorResults).toEqual([
-      [0, 'c'],
-      [1, 'b'],
-      [2, 'a'],
-    ]);
+    expect(iteratorResults).toEqual([[0, 'c'], [1, 'b'], [2, 'a']]);
   });
 
   it('map is called in reverse order but with correct indices', () => {
@@ -140,11 +130,14 @@ describe('Stack', () => {
   it('pop removes the lowest index, decrementing size', () => {
     const s = Stack.of('a', 'b', 'c').pop();
     expect(s.peek()).toBe('b');
-    expect(s.toArray()).toEqual([ 'b', 'c' ]);
+    expect(s.toArray()).toEqual(['b', 'c']);
   });
 
-  check.it('shift removes the lowest index, just like array', {maxSize: 2000},
-    [gen.posInt], len => {
+  check.it(
+    'shift removes the lowest index, just like array',
+    { maxSize: 2000 },
+    [gen.posInt],
+    len => {
       const a = arrayOfSize(len);
       let s = Stack(a);
 
@@ -156,11 +149,14 @@ describe('Stack', () => {
       }
       expect(s.size).toBe(a.length);
       expect(s.toArray()).toEqual(a);
-    },
+    }
   );
 
-  check.it('unshift adds the next lowest index, just like array', {maxSize: 2000},
-    [gen.posInt], len => {
+  check.it(
+    'unshift adds the next lowest index, just like array',
+    { maxSize: 2000 },
+    [gen.posInt],
+    len => {
       const a: Array<any> = [];
       let s = Stack();
 
@@ -172,11 +168,14 @@ describe('Stack', () => {
       }
       expect(s.size).toBe(a.length);
       expect(s.toArray()).toEqual(a);
-    },
+    }
   );
 
-  check.it('unshifts multiple values to the front', {maxSize: 2000},
-    [gen.posInt, gen.posInt], (size1: number, size2: number) => {
+  check.it(
+    'unshifts multiple values to the front',
+    { maxSize: 2000 },
+    [gen.posInt, gen.posInt],
+    (size1: number, size2: number) => {
       const a1 = arrayOfSize(size1);
       const a2 = arrayOfSize(size2);
 
@@ -188,7 +187,7 @@ describe('Stack', () => {
 
       expect(s3.size).toEqual(a3.length);
       expect(s3.toArray()).toEqual(a3);
-    },
+    }
   );
 
   it('finds values using indexOf', () => {
@@ -199,17 +198,28 @@ describe('Stack', () => {
   });
 
   it('pushes on all items in an iter', () => {
-    const abc = Stack([ 'a', 'b', 'c' ]);
-    const xyz = Stack([ 'x', 'y', 'z' ]);
-    const xyzSeq = Seq([ 'x', 'y', 'z' ]);
+    const abc = Stack(['a', 'b', 'c']);
+    const xyz = Stack(['x', 'y', 'z']);
+    const xyzSeq = Seq(['x', 'y', 'z']);
 
     // Push all to the front of the Stack so first item ends up first.
-    expect(abc.pushAll(xyz).toArray()).toEqual([ 'x', 'y', 'z', 'a', 'b', 'c' ]);
-    expect(abc.pushAll(xyzSeq).toArray()).toEqual([ 'x', 'y', 'z', 'a', 'b', 'c' ]);
+    expect(abc.pushAll(xyz).toArray()).toEqual(['x', 'y', 'z', 'a', 'b', 'c']);
+    expect(abc.pushAll(xyzSeq).toArray()).toEqual([
+      'x',
+      'y',
+      'z',
+      'a',
+      'b',
+      'c'
+    ]);
 
     // Pushes Seq contents into Stack
     expect(Stack().pushAll(xyzSeq)).not.toBe(xyzSeq);
-    expect(Stack().pushAll(xyzSeq).toArray()).toEqual([ 'x', 'y', 'z' ]);
+    expect(
+      Stack()
+        .pushAll(xyzSeq)
+        .toArray()
+    ).toEqual(['x', 'y', 'z']);
 
     // Pushing a Stack onto an empty Stack returns === Stack
     expect(Stack().pushAll(xyz)).toBe(xyz);
@@ -217,5 +227,4 @@ describe('Stack', () => {
     // Pushing an empty Stack onto a Stack return === Stack
     expect(abc.pushAll(Stack())).toBe(abc);
   });
-
 });

--- a/__tests__/concat.ts
+++ b/__tests__/concat.ts
@@ -10,7 +10,6 @@
 import { is, List, Seq, Set } from '../';
 
 describe('concat', () => {
-
   it('concats two sequences', () => {
     const a = Seq([1, 2, 3]);
     const b = Seq([4, 5, 6]);
@@ -20,21 +19,35 @@ describe('concat', () => {
   });
 
   it('concats two object sequences', () => {
-    const a = Seq({a: 1, b: 2, c: 3});
-    const b = Seq({d: 4, e: 5, f: 6});
+    const a = Seq({ a: 1, b: 2, c: 3 });
+    const b = Seq({ d: 4, e: 5, f: 6 });
     expect(a.size).toBe(3);
     expect(a.concat(b).size).toBe(6);
-    expect(a.concat(b).toObject()).toEqual({a: 1, b: 2, c: 3, d: 4, e: 5, f: 6});
+    expect(a.concat(b).toObject()).toEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+      e: 5,
+      f: 6
+    });
   });
 
   it('concats objects to keyed seq', () => {
-    const a = Seq({a: 1, b: 2, c: 3});
-    const b = {d: 4, e: 5, f: 6};
-    expect(a.concat(b).toObject()).toEqual({a: 1, b: 2, c: 3, d: 4, e: 5, f: 6});
+    const a = Seq({ a: 1, b: 2, c: 3 });
+    const b = { d: 4, e: 5, f: 6 };
+    expect(a.concat(b).toObject()).toEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+      e: 5,
+      f: 6
+    });
   });
 
   it('doesnt concat raw arrays to keyed seq', () => {
-    const a = Seq({a: 1, b: 2, c: 3});
+    const a = Seq({ a: 1, b: 2, c: 3 });
     const b = [4, 5, 6];
     expect(() => {
       a.concat(b as any).toJS();
@@ -56,11 +69,11 @@ describe('concat', () => {
 
   it('doesnt concat objects to indexed seq', () => {
     const a = Seq([0, 1, 2, 3]);
-    const b = {4: 4};
+    const b = { 4: 4 };
     const i = a.concat(b);
     expect(i.size).toBe(5);
     expect(i.get(4)).toBe(b);
-    expect(i.toArray()).toEqual([0, 1, 2, 3, {4: 4}]);
+    expect(i.toArray()).toEqual([0, 1, 2, 3, { 4: 4 }]);
   });
 
   it('concats multiple arguments', () => {
@@ -102,42 +115,89 @@ describe('concat', () => {
   });
 
   it('iterates repeated keys', () => {
-    const a = Seq({a: 1, b: 2, c: 3});
-    expect(a.concat(a, a).toObject()).toEqual({a: 1, b: 2, c: 3});
-    expect(a.concat(a, a).valueSeq().toArray()).toEqual([1, 2, 3, 1, 2, 3, 1, 2, 3]);
-    expect(a.concat(a, a).keySeq().toArray()).toEqual(['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c']);
-    expect(a.concat(a, a).toArray()).toEqual(
-      [['a', 1], ['b', 2], ['c', 3], ['a', 1], ['b', 2], ['c', 3], ['a', 1], ['b', 2], ['c', 3]],
-    );
+    const a = Seq({ a: 1, b: 2, c: 3 });
+    expect(a.concat(a, a).toObject()).toEqual({ a: 1, b: 2, c: 3 });
+    expect(
+      a
+        .concat(a, a)
+        .valueSeq()
+        .toArray()
+    ).toEqual([1, 2, 3, 1, 2, 3, 1, 2, 3]);
+    expect(
+      a
+        .concat(a, a)
+        .keySeq()
+        .toArray()
+    ).toEqual(['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c']);
+    expect(a.concat(a, a).toArray()).toEqual([
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+      ['a', 1],
+      ['b', 2],
+      ['c', 3],
+      ['a', 1],
+      ['b', 2],
+      ['c', 3]
+    ]);
   });
 
   it('lazily reverses un-indexed sequences', () => {
-    const a = Seq({a: 1, b: 2, c: 3});
-    const b = Seq({d: 4, e: 5, f: 6});
-    expect(a.concat(b).reverse().keySeq().toArray()).toEqual(['f', 'e', 'd', 'c', 'b', 'a']);
+    const a = Seq({ a: 1, b: 2, c: 3 });
+    const b = Seq({ d: 4, e: 5, f: 6 });
+    expect(
+      a
+        .concat(b)
+        .reverse()
+        .keySeq()
+        .toArray()
+    ).toEqual(['f', 'e', 'd', 'c', 'b', 'a']);
   });
 
   it('lazily reverses indexed sequences', () => {
     const a = Seq([1, 2, 3]);
     expect(a.concat(a, a).reverse().size).toBe(9);
-    expect(a.concat(a, a).reverse().toArray()).toEqual([3, 2, 1, 3, 2, 1, 3, 2, 1]);
+    expect(
+      a
+        .concat(a, a)
+        .reverse()
+        .toArray()
+    ).toEqual([3, 2, 1, 3, 2, 1, 3, 2, 1]);
   });
 
   it('lazily reverses indexed sequences with unknown size, maintaining indicies', () => {
     const a = Seq([1, 2, 3]).filter(x => true);
     expect(a.size).toBe(undefined); // Note: lazy filter does not know what size in O(1).
-    expect(a.concat(a, a).toKeyedSeq().reverse().size).toBe(undefined);
-    expect(a.concat(a, a).toKeyedSeq().reverse().toArray()).toEqual(
-      [[8, 3], [7, 2], [6, 1], [5, 3], [4, 2], [3, 1], [2, 3], [1, 2], [0, 1]],
-    );
+    expect(
+      a
+        .concat(a, a)
+        .toKeyedSeq()
+        .reverse().size
+    ).toBe(undefined);
+    expect(
+      a
+        .concat(a, a)
+        .toKeyedSeq()
+        .reverse()
+        .toArray()
+    ).toEqual([
+      [8, 3],
+      [7, 2],
+      [6, 1],
+      [5, 3],
+      [4, 2],
+      [3, 1],
+      [2, 3],
+      [1, 2],
+      [0, 1]
+    ]);
   });
 
   it('counts from the end of the indexed sequence on negative index', () => {
-    const i = List.of(9, 5, 3, 1).map(x => - x);
+    const i = List.of(9, 5, 3, 1).map(x => -x);
     expect(i.get(0)).toBe(-9);
     expect(i.get(-1)).toBe(-1);
     expect(i.get(-4)).toBe(-9);
     expect(i.get(-5, 888)).toBe(888);
   });
-
 });

--- a/__tests__/count.ts
+++ b/__tests__/count.ts
@@ -10,7 +10,6 @@
 import { Range, Seq } from '../';
 
 describe('count', () => {
-
   it('counts sequences with known lengths', () => {
     expect(Seq([1, 2, 3, 4, 5]).size).toBe(5);
     expect(Seq([1, 2, 3, 4, 5]).count()).toBe(5);
@@ -30,33 +29,30 @@ describe('count', () => {
   });
 
   describe('countBy', () => {
-
     it('counts by keyed sequence', () => {
-      const grouped = Seq({a: 1, b: 2, c: 3, d: 4}).countBy(x => x % 2);
-      expect(grouped.toJS()).toEqual({1: 2, 0: 2});
+      const grouped = Seq({ a: 1, b: 2, c: 3, d: 4 }).countBy(x => x % 2);
+      expect(grouped.toJS()).toEqual({ 1: 2, 0: 2 });
       expect(grouped.get(1)).toEqual(2);
     });
 
     it('counts by indexed sequence', () => {
       expect(
-        Seq([1, 2, 3, 4, 5, 6]).countBy(x => x % 2).toJS(),
-      ).toEqual(
-        {1: 3, 0: 3},
-      );
+        Seq([1, 2, 3, 4, 5, 6])
+          .countBy(x => x % 2)
+          .toJS()
+      ).toEqual({ 1: 3, 0: 3 });
     });
 
     it('counts by specific keys', () => {
       expect(
-        Seq([1, 2, 3, 4, 5, 6]).countBy(x => x % 2 ? 'odd' : 'even').toJS(),
-      ).toEqual(
-        {odd: 3, even: 3},
-      );
+        Seq([1, 2, 3, 4, 5, 6])
+          .countBy(x => (x % 2 ? 'odd' : 'even'))
+          .toJS()
+      ).toEqual({ odd: 3, even: 3 });
     });
-
   });
 
   describe('isEmpty', () => {
-
     it('is O(1) on sequences with known lengths', () => {
       expect(Seq([1, 2, 3, 4, 5]).size).toBe(5);
       expect(Seq([1, 2, 3, 4, 5]).isEmpty()).toBe(false);
@@ -88,7 +84,5 @@ describe('count', () => {
       expect(seq.isEmpty()).toBe(false);
       expect(seq.size).toBe(undefined);
     });
-
   });
-
 });

--- a/__tests__/find.ts
+++ b/__tests__/find.ts
@@ -13,23 +13,39 @@ jasmineCheck.install();
 import { List, Range, Seq } from '../';
 
 describe('find', () => {
-
   it('find returns notSetValue when match is not found', () => {
-    expect(Seq([1, 2, 3, 4, 5, 6]).find(function() {
-      return false;
-    }, null, 9)).toEqual(9);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6]).find(
+        function() {
+          return false;
+        },
+        null,
+        9
+      )
+    ).toEqual(9);
   });
 
   it('findEntry returns notSetValue when match is not found', () => {
-    expect(Seq([1, 2, 3, 4, 5, 6]).findEntry(function() {
-      return false;
-    }, null, 9)).toEqual(9);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6]).findEntry(
+        function() {
+          return false;
+        },
+        null,
+        9
+      )
+    ).toEqual(9);
   });
 
   it('findLastEntry returns notSetValue when match is not found', () => {
-    expect(Seq([1, 2, 3, 4, 5, 6]).findLastEntry(function() {
-      return false;
-    }, null, 9)).toEqual(9);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6]).findLastEntry(
+        function() {
+          return false;
+        },
+        null,
+        9
+      )
+    ).toEqual(9);
   });
-
 });

--- a/__tests__/flatten.ts
+++ b/__tests__/flatten.ts
@@ -13,7 +13,6 @@ jasmineCheck.install();
 import { Collection, fromJS, List, Range, Seq } from '../';
 
 describe('flatten', () => {
-
   it('flattens sequences one level deep', () => {
     const nested = fromJS([[1, 2], [3, 4], [5, 6]]);
     const flat = nested.flatten();
@@ -23,7 +22,7 @@ describe('flatten', () => {
   it('flattening a List returns a List', () => {
     const nested = fromJS([[1], 2, 3, [4, 5, 6]]);
     const flat = nested.flatten();
-    expect(flat.toString()).toEqual("List [ 1, 2, 3, 4, 5, 6 ]");
+    expect(flat.toString()).toEqual('List [ 1, 2, 3, 4, 5, 6 ]');
   });
 
   it('gives the correct iteration count', () => {
@@ -48,84 +47,59 @@ describe('flatten', () => {
   });
 
   it('can flatten at various levels of depth', () => {
-    const deeplyNested = fromJS(
-      [
-        [
-          [
-            [ 'A', 'B' ],
-            [ 'A', 'B' ],
-          ],
-          [
-            [ 'A', 'B' ],
-            [ 'A', 'B' ],
-          ],
-        ],
-        [
-          [
-            [ 'A', 'B' ],
-            [ 'A', 'B' ],
-          ],
-          [
-            [ 'A', 'B' ],
-            [ 'A', 'B' ],
-          ],
-        ],
-      ],
-    );
+    const deeplyNested = fromJS([
+      [[['A', 'B'], ['A', 'B']], [['A', 'B'], ['A', 'B']]],
+      [[['A', 'B'], ['A', 'B']], [['A', 'B'], ['A', 'B']]]
+    ]);
 
     // deeply flatten
-    expect(deeplyNested.flatten().toJS()).toEqual(
-      ['A', 'B', 'A', 'B', 'A', 'B', 'A', 'B', 'A', 'B', 'A', 'B', 'A', 'B', 'A', 'B'],
-    );
+    expect(deeplyNested.flatten().toJS()).toEqual([
+      'A',
+      'B',
+      'A',
+      'B',
+      'A',
+      'B',
+      'A',
+      'B',
+      'A',
+      'B',
+      'A',
+      'B',
+      'A',
+      'B',
+      'A',
+      'B'
+    ]);
 
     // shallow flatten
-    expect(deeplyNested.flatten(true).toJS()).toEqual(
-      [
-        [
-          [ 'A', 'B' ],
-          [ 'A', 'B' ],
-        ],
-        [
-          [ 'A', 'B' ],
-          [ 'A', 'B' ],
-        ],
-        [
-          [ 'A', 'B' ],
-          [ 'A', 'B' ],
-        ],
-        [
-          [ 'A', 'B' ],
-          [ 'A', 'B' ],
-        ],
-      ],
-    );
+    expect(deeplyNested.flatten(true).toJS()).toEqual([
+      [['A', 'B'], ['A', 'B']],
+      [['A', 'B'], ['A', 'B']],
+      [['A', 'B'], ['A', 'B']],
+      [['A', 'B'], ['A', 'B']]
+    ]);
 
     // flatten two levels
-    expect(deeplyNested.flatten(2).toJS()).toEqual(
-      [
-        [ 'A', 'B' ],
-        [ 'A', 'B' ],
-        [ 'A', 'B' ],
-        [ 'A', 'B' ],
-        [ 'A', 'B' ],
-        [ 'A', 'B' ],
-        [ 'A', 'B' ],
-        [ 'A', 'B' ],
-      ],
-    );
+    expect(deeplyNested.flatten(2).toJS()).toEqual([
+      ['A', 'B'],
+      ['A', 'B'],
+      ['A', 'B'],
+      ['A', 'B'],
+      ['A', 'B'],
+      ['A', 'B'],
+      ['A', 'B'],
+      ['A', 'B']
+    ]);
   });
 
   describe('flatMap', () => {
-
     it('first maps, then shallow flattens', () => {
       const numbers = Range(97, 100);
-      const letters = numbers.flatMap(v => fromJS([
-        String.fromCharCode(v),
-        String.fromCharCode(v).toUpperCase(),
-      ]));
-      expect(letters.toJS()).toEqual(
-        ['a', 'A', 'b', 'B', 'c', 'C'],
+      const letters = numbers.flatMap(v =>
+        fromJS([String.fromCharCode(v), String.fromCharCode(v).toUpperCase()])
       );
+      expect(letters.toJS()).toEqual(['a', 'A', 'b', 'B', 'c', 'C']);
     });
 
     it('maps to sequenceables, not only Sequences.', () => {
@@ -134,13 +108,9 @@ describe('flatten', () => {
       // Array is iterable, so this works just fine.
       const letters = numbers.flatMap(v => [
         String.fromCharCode(v),
-        String.fromCharCode(v).toUpperCase(),
+        String.fromCharCode(v).toUpperCase()
       ]);
-      expect(letters.toJS()).toEqual(
-        ['a', 'A', 'b', 'B', 'c', 'C'],
-      );
+      expect(letters.toJS()).toEqual(['a', 'A', 'b', 'B', 'c', 'C']);
     });
-
   });
-
 });

--- a/__tests__/get.ts
+++ b/__tests__/get.ts
@@ -10,7 +10,6 @@
 import { Range } from '../';
 
 describe('get', () => {
-
   it('gets any index', () => {
     const seq = Range(0, 100);
     expect(seq.get(20)).toBe(20);
@@ -55,5 +54,4 @@ describe('get', () => {
     const seq = Range(0, 100).filter(x => x % 2 === 1);
     expect(seq.last()).toBe(99); // Note: this is O(N)
   });
-
 });

--- a/__tests__/getIn.ts
+++ b/__tests__/getIn.ts
@@ -10,37 +10,36 @@
 import { fromJS, getIn, List, Map, Set } from '../';
 
 describe('getIn', () => {
-
   it('deep get', () => {
-    const m = fromJS({a: {b: {c: 10}}});
+    const m = fromJS({ a: { b: { c: 10 } } });
     expect(m.getIn(['a', 'b', 'c'])).toEqual(10);
     expect(getIn(m, ['a', 'b', 'c'])).toEqual(10);
   });
 
   it('deep get with list as keyPath', () => {
-    const m = fromJS({a: {b: {c: 10}}});
+    const m = fromJS({ a: { b: { c: 10 } } });
     expect(m.getIn(fromJS(['a', 'b', 'c']))).toEqual(10);
     expect(getIn(m, fromJS(['a', 'b', 'c']))).toEqual(10);
   });
 
   it('deep get throws without list or array-like', () => {
     // need to cast these as TypeScript first prevents us from such clownery.
-    expect(() =>
-      Map().getIn(undefined as any),
-    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: undefined');
-    expect(() =>
-      Map().getIn({ a: 1, b: 2 } as any),
-    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: [object Object]');
-    expect(() =>
-      Map().getIn('abc' as any),
-    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
-    expect(() =>
-      getIn(Map(), 'abc' as any),
-    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
+    expect(() => Map().getIn(undefined as any)).toThrow(
+      'Invalid keyPath: expected Ordered Collection or Array: undefined'
+    );
+    expect(() => Map().getIn({ a: 1, b: 2 } as any)).toThrow(
+      'Invalid keyPath: expected Ordered Collection or Array: [object Object]'
+    );
+    expect(() => Map().getIn('abc' as any)).toThrow(
+      'Invalid keyPath: expected Ordered Collection or Array: abc'
+    );
+    expect(() => getIn(Map(), 'abc' as any)).toThrow(
+      'Invalid keyPath: expected Ordered Collection or Array: abc'
+    );
   });
 
   it('deep get returns not found if path does not match', () => {
-    const m = fromJS({a: {b: {c: 10}}});
+    const m = fromJS({ a: { b: { c: 10 } } });
     expect(m.getIn(['a', 'b', 'z'])).toEqual(undefined);
     expect(m.getIn(['a', 'b', 'z'], 123)).toEqual(123);
     expect(m.getIn(['a', 'y', 'z'])).toEqual(undefined);
@@ -50,7 +49,7 @@ describe('getIn', () => {
   });
 
   it('does not use notSetValue when path does exist but value is nullable', () => {
-    const m = fromJS({a: {b: {c: null, d: undefined}}});
+    const m = fromJS({ a: { b: { c: null, d: undefined } } });
     expect(m.getIn(['a', 'b', 'c'])).toEqual(null);
     expect(m.getIn(['a', 'b', 'd'])).toEqual(undefined);
     expect(m.getIn(['a', 'b', 'c'], 123)).toEqual(null);
@@ -60,7 +59,7 @@ describe('getIn', () => {
   });
 
   it('deep get returns not found if path encounters non-data-structure', () => {
-    const m = fromJS({a: {b: {c: null, d: undefined}}});
+    const m = fromJS({ a: { b: { c: null, d: undefined } } });
     expect(m.getIn(['a', 'b', 'c', 'x'])).toEqual(undefined);
     expect(m.getIn(['a', 'b', 'c', 'x'], 123)).toEqual(123);
     expect(m.getIn(['a', 'b', 'd', 'x'])).toEqual(undefined);
@@ -73,12 +72,15 @@ describe('getIn', () => {
   });
 
   it('gets in nested plain Objects and Arrays', () => {
-    const m = List([ { key: [ 'item' ] } ]);
+    const m = List([{ key: ['item'] }]);
     expect(m.getIn([0, 'key', 0])).toEqual('item');
   });
 
   it('deep get returns not found if non-existing path in nested plain Object', () => {
-    const deep = Map({ key: { regular: 'jsobj' }, list: List([ Map({num: 10}) ]) });
+    const deep = Map({
+      key: { regular: 'jsobj' },
+      list: List([Map({ num: 10 })])
+    });
     expect(deep.getIn(['key', 'foo', 'item'])).toBe(undefined);
     expect(deep.getIn(['key', 'foo', 'item'], 'notSet')).toBe('notSet');
     expect(deep.getIn(['list', 0, 'num', 'badKey'])).toBe(undefined);
@@ -86,16 +88,15 @@ describe('getIn', () => {
   });
 
   it('gets in plain Objects and Arrays', () => {
-    const m = [ { key: [ 'item' ] } ];
+    const m = [{ key: ['item'] }];
     expect(getIn(m, [0, 'key', 0])).toEqual('item');
   });
 
   it('deep get returns not found if non-existing path in plain Object', () => {
-    const deep = { key: { regular: 'jsobj' }, list: [ {num: 10} ] };
+    const deep = { key: { regular: 'jsobj' }, list: [{ num: 10 }] };
     expect(getIn(deep, ['key', 'foo', 'item'])).toBe(undefined);
     expect(getIn(deep, ['key', 'foo', 'item'], 'notSet')).toBe('notSet');
     expect(getIn(deep, ['list', 0, 'num', 'badKey'])).toBe(undefined);
     expect(getIn(deep, ['list', 0, 'num', 'badKey'], 'notSet')).toBe('notSet');
   });
-
 });

--- a/__tests__/groupBy.ts
+++ b/__tests__/groupBy.ts
@@ -10,10 +10,9 @@
 import { Collection, Map, Seq } from '../';
 
 describe('groupBy', () => {
-
   it('groups keyed sequence', () => {
-    const grouped = Seq({a: 1, b: 2, c: 3, d: 4}).groupBy(x => x % 2);
-    expect(grouped.toJS()).toEqual({1: {a: 1, c: 3}, 0: {b: 2, d: 4}});
+    const grouped = Seq({ a: 1, b: 2, c: 3, d: 4 }).groupBy(x => x % 2);
+    expect(grouped.toJS()).toEqual({ 1: { a: 1, c: 3 }, 0: { b: 2, d: 4 } });
 
     // Each group should be a keyed sequence, not an indexed sequence
     const firstGroup = grouped.get(1);
@@ -22,39 +21,41 @@ describe('groupBy', () => {
 
   it('groups indexed sequence', () => {
     expect(
-      Seq([1, 2, 3, 4, 5, 6]).groupBy(x => x % 2).toJS(),
-    ).toEqual(
-      {1: [1, 3, 5], 0: [2, 4, 6]},
-    );
+      Seq([1, 2, 3, 4, 5, 6])
+        .groupBy(x => x % 2)
+        .toJS()
+    ).toEqual({ 1: [1, 3, 5], 0: [2, 4, 6] });
   });
 
   it('groups to keys', () => {
     expect(
-      Seq([1, 2, 3, 4, 5, 6]).groupBy(x => x % 2 ? 'odd' : 'even').toJS(),
-    ).toEqual(
-      {odd: [1, 3, 5], even: [2, 4, 6]},
-    );
+      Seq([1, 2, 3, 4, 5, 6])
+        .groupBy(x => (x % 2 ? 'odd' : 'even'))
+        .toJS()
+    ).toEqual({ odd: [1, 3, 5], even: [2, 4, 6] });
   });
 
   it('groups indexed sequences, maintaining indicies when keyed sequences', () => {
     expect(
-      Seq([1, 2, 3, 4, 5, 6]).groupBy(x => x % 2).toJS(),
-    ).toEqual(
-      {1: [1, 3, 5], 0: [2, 4, 6]},
-    );
+      Seq([1, 2, 3, 4, 5, 6])
+        .groupBy(x => x % 2)
+        .toJS()
+    ).toEqual({ 1: [1, 3, 5], 0: [2, 4, 6] });
     expect(
-      Seq([1, 2, 3, 4, 5, 6]).toKeyedSeq().groupBy(x => x % 2).toJS(),
-    ).toEqual(
-      {1: {0: 1, 2: 3, 4: 5}, 0: {1: 2, 3: 4, 5: 6}},
-    );
+      Seq([1, 2, 3, 4, 5, 6])
+        .toKeyedSeq()
+        .groupBy(x => x % 2)
+        .toJS()
+    ).toEqual({ 1: { 0: 1, 2: 3, 4: 5 }, 0: { 1: 2, 3: 4, 5: 6 } });
   });
 
   it('has groups that can be mapped', () => {
     expect(
-      Seq([1, 2, 3, 4, 5, 6]).groupBy(x => x % 2).map(group => group.map(value => value * 10)).toJS(),
-    ).toEqual(
-      {1: [10, 30, 50], 0: [20, 40, 60]},
-    );
+      Seq([1, 2, 3, 4, 5, 6])
+        .groupBy(x => x % 2)
+        .map(group => group.map(value => value * 10))
+        .toJS()
+    ).toEqual({ 1: [10, 30, 50], 0: [20, 40, 60] });
   });
 
   it('returns an ordered map from an ordered collection', () => {
@@ -68,5 +69,4 @@ describe('groupBy', () => {
     const mapGroups = map.groupBy(x => x);
     expect(Collection.isOrdered(mapGroups)).toBe(false);
   });
-
 });

--- a/__tests__/hasIn.ts
+++ b/__tests__/hasIn.ts
@@ -10,9 +10,8 @@
 import { fromJS, hasIn, List, Map } from '../';
 
 describe('hasIn', () => {
-
   it('deep has', () => {
-    const m = fromJS({a: {b: {c: 10, d: undefined}}});
+    const m = fromJS({ a: { b: { c: 10, d: undefined } } });
     expect(m.hasIn(['a', 'b', 'c'])).toEqual(true);
     expect(m.hasIn(['a', 'b', 'd'])).toEqual(true);
     expect(m.hasIn(['a', 'b', 'z'])).toEqual(false);
@@ -22,7 +21,7 @@ describe('hasIn', () => {
   });
 
   it('deep has with list as keyPath', () => {
-    const m = fromJS({a: {b: {c: 10}}});
+    const m = fromJS({ a: { b: { c: 10 } } });
     expect(m.hasIn(fromJS(['a', 'b', 'c']))).toEqual(true);
     expect(m.hasIn(fromJS(['a', 'b', 'z']))).toEqual(false);
     expect(m.hasIn(fromJS(['a', 'y', 'z']))).toEqual(false);
@@ -32,22 +31,25 @@ describe('hasIn', () => {
 
   it('deep has throws without list or array-like', () => {
     // need to cast these as TypeScript first prevents us from such clownery.
-    expect(() =>
-      Map().hasIn(undefined as any),
-    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: undefined');
-    expect(() =>
-      Map().hasIn({ a: 1, b: 2 } as any),
-    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: [object Object]');
-    expect(() =>
-      Map().hasIn('abc' as any),
-    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
-    expect(() =>
-      hasIn(Map(), 'abc' as any),
-    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
+    expect(() => Map().hasIn(undefined as any)).toThrow(
+      'Invalid keyPath: expected Ordered Collection or Array: undefined'
+    );
+    expect(() => Map().hasIn({ a: 1, b: 2 } as any)).toThrow(
+      'Invalid keyPath: expected Ordered Collection or Array: [object Object]'
+    );
+    expect(() => Map().hasIn('abc' as any)).toThrow(
+      'Invalid keyPath: expected Ordered Collection or Array: abc'
+    );
+    expect(() => hasIn(Map(), 'abc' as any)).toThrow(
+      'Invalid keyPath: expected Ordered Collection or Array: abc'
+    );
   });
 
   it('deep has does not throw if non-readable path', () => {
-    const deep = Map({ key: { regular: "jsobj" }, list: List([ Map({num: 10}) ]) });
+    const deep = Map({
+      key: { regular: 'jsobj' },
+      list: List([Map({ num: 10 })])
+    });
     expect(deep.hasIn(['key', 'foo', 'item'])).toBe(false);
     expect(deep.hasIn(['list', 0, 'num', 'badKey'])).toBe(false);
     expect(hasIn(deep, ['key', 'foo', 'item'])).toBe(false);
@@ -55,7 +57,7 @@ describe('hasIn', () => {
   });
 
   it('deep has in plain Object and Array', () => {
-    const m = {a: {b: {c: [10, undefined], d: undefined}}};
+    const m = { a: { b: { c: [10, undefined], d: undefined } } };
     expect(hasIn(m, ['a', 'b', 'c', 0])).toEqual(true);
     expect(hasIn(m, ['a', 'b', 'c', 1])).toEqual(true);
     expect(hasIn(m, ['a', 'b', 'c', 2])).toEqual(false);
@@ -63,5 +65,4 @@ describe('hasIn', () => {
     expect(hasIn(m, ['a', 'b', 'z'])).toEqual(false);
     expect(hasIn(m, ['a', 'b', 'z'])).toEqual(false);
   });
-
 });

--- a/__tests__/hash.ts
+++ b/__tests__/hash.ts
@@ -13,7 +13,6 @@ jasmineCheck.install();
 import { hash } from '../';
 
 describe('hash', () => {
-
   it('stable hash of well known values', () => {
     expect(hash(true)).toBe(1);
     expect(hash(false)).toBe(0);
@@ -37,5 +36,4 @@ describe('hash', () => {
     expect(hashVal % 1).toBe(0);
     expect(hashVal).toBeLessThan(Math.pow(2, 31));
   });
-
 });

--- a/__tests__/interpose.ts
+++ b/__tests__/interpose.ts
@@ -10,13 +10,10 @@
 import { Range } from '../';
 
 describe('interpose', () => {
-
   it('separates with a value', () => {
     const range = Range(10, 15);
     const interposed = range.interpose(0);
-    expect(interposed.toArray()).toEqual(
-      [ 10, 0, 11, 0, 12, 0, 13, 0, 14 ],
-    );
+    expect(interposed.toArray()).toEqual([10, 0, 11, 0, 12, 0, 13, 0, 14]);
   });
 
   it('can be iterated', () => {
@@ -34,5 +31,4 @@ describe('interpose', () => {
     expect(values.next()).toEqual({ value: 14, done: false });
     expect(values.next()).toEqual({ value: undefined, done: true });
   });
-
 });

--- a/__tests__/issues.ts
+++ b/__tests__/issues.ts
@@ -38,7 +38,7 @@ describe('Issue #1220 : Seq.rest() throws an exception when invoked on a single 
   it('should be iterable', () => {
     // Helper for this test
     const ITERATOR_SYMBOL =
-      typeof Symbol === 'function' && Symbol.iterator || '@@iterator';
+      (typeof Symbol === 'function' && Symbol.iterator) || '@@iterator';
 
     const r = Seq([1]).rest();
     const i = r[ITERATOR_SYMBOL]();
@@ -56,7 +56,11 @@ describe('Issue #1245', () => {
 describe('Issue #1262', () => {
   it('Set.subtract should accept an array', () => {
     const MyType = Record({ val: 1 });
-    const set1 = Set([MyType({ val: 1 }), MyType({ val: 2 }), MyType({ val: 3 })]);
+    const set1 = Set([
+      MyType({ val: 1 }),
+      MyType({ val: 2 }),
+      MyType({ val: 3 })
+    ]);
     const set2 = set1.subtract([MyType({ val: 2 })]);
     const set3 = set1.subtract(List([MyType({ val: 2 })]));
     expect(set2).toEqual(set3);

--- a/__tests__/join.ts
+++ b/__tests__/join.ts
@@ -13,7 +13,6 @@ jasmineCheck.install();
 import { Seq } from '../';
 
 describe('join', () => {
-
   it('string-joins sequences with commas by default', () => {
     expect(Seq([1, 2, 3, 4, 5]).join()).toBe('1,2,3,4,5');
   });
@@ -27,13 +26,27 @@ describe('join', () => {
   });
 
   it('joins sparse-sequences like Array.join', () => {
-    const a = [1, undefined, 2, undefined, 3, undefined, 4, undefined, 5, undefined, undefined];
+    const a = [
+      1,
+      undefined,
+      2,
+      undefined,
+      3,
+      undefined,
+      4,
+      undefined,
+      5,
+      undefined,
+      undefined
+    ];
     expect(Seq(a).join()).toBe(a.join());
   });
 
-  check.it('behaves the same as Array.join',
-    [gen.array(gen.primitive), gen.primitive], (array, joiner) => {
+  check.it(
+    'behaves the same as Array.join',
+    [gen.array(gen.primitive), gen.primitive],
+    (array, joiner) => {
       expect(Seq(array).join(joiner)).toBe(array.join(joiner));
-  });
-
+    }
+  );
 });

--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -7,130 +7,135 @@
 
 ///<reference path='../resources/jest.d.ts'/>
 
-import { fromJS, is, List, Map, merge, mergeDeep, mergeDeepWith, Set } from '../';
+import {
+  fromJS,
+  is,
+  List,
+  Map,
+  merge,
+  mergeDeep,
+  mergeDeepWith,
+  Set
+} from '../';
 
 describe('merge', () => {
   it('merges two maps', () => {
-    const m1 = Map({a: 1, b: 2, c: 3});
-    const m2 = Map({d: 10, b: 20, e: 30});
-    expect(m1.merge(m2)).toEqual(Map({a: 1, b: 20, c: 3, d: 10, e: 30}));
+    const m1 = Map({ a: 1, b: 2, c: 3 });
+    const m2 = Map({ d: 10, b: 20, e: 30 });
+    expect(m1.merge(m2)).toEqual(Map({ a: 1, b: 20, c: 3, d: 10, e: 30 }));
   });
 
   it('can merge in an explicitly undefined value', () => {
-    const m1 = Map({a: 1, b: 2});
-    const m2 = Map({a: undefined as any});
-    expect(m1.merge(m2)).toEqual(Map({a: undefined, b: 2}));
+    const m1 = Map({ a: 1, b: 2 });
+    const m2 = Map({ a: undefined as any });
+    expect(m1.merge(m2)).toEqual(Map({ a: undefined, b: 2 }));
   });
 
   it('merges two maps with a merge function', () => {
-    const m1 = Map({a: 1, b: 2, c: 3});
-    const m2 = Map({d: 10, b: 20, e: 30});
-    expect(m1.mergeWith((a, b) => a + b, m2)).toEqual(Map({a: 1, b: 22, c: 3, d: 10, e: 30}));
+    const m1 = Map({ a: 1, b: 2, c: 3 });
+    const m2 = Map({ d: 10, b: 20, e: 30 });
+    expect(m1.mergeWith((a, b) => a + b, m2)).toEqual(
+      Map({ a: 1, b: 22, c: 3, d: 10, e: 30 })
+    );
   });
 
   it('provides key as the third argument of merge function', () => {
-    const m1 = Map({id: 'temp',  b: 2,  c: 3});
-    const m2 = Map({id: 10,  b: 20, e: 30});
+    const m1 = Map({ id: 'temp', b: 2, c: 3 });
+    const m2 = Map({ id: 10, b: 20, e: 30 });
     const add = (a, b) => a + b;
     expect(
-      m1.mergeWith((a, b, key) => key !== 'id' ? add(a, b) : b, m2),
-    ).toEqual(Map({id: 10, b: 22, c: 3, e: 30}));
+      m1.mergeWith((a, b, key) => (key !== 'id' ? add(a, b) : b), m2)
+    ).toEqual(Map({ id: 10, b: 22, c: 3, e: 30 }));
   });
 
   it('deep merges two maps', () => {
-    const m1 = fromJS({a: {b: {c: 1, d: 2}}});
-    const m2 = fromJS({a: {b: {c: 10, e: 20}, f: 30}, g: 40});
-    expect(m1.mergeDeep(m2)).toEqual(fromJS({a: {b: {c: 10, d: 2, e: 20}, f: 30}, g: 40}));
+    const m1 = fromJS({ a: { b: { c: 1, d: 2 } } });
+    const m2 = fromJS({ a: { b: { c: 10, e: 20 }, f: 30 }, g: 40 });
+    expect(m1.mergeDeep(m2)).toEqual(
+      fromJS({ a: { b: { c: 10, d: 2, e: 20 }, f: 30 }, g: 40 })
+    );
   });
 
-  it('merge uses === for return-self optimization', () =>  {
+  it('merge uses === for return-self optimization', () => {
     const date1 = new Date(1234567890000);
     // Value equal, but different reference.
     const date2 = new Date(1234567890000);
     const m = Map().set('a', date1);
-    expect(m.merge({a: date2})).not.toBe(m);
-    expect(m.merge({a: date1})).toBe(m);
+    expect(m.merge({ a: date2 })).not.toBe(m);
+    expect(m.merge({ a: date1 })).toBe(m);
   });
 
-  it('deep merge uses === for return-self optimization', () =>  {
+  it('deep merge uses === for return-self optimization', () => {
     const date1 = new Date(1234567890000);
     // Value equal, but different reference.
     const date2 = new Date(1234567890000);
     const m = Map().setIn(['a', 'b', 'c'], date1);
-    expect(m.mergeDeep({a: {b: {c: date2}}})).not.toBe(m);
-    expect(m.mergeDeep({a: {b: {c: date1}}})).toBe(m);
+    expect(m.mergeDeep({ a: { b: { c: date2 } } })).not.toBe(m);
+    expect(m.mergeDeep({ a: { b: { c: date1 } } })).toBe(m);
   });
 
   it('deep merges raw JS', () => {
-    const m1 = fromJS({a: {b: {c: 1, d: 2}}});
-    const js = {a: {b: {c: 10, e: 20}, f: 30}, g: 40};
-    expect(m1.mergeDeep(js)).toEqual(fromJS({a: {b: {c: 10, d: 2, e: 20}, f: 30}, g: 40}));
+    const m1 = fromJS({ a: { b: { c: 1, d: 2 } } });
+    const js = { a: { b: { c: 10, e: 20 }, f: 30 }, g: 40 };
+    expect(m1.mergeDeep(js)).toEqual(
+      fromJS({ a: { b: { c: 10, d: 2, e: 20 }, f: 30 }, g: 40 })
+    );
   });
 
   it('deep merges raw JS with a merge function', () => {
-    const m1 = fromJS({a: {b: {c: 1, d: 2}}});
-    const js = {a: {b: {c: 10, e: 20}, f: 30}, g: 40};
-    expect(
-      m1.mergeDeepWith((a, b) => a + b, js),
-    ).toEqual(
-      fromJS({a: {b: {c: 11, d: 2, e: 20}, f: 30}, g: 40}),
+    const m1 = fromJS({ a: { b: { c: 1, d: 2 } } });
+    const js = { a: { b: { c: 10, e: 20 }, f: 30 }, g: 40 };
+    expect(m1.mergeDeepWith((a, b) => a + b, js)).toEqual(
+      fromJS({ a: { b: { c: 11, d: 2, e: 20 }, f: 30 }, g: 40 })
     );
   });
 
   it('deep merges raw JS into raw JS with a merge function', () => {
-    const js1 = {a: {b: {c: 1, d: 2}}};
-    const js2 = {a: {b: {c: 10, e: 20}, f: 30}, g: 40};
-    expect(
-      mergeDeepWith((a, b) => a + b, js1, js2),
-    ).toEqual(
-      {a: {b: {c: 11, d: 2, e: 20}, f: 30}, g: 40},
-    );
+    const js1 = { a: { b: { c: 1, d: 2 } } };
+    const js2 = { a: { b: { c: 10, e: 20 }, f: 30 }, g: 40 };
+    expect(mergeDeepWith((a, b) => a + b, js1, js2)).toEqual({
+      a: { b: { c: 11, d: 2, e: 20 }, f: 30 },
+      g: 40
+    });
   });
 
   it('deep merges collections into raw JS with a merge function', () => {
-    const js = {a: {b: {c: 1, d: 2}}};
-    const m = fromJS({a: {b: {c: 10, e: 20}, f: 30}, g: 40});
-    expect(
-      mergeDeepWith((a, b) => a + b, js, m),
-    ).toEqual(
-      {a: {b: {c: 11, d: 2, e: 20}, f: 30}, g: 40},
-    );
+    const js = { a: { b: { c: 1, d: 2 } } };
+    const m = fromJS({ a: { b: { c: 10, e: 20 }, f: 30 }, g: 40 });
+    expect(mergeDeepWith((a, b) => a + b, js, m)).toEqual({
+      a: { b: { c: 11, d: 2, e: 20 }, f: 30 },
+      g: 40
+    });
   });
 
   it('returns self when a deep merges is a no-op', () => {
-    const m1 = fromJS({a: {b: {c: 1, d: 2}}});
-    expect(
-      m1.mergeDeep({a: {b: {c: 1}}}),
-    ).toBe(m1);
+    const m1 = fromJS({ a: { b: { c: 1, d: 2 } } });
+    expect(m1.mergeDeep({ a: { b: { c: 1 } } })).toBe(m1);
   });
 
   it('returns arg when a deep merges is a no-op', () => {
-    const m1 = fromJS({a: {b: {c: 1, d: 2}}});
-    expect(
-      Map().mergeDeep(m1),
-    ).toBe(m1);
+    const m1 = fromJS({ a: { b: { c: 1, d: 2 } } });
+    expect(Map().mergeDeep(m1)).toBe(m1);
   });
 
   it('returns self when a deep merges is a no-op on raw JS', () => {
-    const m1 = {a: {b: {c: 1, d: 2}}};
-    expect(
-      mergeDeep(m1, {a: {b: {c: 1}}}),
-    ).toBe(m1);
+    const m1 = { a: { b: { c: 1, d: 2 } } };
+    expect(mergeDeep(m1, { a: { b: { c: 1 } } })).toBe(m1);
   });
 
   it('can overwrite existing maps', () => {
     expect(
-      fromJS({ a: { x: 1, y: 1 }, b: { x: 2, y: 2 } })
-        .merge({ a: null, b: Map({ x: 10 }) }),
-    ).toEqual(
-      fromJS({ a: null, b: { x: 10 } }),
-    );
+      fromJS({ a: { x: 1, y: 1 }, b: { x: 2, y: 2 } }).merge({
+        a: null,
+        b: Map({ x: 10 })
+      })
+    ).toEqual(fromJS({ a: null, b: { x: 10 } }));
     expect(
-      fromJS({ a: { x: 1, y: 1 }, b: { x: 2, y: 2 } })
-        .mergeDeep({ a: null, b: { x: 10 } }),
-    ).toEqual(
-      fromJS({ a: null, b: { x: 10, y: 2 } }),
-    );
+      fromJS({ a: { x: 1, y: 1 }, b: { x: 2, y: 2 } }).mergeDeep({
+        a: null,
+        b: { x: 10 }
+      })
+    ).toEqual(fromJS({ a: null, b: { x: 10, y: 2 } }));
   });
 
   it('can overwrite existing maps with objects', () => {
@@ -138,66 +143,68 @@ describe('merge', () => {
     const m2 = Map({ a: { z: 10 } }); // shallow conversion to Map.
 
     // Raw object simply replaces map.
-    expect(m1.merge(m2).get('a')).toEqual({z: 10}); // raw object.
+    expect(m1.merge(m2).get('a')).toEqual({ z: 10 }); // raw object.
     // However, mergeDeep will merge that value into the inner Map.
-    expect(m1.mergeDeep(m2).get('a')).toEqual(Map({x: 1, y: 1, z: 10}));
+    expect(m1.mergeDeep(m2).get('a')).toEqual(Map({ x: 1, y: 1, z: 10 }));
   });
 
   it('merges map entries with List and Set values', () => {
-    const initial = Map({a: Map({x: 10, y: 20}), b: List([1, 2, 3]), c: Set([1, 2, 3])});
-    const additions = Map({a: Map({y: 50, z: 100}), b: List([4, 5, 6]), c: Set([4, 5, 6])});
+    const initial = Map({
+      a: Map({ x: 10, y: 20 }),
+      b: List([1, 2, 3]),
+      c: Set([1, 2, 3])
+    });
+    const additions = Map({
+      a: Map({ y: 50, z: 100 }),
+      b: List([4, 5, 6]),
+      c: Set([4, 5, 6])
+    });
     expect(initial.mergeDeep(additions)).toEqual(
-      Map({a: Map({x: 10, y: 50, z: 100}), b: List([1, 2, 3, 4, 5, 6]), c: Set([1, 2, 3, 4, 5, 6])}),
+      Map({
+        a: Map({ x: 10, y: 50, z: 100 }),
+        b: List([1, 2, 3, 4, 5, 6]),
+        c: Set([1, 2, 3, 4, 5, 6])
+      })
     );
   });
 
   it('merges map entries with new values', () => {
-    const initial = Map({a: List([1])});
+    const initial = Map({ a: List([1]) });
 
     // Note: merge and mergeDeep do not deeply coerce values, they only merge
     // with what's there prior.
-    expect(
-      initial.merge({b: [2]} as any),
-    ).toEqual(
-      Map({a: List([1]), b: [2]}),
+    expect(initial.merge({ b: [2] } as any)).toEqual(
+      Map({ a: List([1]), b: [2] })
     );
-    expect(
-      initial.mergeDeep({b: [2]} as any),
-    ).toEqual(fromJS(
-      Map({a: List([1]), b: [2]}),
-    ));
+    expect(initial.mergeDeep({ b: [2] } as any)).toEqual(
+      fromJS(Map({ a: List([1]), b: [2] }))
+    );
   });
 
   it('maintains JS values inside immutable collections', () => {
-    const m1 = fromJS({a: {b: {imm: 'map'}}});
-    const m2 = m1.mergeDeep(
-      Map({a: Map({b: {plain: 'obj'} })}),
-    );
+    const m1 = fromJS({ a: { b: { imm: 'map' } } });
+    const m2 = m1.mergeDeep(Map({ a: Map({ b: { plain: 'obj' } }) }));
 
     expect(m1.getIn(['a', 'b'])).toEqual(Map([['imm', 'map']]));
     // However mergeDeep will merge that value into the inner Map
-    expect(m2.getIn(['a', 'b'])).toEqual(Map({imm: 'map', plain: 'obj'}));
+    expect(m2.getIn(['a', 'b'])).toEqual(Map({ imm: 'map', plain: 'obj' }));
   });
 
   it('merges plain Objects', () => {
-    expect(
-      merge({ x: 1, y: 1 }, { y: 2, z: 2 }, Map({ z: 3, q: 3 })),
-    ).toEqual(
-      { x: 1, y: 2, z: 3, q: 3 },
-    );
+    expect(merge({ x: 1, y: 1 }, { y: 2, z: 2 }, Map({ z: 3, q: 3 }))).toEqual({
+      x: 1,
+      y: 2,
+      z: 3,
+      q: 3
+    });
   });
 
   it('merges plain Arrays', () => {
-    expect(
-      merge([1, 2], [3, 4], List([5, 6])),
-    ).toEqual(
-      [1, 2, 3, 4, 5, 6],
-    );
+    expect(merge([1, 2], [3, 4], List([5, 6]))).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
   it('merging plain Array returns self after no-op', () => {
     const a = [1, 2, 3];
     expect(merge(a, [], [])).toBe(a);
   });
-
 });

--- a/__tests__/minmax.ts
+++ b/__tests__/minmax.ts
@@ -14,11 +14,10 @@ import { is, Seq } from '../';
 
 const genHeterogeneousishArray = gen.oneOf([
   gen.array(gen.oneOf([gen.string, gen.undefined])),
-  gen.array(gen.oneOf([gen.int, gen.NaN])),
+  gen.array(gen.oneOf([gen.int, gen.NaN]))
 ]);
 
 describe('max', () => {
-
   it('returns max in a sequence', () => {
     expect(Seq([1, 9, 2, 8, 3, 7, 4, 6, 5]).max()).toBe(9);
   });
@@ -32,7 +31,7 @@ describe('max', () => {
       { name: 'Oakley', age: 7 },
       { name: 'Dakota', age: 7 },
       { name: 'Casey', age: 34 },
-      { name: 'Avery', age: 34 },
+      { name: 'Avery', age: 34 }
     ]);
     expect(family.maxBy(p => p.age)).toBe(family.get(2));
   });
@@ -42,45 +41,30 @@ describe('max', () => {
       { name: 'Oakley', age: 7 },
       { name: 'Dakota', age: 7 },
       { name: 'Casey', age: 34 },
-      { name: 'Avery', age: 34 },
+      { name: 'Avery', age: 34 }
     ]);
-    expect(family.maxBy<number>(p => p.age, (a, b) => b - a)).toBe(family.get(0));
+    expect(family.maxBy<number>(p => p.age, (a, b) => b - a)).toBe(
+      family.get(0)
+    );
   });
 
   it('surfaces NaN, null, and undefined', () => {
-    expect(
-      is(NaN, Seq([1, 2, 3, 4, 5, NaN]).max()),
-    ).toBe(true);
-    expect(
-      is(NaN, Seq([NaN, 1, 2, 3, 4, 5]).max()),
-    ).toBe(true);
-    expect(
-      is(null, Seq(['A', 'B', 'C', 'D', null]).max()),
-    ).toBe(true);
-    expect(
-      is(null, Seq([null, 'A', 'B', 'C', 'D']).max()),
-    ).toBe(true);
+    expect(is(NaN, Seq([1, 2, 3, 4, 5, NaN]).max())).toBe(true);
+    expect(is(NaN, Seq([NaN, 1, 2, 3, 4, 5]).max())).toBe(true);
+    expect(is(null, Seq(['A', 'B', 'C', 'D', null]).max())).toBe(true);
+    expect(is(null, Seq([null, 'A', 'B', 'C', 'D']).max())).toBe(true);
   });
 
   it('null treated as 0 in default iterator', () => {
-    expect(
-      is(2, Seq([-1, -2, null, 1, 2]).max()),
-    ).toBe(true);
+    expect(is(2, Seq([-1, -2, null, 1, 2]).max())).toBe(true);
   });
 
   check.it('is not dependent on order', [genHeterogeneousishArray], vals => {
-    expect(
-      is(
-        Seq(shuffle(vals.slice())).max(),
-        Seq(vals).max(),
-      ),
-    ).toEqual(true);
+    expect(is(Seq(shuffle(vals.slice())).max(), Seq(vals).max())).toEqual(true);
   });
-
 });
 
 describe('min', () => {
-
   it('returns min in a sequence', () => {
     expect(Seq([1, 9, 2, 8, 3, 7, 4, 6, 5]).min()).toBe(1);
   });
@@ -94,7 +78,7 @@ describe('min', () => {
       { name: 'Oakley', age: 7 },
       { name: 'Dakota', age: 7 },
       { name: 'Casey', age: 34 },
-      { name: 'Avery', age: 34 },
+      { name: 'Avery', age: 34 }
     ]);
     expect(family.minBy(p => p.age)).toBe(family.get(0));
   });
@@ -104,20 +88,16 @@ describe('min', () => {
       { name: 'Oakley', age: 7 },
       { name: 'Dakota', age: 7 },
       { name: 'Casey', age: 34 },
-      { name: 'Avery', age: 34 },
+      { name: 'Avery', age: 34 }
     ]);
-    expect(family.minBy<number>(p => p.age, (a, b) => b - a)).toBe(family.get(2));
+    expect(family.minBy<number>(p => p.age, (a, b) => b - a)).toBe(
+      family.get(2)
+    );
   });
 
   check.it('is not dependent on order', [genHeterogeneousishArray], vals => {
-    expect(
-      is(
-        Seq(shuffle(vals.slice())).min(),
-        Seq(vals).min(),
-      ),
-    ).toEqual(true);
+    expect(is(Seq(shuffle(vals.slice())).min(), Seq(vals).min())).toEqual(true);
   });
-
 });
 
 function shuffle(array) {

--- a/__tests__/slice.ts
+++ b/__tests__/slice.ts
@@ -7,18 +7,37 @@
 
 ///<reference path='../resources/jest.d.ts'/>
 
-import * as jasmineCheck from "jasmine-check";
-import {List, Range, Seq} from "../";
+import * as jasmineCheck from 'jasmine-check';
+import { List, Range, Seq } from '../';
 jasmineCheck.install();
 
 describe('slice', () => {
-
   it('slices a sequence', () => {
-    expect(Seq([1, 2, 3, 4, 5, 6]).slice(2).toArray()).toEqual([3, 4, 5, 6]);
-    expect(Seq([1, 2, 3, 4, 5, 6]).slice(2, 4).toArray()).toEqual([3, 4]);
-    expect(Seq([1, 2, 3, 4, 5, 6]).slice(-3, -1).toArray()).toEqual([4, 5]);
-    expect(Seq([1, 2, 3, 4, 5, 6]).slice(-1).toArray()).toEqual([6]);
-    expect(Seq([1, 2, 3, 4, 5, 6]).slice(0, -1).toArray()).toEqual([1, 2, 3, 4, 5]);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6])
+        .slice(2)
+        .toArray()
+    ).toEqual([3, 4, 5, 6]);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6])
+        .slice(2, 4)
+        .toArray()
+    ).toEqual([3, 4]);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6])
+        .slice(-3, -1)
+        .toArray()
+    ).toEqual([4, 5]);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6])
+        .slice(-1)
+        .toArray()
+    ).toEqual([6]);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6])
+        .slice(0, -1)
+        .toArray()
+    ).toEqual([1, 2, 3, 4, 5]);
   });
 
   it('creates an immutable stable sequence', () => {
@@ -30,53 +49,157 @@ describe('slice', () => {
   });
 
   it('slices a sparse indexed sequence', () => {
-    expect(Seq([1, undefined, 2, undefined, 3, undefined, 4, undefined, 5, undefined, 6]).slice(1).toArray())
-      .toEqual([undefined, 2, undefined, 3, undefined, 4, undefined, 5, undefined, 6]);
-    expect(Seq([1, undefined, 2, undefined, 3, undefined, 4, undefined, 5, undefined, 6]).slice(2).toArray())
-      .toEqual([2, undefined, 3, undefined, 4, undefined, 5, undefined, 6]);
-    expect(Seq([1, undefined, 2, undefined, 3, undefined, 4, undefined, 5, undefined, 6]).slice(3, -3).toArray())
-      .toEqual([undefined, 3, undefined, 4, undefined]); // one trailing hole.
+    expect(
+      Seq([
+        1,
+        undefined,
+        2,
+        undefined,
+        3,
+        undefined,
+        4,
+        undefined,
+        5,
+        undefined,
+        6
+      ])
+        .slice(1)
+        .toArray()
+    ).toEqual([
+      undefined,
+      2,
+      undefined,
+      3,
+      undefined,
+      4,
+      undefined,
+      5,
+      undefined,
+      6
+    ]);
+    expect(
+      Seq([
+        1,
+        undefined,
+        2,
+        undefined,
+        3,
+        undefined,
+        4,
+        undefined,
+        5,
+        undefined,
+        6
+      ])
+        .slice(2)
+        .toArray()
+    ).toEqual([2, undefined, 3, undefined, 4, undefined, 5, undefined, 6]);
+    expect(
+      Seq([
+        1,
+        undefined,
+        2,
+        undefined,
+        3,
+        undefined,
+        4,
+        undefined,
+        5,
+        undefined,
+        6
+      ])
+        .slice(3, -3)
+        .toArray()
+    ).toEqual([undefined, 3, undefined, 4, undefined]); // one trailing hole.
   });
 
   it('can maintain indices for an keyed indexed sequence', () => {
-    expect(Seq([1, 2, 3, 4, 5, 6]).toKeyedSeq().slice(2).entrySeq().toArray()).toEqual([
-      [2, 3],
-      [3, 4],
-      [4, 5],
-      [5, 6],
-    ]);
-    expect(Seq([1, 2, 3, 4, 5, 6]).toKeyedSeq().slice(2, 4).entrySeq().toArray()).toEqual([
-      [2, 3],
-      [3, 4],
-    ]);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6])
+        .toKeyedSeq()
+        .slice(2)
+        .entrySeq()
+        .toArray()
+    ).toEqual([[2, 3], [3, 4], [4, 5], [5, 6]]);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6])
+        .toKeyedSeq()
+        .slice(2, 4)
+        .entrySeq()
+        .toArray()
+    ).toEqual([[2, 3], [3, 4]]);
   });
 
   it('slices an unindexed sequence', () => {
-    expect(Seq({a: 1, b: 2, c: 3}).slice(1).toObject()).toEqual({b: 2, c: 3});
-    expect(Seq({a: 1, b: 2, c: 3}).slice(1, 2).toObject()).toEqual({b: 2});
-    expect(Seq({a: 1, b: 2, c: 3}).slice(0, 2).toObject()).toEqual({a: 1, b: 2});
-    expect(Seq({a: 1, b: 2, c: 3}).slice(-1).toObject()).toEqual({c: 3});
-    expect(Seq({a: 1, b: 2, c: 3}).slice(1, -1).toObject()).toEqual({b: 2});
+    expect(
+      Seq({ a: 1, b: 2, c: 3 })
+        .slice(1)
+        .toObject()
+    ).toEqual({ b: 2, c: 3 });
+    expect(
+      Seq({ a: 1, b: 2, c: 3 })
+        .slice(1, 2)
+        .toObject()
+    ).toEqual({ b: 2 });
+    expect(
+      Seq({ a: 1, b: 2, c: 3 })
+        .slice(0, 2)
+        .toObject()
+    ).toEqual({ a: 1, b: 2 });
+    expect(
+      Seq({ a: 1, b: 2, c: 3 })
+        .slice(-1)
+        .toObject()
+    ).toEqual({ c: 3 });
+    expect(
+      Seq({ a: 1, b: 2, c: 3 })
+        .slice(1, -1)
+        .toObject()
+    ).toEqual({ b: 2 });
   });
 
   it('is reversable', () => {
-    expect(Seq([1, 2, 3, 4, 5, 6]).slice(2).reverse().toArray()).toEqual([6, 5, 4, 3]);
-    expect(Seq([1, 2, 3, 4, 5, 6]).slice(2, 4).reverse().toArray()).toEqual([4, 3]);
-    expect(Seq([1, 2, 3, 4, 5, 6]).toKeyedSeq().slice(2).reverse().entrySeq().toArray()).toEqual([
-      [5, 6],
-      [4, 5],
-      [3, 4],
-      [2, 3],
-    ]);
-    expect(Seq([1, 2, 3, 4, 5, 6]).toKeyedSeq().slice(2, 4).reverse().entrySeq().toArray()).toEqual([
-      [3, 4],
-      [2, 3],
-    ]);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6])
+        .slice(2)
+        .reverse()
+        .toArray()
+    ).toEqual([6, 5, 4, 3]);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6])
+        .slice(2, 4)
+        .reverse()
+        .toArray()
+    ).toEqual([4, 3]);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6])
+        .toKeyedSeq()
+        .slice(2)
+        .reverse()
+        .entrySeq()
+        .toArray()
+    ).toEqual([[5, 6], [4, 5], [3, 4], [2, 3]]);
+    expect(
+      Seq([1, 2, 3, 4, 5, 6])
+        .toKeyedSeq()
+        .slice(2, 4)
+        .reverse()
+        .entrySeq()
+        .toArray()
+    ).toEqual([[3, 4], [2, 3]]);
   });
 
   it('slices a list', () => {
-    expect(List([1, 2, 3, 4, 5, 6]).slice(2).toArray()).toEqual([3, 4, 5, 6]);
-    expect(List([1, 2, 3, 4, 5, 6]).slice(2, 4).toArray()).toEqual([3, 4]);
+    expect(
+      List([1, 2, 3, 4, 5, 6])
+        .slice(2)
+        .toArray()
+    ).toEqual([3, 4, 5, 6]);
+    expect(
+      List([1, 2, 3, 4, 5, 6])
+        .slice(2, 4)
+        .toArray()
+    ).toEqual([3, 4]);
   });
 
   it('returns self for whole slices', () => {
@@ -92,13 +215,23 @@ describe('slice', () => {
   });
 
   it('creates a sliced list in O(log32(n))', () => {
-    expect(List([1, 2, 3, 4, 5]).slice(-3, -1).toList().toArray()).toEqual([3, 4]);
+    expect(
+      List([1, 2, 3, 4, 5])
+        .slice(-3, -1)
+        .toList()
+        .toArray()
+    ).toEqual([3, 4]);
   });
 
   it('has the same behavior as array slice in known edge cases', () => {
     const a = Range(0, 33).toArray();
     const v = List(a);
-    expect(v.slice(31).toList().toArray()).toEqual(a.slice(31));
+    expect(
+      v
+        .slice(31)
+        .toList()
+        .toArray()
+    ).toEqual(a.slice(31));
   });
 
   it('does not slice by floating-point numbers', () => {
@@ -111,19 +244,19 @@ describe('slice', () => {
   it('can create an iterator', () => {
     const seq = Seq([0, 1, 2, 3, 4, 5]);
     const iterFront = seq.slice(0, 2).values();
-    expect(iterFront.next()).toEqual({value: 0, done: false});
-    expect(iterFront.next()).toEqual({value: 1, done: false});
-    expect(iterFront.next()).toEqual({value: undefined, done: true});
+    expect(iterFront.next()).toEqual({ value: 0, done: false });
+    expect(iterFront.next()).toEqual({ value: 1, done: false });
+    expect(iterFront.next()).toEqual({ value: undefined, done: true });
 
     const iterMiddle = seq.slice(2, 4).values();
-    expect(iterMiddle.next()).toEqual({value: 2, done: false});
-    expect(iterMiddle.next()).toEqual({value: 3, done: false});
-    expect(iterMiddle.next()).toEqual({value: undefined, done: true});
+    expect(iterMiddle.next()).toEqual({ value: 2, done: false });
+    expect(iterMiddle.next()).toEqual({ value: 3, done: false });
+    expect(iterMiddle.next()).toEqual({ value: undefined, done: true });
 
     const iterTail = seq.slice(4, 123456).values();
-    expect(iterTail.next()).toEqual({value: 4, done: false});
-    expect(iterTail.next()).toEqual({value: 5, done: false});
-    expect(iterTail.next()).toEqual({value: undefined, done: true});
+    expect(iterTail.next()).toEqual({ value: 4, done: false });
+    expect(iterTail.next()).toEqual({ value: 5, done: false });
+    expect(iterTail.next()).toEqual({ value: undefined, done: true });
   });
 
   it('stops the entries iterator when the sequence has an undefined end', () => {
@@ -133,22 +266,23 @@ describe('slice', () => {
     expect(seq.size).toEqual(undefined);
 
     const iterFront = seq.slice(0, 2).entries();
-    expect(iterFront.next()).toEqual({value: [0, 0], done: false});
-    expect(iterFront.next()).toEqual({value: [1, 1], done: false});
-    expect(iterFront.next()).toEqual({value: undefined, done: true});
+    expect(iterFront.next()).toEqual({ value: [0, 0], done: false });
+    expect(iterFront.next()).toEqual({ value: [1, 1], done: false });
+    expect(iterFront.next()).toEqual({ value: undefined, done: true });
 
     const iterMiddle = seq.slice(2, 4).entries();
-    expect(iterMiddle.next()).toEqual({value: [0, 2], done: false});
-    expect(iterMiddle.next()).toEqual({value: [1, 3], done: false});
-    expect(iterMiddle.next()).toEqual({value: undefined, done: true});
+    expect(iterMiddle.next()).toEqual({ value: [0, 2], done: false });
+    expect(iterMiddle.next()).toEqual({ value: [1, 3], done: false });
+    expect(iterMiddle.next()).toEqual({ value: undefined, done: true });
 
     const iterTail = seq.slice(4, 123456).entries();
-    expect(iterTail.next()).toEqual({value: [0, 4], done: false});
-    expect(iterTail.next()).toEqual({value: [1, 5], done: false});
-    expect(iterTail.next()).toEqual({value: undefined, done: true});
+    expect(iterTail.next()).toEqual({ value: [0, 4], done: false });
+    expect(iterTail.next()).toEqual({ value: [1, 5], done: false });
+    expect(iterTail.next()).toEqual({ value: undefined, done: true });
   });
 
-  check.it('works like Array.prototype.slice',
+  check.it(
+    'works like Array.prototype.slice',
     [gen.int, gen.array(gen.oneOf([gen.int, gen.undefined]), 0, 3)],
     (valuesLen, args) => {
       const a = Range(0, valuesLen).toArray();
@@ -156,27 +290,35 @@ describe('slice', () => {
       const slicedV = v.slice.apply(v, args);
       const slicedA = a.slice.apply(a, args);
       expect(slicedV.toArray()).toEqual(slicedA);
-    });
+    }
+  );
 
-  check.it('works like Array.prototype.slice on sparse array input',
-    [gen.array(gen.array([gen.posInt, gen.int])),
-      gen.array(gen.oneOf([gen.int, gen.undefined]), 0, 3)],
+  check.it(
+    'works like Array.prototype.slice on sparse array input',
+    [
+      gen.array(gen.array([gen.posInt, gen.int])),
+      gen.array(gen.oneOf([gen.int, gen.undefined]), 0, 3)
+    ],
     (entries, args) => {
       const a: Array<any> = [];
-      entries.forEach(entry => a[entry[0]] = entry[1]);
+      entries.forEach(entry => (a[entry[0]] = entry[1]));
       const s = Seq(a);
       const slicedS = s.slice.apply(s, args);
       const slicedA = a.slice.apply(a, args);
       expect(slicedS.toArray()).toEqual(slicedA);
-    });
+    }
+  );
 
   describe('take', () => {
-
-    check.it('takes the first n from a list', [gen.int, gen.posInt], (len, num) => {
-      const a = Range(0, len).toArray();
-      const v = List(a);
-      expect(v.take(num).toArray()).toEqual(a.slice(0, num));
-    });
+    check.it(
+      'takes the first n from a list',
+      [gen.int, gen.posInt],
+      (len, num) => {
+        const a = Range(0, len).toArray();
+        const v = List(a);
+        expect(v.take(num).toArray()).toEqual(a.slice(0, num));
+      }
+    );
 
     it('creates an immutable stable sequence', () => {
       const seq = Seq([1, 2, 3, 4, 5, 6]);
@@ -199,7 +341,5 @@ describe('slice', () => {
       expect(s3.toArray().length).toEqual(3);
       expect(s4.toArray().length).toEqual(2);
     });
-
   });
-
 });

--- a/__tests__/sort.ts
+++ b/__tests__/sort.ts
@@ -10,42 +10,69 @@
 import { List, OrderedMap, Range, Seq } from '../';
 
 describe('sort', () => {
-
   it('sorts a sequence', () => {
-    expect(Seq([4, 5, 6, 3, 2, 1]).sort().toArray()).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(
+      Seq([4, 5, 6, 3, 2, 1])
+        .sort()
+        .toArray()
+    ).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
   it('sorts a list', () => {
-    expect(List([4, 5, 6, 3, 2, 1]).sort().toArray()).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(
+      List([4, 5, 6, 3, 2, 1])
+        .sort()
+        .toArray()
+    ).toEqual([1, 2, 3, 4, 5, 6]);
   });
 
   it('sorts undefined values last', () => {
-    expect(List([4, undefined, 5, 6, 3, undefined, 2, 1]).sort().toArray())
-      .toEqual([1, 2, 3, 4, 5, 6, undefined, undefined]);
+    expect(
+      List([4, undefined, 5, 6, 3, undefined, 2, 1])
+        .sort()
+        .toArray()
+    ).toEqual([1, 2, 3, 4, 5, 6, undefined, undefined]);
   });
 
   it('sorts a keyed sequence', () => {
-    expect(Seq({z: 1, y: 2, x: 3, c: 3, b: 2, a: 1}).sort().entrySeq().toArray())
-      .toEqual([['z', 1], ['a', 1], ['y', 2], ['b', 2], ['x', 3], ['c', 3]]);
+    expect(
+      Seq({ z: 1, y: 2, x: 3, c: 3, b: 2, a: 1 })
+        .sort()
+        .entrySeq()
+        .toArray()
+    ).toEqual([['z', 1], ['a', 1], ['y', 2], ['b', 2], ['x', 3], ['c', 3]]);
   });
 
   it('sorts an OrderedMap', () => {
-    expect(OrderedMap({z: 1, y: 2, x: 3, c: 3, b: 2, a: 1}).sort().entrySeq().toArray())
-      .toEqual([['z', 1], ['a', 1], ['y', 2], ['b', 2], ['x', 3], ['c', 3]]);
+    expect(
+      OrderedMap({ z: 1, y: 2, x: 3, c: 3, b: 2, a: 1 })
+        .sort()
+        .entrySeq()
+        .toArray()
+    ).toEqual([['z', 1], ['a', 1], ['y', 2], ['b', 2], ['x', 3], ['c', 3]]);
   });
 
   it('accepts a sort function', () => {
-    expect(Seq([4, 5, 6, 3, 2, 1]).sort((a, b) => b - a).toArray()).toEqual([6, 5, 4, 3, 2, 1]);
+    expect(
+      Seq([4, 5, 6, 3, 2, 1])
+        .sort((a, b) => b - a)
+        .toArray()
+    ).toEqual([6, 5, 4, 3, 2, 1]);
   });
 
   it('sorts by using a mapper', () => {
-    expect(Range(1, 10).sortBy(v => v % 3).toArray())
-      .toEqual([3, 6, 9, 1, 4, 7, 2, 5, 8]);
+    expect(
+      Range(1, 10)
+        .sortBy(v => v % 3)
+        .toArray()
+    ).toEqual([3, 6, 9, 1, 4, 7, 2, 5, 8]);
   });
 
   it('sorts by using a mapper and a sort function', () => {
-    expect(Range(1, 10).sortBy(v => v % 3, (a: number, b: number) => b - a).toArray())
-      .toEqual([2, 5, 8, 1, 4, 7, 3, 6, 9]);
+    expect(
+      Range(1, 10)
+        .sortBy(v => v % 3, (a: number, b: number) => b - a)
+        .toArray()
+    ).toEqual([2, 5, 8, 1, 4, 7, 3, 6, 9]);
   });
-
 });

--- a/__tests__/splice.ts
+++ b/__tests__/splice.ts
@@ -13,29 +13,72 @@ jasmineCheck.install();
 import { List, Range, Seq } from '../';
 
 describe('splice', () => {
-
   it('splices a sequence only removing elements', () => {
-    expect(Seq([1, 2, 3]).splice(0, 1).toArray()).toEqual([2, 3]);
-    expect(Seq([1, 2, 3]).splice(1, 1).toArray()).toEqual([1, 3]);
-    expect(Seq([1, 2, 3]).splice(2, 1).toArray()).toEqual([1, 2]);
-    expect(Seq([1, 2, 3]).splice(3, 1).toArray()).toEqual([1, 2, 3]);
+    expect(
+      Seq([1, 2, 3])
+        .splice(0, 1)
+        .toArray()
+    ).toEqual([2, 3]);
+    expect(
+      Seq([1, 2, 3])
+        .splice(1, 1)
+        .toArray()
+    ).toEqual([1, 3]);
+    expect(
+      Seq([1, 2, 3])
+        .splice(2, 1)
+        .toArray()
+    ).toEqual([1, 2]);
+    expect(
+      Seq([1, 2, 3])
+        .splice(3, 1)
+        .toArray()
+    ).toEqual([1, 2, 3]);
   });
 
   it('splices a list only removing elements', () => {
-    expect(List([1, 2, 3]).splice(0, 1).toArray()).toEqual([2, 3]);
-    expect(List([1, 2, 3]).splice(1, 1).toArray()).toEqual([1, 3]);
-    expect(List([1, 2, 3]).splice(2, 1).toArray()).toEqual([1, 2]);
-    expect(List([1, 2, 3]).splice(3, 1).toArray()).toEqual([1, 2, 3]);
+    expect(
+      List([1, 2, 3])
+        .splice(0, 1)
+        .toArray()
+    ).toEqual([2, 3]);
+    expect(
+      List([1, 2, 3])
+        .splice(1, 1)
+        .toArray()
+    ).toEqual([1, 3]);
+    expect(
+      List([1, 2, 3])
+        .splice(2, 1)
+        .toArray()
+    ).toEqual([1, 2]);
+    expect(
+      List([1, 2, 3])
+        .splice(3, 1)
+        .toArray()
+    ).toEqual([1, 2, 3]);
   });
 
   it('splicing by infinity', () => {
     const l = List(['a', 'b', 'c', 'd']);
     expect(l.splice(2, Infinity, 'x').toArray()).toEqual(['a', 'b', 'x']);
-    expect(l.splice(Infinity, 2, 'x').toArray()).toEqual(['a', 'b', 'c', 'd', 'x']);
+    expect(l.splice(Infinity, 2, 'x').toArray()).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+      'x'
+    ]);
 
     const s = List(['a', 'b', 'c', 'd']);
     expect(s.splice(2, Infinity, 'x').toArray()).toEqual(['a', 'b', 'x']);
-    expect(s.splice(Infinity, 2, 'x').toArray()).toEqual(['a', 'b', 'c', 'd', 'x']);
+    expect(s.splice(Infinity, 2, 'x').toArray()).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+      'x'
+    ]);
   });
 
   it('has the same behavior as array splice in known edge cases', () => {
@@ -43,17 +86,23 @@ describe('splice', () => {
     const a = Range(0, 49).toArray();
     const v = List(a);
     a.splice(-18, 0, 0);
-    expect(v.splice(-18, 0, 0).toList().toArray()).toEqual(a);
+    expect(
+      v
+        .splice(-18, 0, 0)
+        .toList()
+        .toArray()
+    ).toEqual(a);
   });
 
-  check.it('has the same behavior as array splice',
-           [gen.array(gen.int), gen.array(gen.oneOf([gen.int, gen.undefined]))],
-           (values, args) => {
-    const v = List(values);
-    const a = values.slice(); // clone
-    const splicedV = v.splice.apply(v, args); // persistent
-    a.splice.apply(a, args); // mutative
-    expect(splicedV.toArray()).toEqual(a);
-  });
-
+  check.it(
+    'has the same behavior as array splice',
+    [gen.array(gen.int), gen.array(gen.oneOf([gen.int, gen.undefined]))],
+    (values, args) => {
+      const v = List(values);
+      const a = values.slice(); // clone
+      const splicedV = v.splice.apply(v, args); // persistent
+      a.splice.apply(a, args); // mutative
+      expect(splicedV.toArray()).toEqual(a);
+    }
+  );
 });

--- a/__tests__/transformerProtocol.ts
+++ b/__tests__/transformerProtocol.ts
@@ -14,13 +14,9 @@ jasmineCheck.install();
 import { List, Map, Set, Stack } from '../';
 
 describe('Transformer Protocol', () => {
-
   it('transduces Stack without initial values', () => {
     const s = Stack.of(1, 2, 3, 4);
-    const xform = t.comp(
-      t.filter(x => x % 2 === 0),
-      t.map(x => x + 1),
-    );
+    const xform = t.comp(t.filter(x => x % 2 === 0), t.map(x => x + 1));
     const s2 = t.transduce(xform, Stack(), s);
     expect(s.toArray()).toEqual([1, 2, 3, 4]);
     expect(s2.toArray()).toEqual([5, 3]);
@@ -29,10 +25,7 @@ describe('Transformer Protocol', () => {
   it('transduces Stack with initial values', () => {
     const v1 = Stack.of(1, 2, 3);
     const v2 = Stack.of(4, 5, 6, 7);
-    const xform = t.comp(
-      t.filter(x => x % 2 === 0),
-      t.map(x => x + 1),
-    );
+    const xform = t.comp(t.filter(x => x % 2 === 0), t.map(x => x + 1));
     const r = t.transduce(xform, Stack(), v1, v2);
     expect(v1.toArray()).toEqual([1, 2, 3]);
     expect(v2.toArray()).toEqual([4, 5, 6, 7]);
@@ -41,10 +34,7 @@ describe('Transformer Protocol', () => {
 
   it('transduces List without initial values', () => {
     const v = List.of(1, 2, 3, 4);
-    const xform = t.comp(
-      t.filter(x => x % 2 === 0),
-      t.map(x => x + 1),
-    );
+    const xform = t.comp(t.filter(x => x % 2 === 0), t.map(x => x + 1));
     const r = t.transduce(xform, List(), v);
     expect(v.toArray()).toEqual([1, 2, 3, 4]);
     expect(r.toArray()).toEqual([3, 5]);
@@ -53,10 +43,7 @@ describe('Transformer Protocol', () => {
   it('transduces List with initial values', () => {
     const v1 = List.of(1, 2, 3);
     const v2 = List.of(4, 5, 6, 7);
-    const xform = t.comp(
-      t.filter(x => x % 2 === 0),
-      t.map(x => x + 1),
-    );
+    const xform = t.comp(t.filter(x => x % 2 === 0), t.map(x => x + 1));
     const r = t.transduce(xform, List(), v1, v2);
     expect(v1.toArray()).toEqual([1, 2, 3]);
     expect(v2.toArray()).toEqual([4, 5, 6, 7]);
@@ -64,35 +51,32 @@ describe('Transformer Protocol', () => {
   });
 
   it('transduces Map without initial values', () => {
-    const m1 = Map({a: 1, b: 2, c: 3, d: 4});
+    const m1 = Map({ a: 1, b: 2, c: 3, d: 4 });
     const xform = t.comp(
       t.filter(([k, v]) => v % 2 === 0),
-      t.map(([k, v]) => [k, v * 2]),
+      t.map(([k, v]) => [k, v * 2])
     );
     const m2 = t.transduce(xform, Map(), m1);
-    expect(m1.toObject()).toEqual({a: 1, b: 2, c: 3, d: 4});
-    expect(m2.toObject()).toEqual({b: 4, d: 8});
+    expect(m1.toObject()).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+    expect(m2.toObject()).toEqual({ b: 4, d: 8 });
   });
 
   it('transduces Map with initial values', () => {
-    const m1 = Map({a: 1, b: 2, c: 3});
-    const m2 = Map({a: 4, b: 5});
+    const m1 = Map({ a: 1, b: 2, c: 3 });
+    const m2 = Map({ a: 4, b: 5 });
     const xform = t.comp(
       t.filter(([k, v]) => v % 2 === 0),
-      t.map(([k, v]) => [k, v * 2]),
+      t.map(([k, v]) => [k, v * 2])
     );
     const m3 = t.transduce(xform, Map(), m1, m2);
-    expect(m1.toObject()).toEqual({a: 1, b: 2, c: 3});
-    expect(m2.toObject()).toEqual({a: 4, b: 5});
-    expect(m3.toObject()).toEqual({a: 8, b: 2, c: 3});
+    expect(m1.toObject()).toEqual({ a: 1, b: 2, c: 3 });
+    expect(m2.toObject()).toEqual({ a: 4, b: 5 });
+    expect(m3.toObject()).toEqual({ a: 8, b: 2, c: 3 });
   });
 
   it('transduces Set without initial values', () => {
     const s1 = Set.of(1, 2, 3, 4);
-    const xform = t.comp(
-      t.filter(x => x % 2 === 0),
-      t.map(x => x + 1),
-    );
+    const xform = t.comp(t.filter(x => x % 2 === 0), t.map(x => x + 1));
     const s2 = t.transduce(xform, Set(), s1);
     expect(s1.toArray()).toEqual([1, 2, 3, 4]);
     expect(s2.toArray()).toEqual([3, 5]);
@@ -101,14 +85,10 @@ describe('Transformer Protocol', () => {
   it('transduces Set with initial values', () => {
     const s1 = Set.of(1, 2, 3, 4);
     const s2 = Set.of(2, 3, 4, 5, 6);
-    const xform = t.comp(
-      t.filter(x => x % 2 === 0),
-      t.map(x => x + 1),
-    );
+    const xform = t.comp(t.filter(x => x % 2 === 0), t.map(x => x + 1));
     const s3 = t.transduce(xform, Set(), s1, s2);
     expect(s1.toArray()).toEqual([1, 2, 3, 4]);
     expect(s2.toArray()).toEqual([2, 3, 4, 5, 6]);
     expect(s3.toArray()).toEqual([1, 2, 3, 4, 5, 7]);
   });
-
 });

--- a/__tests__/updateIn.ts
+++ b/__tests__/updateIn.ts
@@ -10,184 +10,151 @@
 import { fromJS, List, Map, removeIn, Seq, Set, setIn, updateIn } from '../';
 
 describe('updateIn', () => {
-
   it('deep edit', () => {
-    const m = fromJS({a: {b: {c: 10}}});
-    expect(
-      m.updateIn(['a', 'b', 'c'], value => value * 2).toJS(),
-    ).toEqual(
-      {a: {b: {c: 20}}},
-    );
+    const m = fromJS({ a: { b: { c: 10 } } });
+    expect(m.updateIn(['a', 'b', 'c'], value => value * 2).toJS()).toEqual({
+      a: { b: { c: 20 } }
+    });
   });
 
   it('deep edit with list as keyPath', () => {
-    const m = fromJS({a: {b: {c: 10}}});
+    const m = fromJS({ a: { b: { c: 10 } } });
     expect(
-      m.updateIn(fromJS(['a', 'b', 'c']), value => value * 2).toJS(),
-    ).toEqual(
-      {a: {b: {c: 20}}},
-    );
+      m.updateIn(fromJS(['a', 'b', 'c']), value => value * 2).toJS()
+    ).toEqual({ a: { b: { c: 20 } } });
   });
 
   it('deep edit in raw JS', () => {
-    const m = {a: {b: {c: [10]}}};
-    expect(
-      updateIn(m, ['a', 'b', 'c', 0], value => value * 2),
-    ).toEqual(
-      {a: {b: {c: [20]}}},
-    );
+    const m = { a: { b: { c: [10] } } };
+    expect(updateIn(m, ['a', 'b', 'c', 0], value => value * 2)).toEqual({
+      a: { b: { c: [20] } }
+    });
   });
 
   it('deep edit throws without list or array-like', () => {
     // need to cast these as TypeScript first prevents us from such clownery.
-    expect(() =>
-      Map().updateIn(undefined as any, x => x),
-    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: undefined');
-    expect(() =>
-      Map().updateIn({ a: 1, b: 2 } as any, x => x),
-    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: [object Object]');
-    expect(() =>
-      Map().updateIn('abc' as any, x => x),
-    ).toThrow('Invalid keyPath: expected Ordered Collection or Array: abc');
+    expect(() => Map().updateIn(undefined as any, x => x)).toThrow(
+      'Invalid keyPath: expected Ordered Collection or Array: undefined'
+    );
+    expect(() => Map().updateIn({ a: 1, b: 2 } as any, x => x)).toThrow(
+      'Invalid keyPath: expected Ordered Collection or Array: [object Object]'
+    );
+    expect(() => Map().updateIn('abc' as any, x => x)).toThrow(
+      'Invalid keyPath: expected Ordered Collection or Array: abc'
+    );
   });
 
   it('deep edit throws if non-editable path', () => {
-    const deep = Map({ key: Set([ List([ 'item' ]) ]) });
-    expect(() =>
-      deep.updateIn(['key', 'foo', 'item'], () => 'newval'),
-    ).toThrow(
-      'Cannot update immutable value without .set() method: Set { List [ "item" ] }',
+    const deep = Map({ key: Set([List(['item'])]) });
+    expect(() => deep.updateIn(['key', 'foo', 'item'], () => 'newval')).toThrow(
+      'Cannot update immutable value without .set() method: Set { List [ "item" ] }'
     );
 
-    const deepSeq = Map({ key: Seq([ List([ 'item' ]) ]) });
+    const deepSeq = Map({ key: Seq([List(['item'])]) });
     expect(() =>
-      deepSeq.updateIn(['key', 'foo', 'item'], () => 'newval'),
+      deepSeq.updateIn(['key', 'foo', 'item'], () => 'newval')
     ).toThrow(
-      'Cannot update immutable value without .set() method: Seq [ List [ "item" ] ]',
+      'Cannot update immutable value without .set() method: Seq [ List [ "item" ] ]'
     );
 
     const nonObj = Map({ key: 123 });
-    expect(() =>
-      nonObj.updateIn(['key', 'foo'], () => 'newval'),
-    ).toThrow(
-      'Cannot update within non-data-structure value in path ["key"]: 123',
+    expect(() => nonObj.updateIn(['key', 'foo'], () => 'newval')).toThrow(
+      'Cannot update within non-data-structure value in path ["key"]: 123'
     );
   });
 
   it('identity with notSetValue is still identity', () => {
-    const m = Map({a: {b: {c: 10}}});
-    expect(
-      m.updateIn(['x'], 100, id => id),
-    ).toEqual(
-      m,
-    );
+    const m = Map({ a: { b: { c: 10 } } });
+    expect(m.updateIn(['x'], 100, id => id)).toEqual(m);
   });
 
   it('shallow remove', () => {
-    const m = Map({a: 123});
-    expect(
-      m.updateIn([], map => undefined),
-    ).toEqual(
-      undefined,
-    );
+    const m = Map({ a: 123 });
+    expect(m.updateIn([], map => undefined)).toEqual(undefined);
   });
 
   it('deep remove', () => {
-    const m = fromJS({a: {b: {c: 10}}});
-    expect(
-      m.updateIn(['a', 'b'], map => map.remove('c')).toJS(),
-    ).toEqual(
-      {a: {b: {}}},
-    );
+    const m = fromJS({ a: { b: { c: 10 } } });
+    expect(m.updateIn(['a', 'b'], map => map.remove('c')).toJS()).toEqual({
+      a: { b: {} }
+    });
   });
 
   it('deep set', () => {
-    const m = fromJS({a: {b: {c: 10}}});
-    expect(
-      m.updateIn(['a', 'b'], map => map.set('d', 20)).toJS(),
-    ).toEqual(
-      {a: {b: {c: 10, d: 20}}},
-    );
+    const m = fromJS({ a: { b: { c: 10 } } });
+    expect(m.updateIn(['a', 'b'], map => map.set('d', 20)).toJS()).toEqual({
+      a: { b: { c: 10, d: 20 } }
+    });
   });
 
   it('deep push', () => {
-    const m = fromJS({a: {b: [1, 2, 3]}});
-    expect(
-      m.updateIn(['a', 'b'], list => list.push(4)).toJS(),
-    ).toEqual(
-      {a: {b: [1, 2, 3, 4]}},
-    );
+    const m = fromJS({ a: { b: [1, 2, 3] } });
+    expect(m.updateIn(['a', 'b'], list => list.push(4)).toJS()).toEqual({
+      a: { b: [1, 2, 3, 4] }
+    });
   });
 
   it('deep map', () => {
-    const m = fromJS({a: {b: [1, 2, 3]}});
+    const m = fromJS({ a: { b: [1, 2, 3] } });
     expect(
-      m.updateIn(['a', 'b'], list => list.map(value => value * 10)).toJS(),
-    ).toEqual(
-      {a: {b: [10, 20, 30]}},
-    );
+      m.updateIn(['a', 'b'], list => list.map(value => value * 10)).toJS()
+    ).toEqual({ a: { b: [10, 20, 30] } });
   });
 
   it('creates new maps if path contains gaps', () => {
-    const m = fromJS({a: {b: {c: 10}}});
+    const m = fromJS({ a: { b: { c: 10 } } });
     expect(
-      m.updateIn(['a', 'q', 'z'], Map(), map => map.set('d', 20)).toJS(),
-    ).toEqual(
-      {a: {b: {c: 10}, q: {z: {d: 20}}}},
-    );
+      m.updateIn(['a', 'q', 'z'], Map(), map => map.set('d', 20)).toJS()
+    ).toEqual({ a: { b: { c: 10 }, q: { z: { d: 20 } } } });
   });
 
   it('creates new objects if path contains gaps within raw JS', () => {
-    const m = {a: {b: {c: 10}}};
+    const m = { a: { b: { c: 10 } } };
     expect(
-      updateIn(m, ['a', 'b', 'z'], Map(), map => map.set('d', 20)),
-    ).toEqual(
-      {a: {b: {c: 10, z: Map({d: 20})}}},
-    );
+      updateIn(m, ['a', 'b', 'z'], Map(), map => map.set('d', 20))
+    ).toEqual({ a: { b: { c: 10, z: Map({ d: 20 }) } } });
   });
 
   it('throws if path cannot be set', () => {
-    const m = fromJS({a: {b: {c: 10}}});
+    const m = fromJS({ a: { b: { c: 10 } } });
     expect(() => {
       m.updateIn(['a', 'b', 'c', 'd'], v => 20).toJS();
     }).toThrow();
   });
 
   it('update with notSetValue when non-existing key', () => {
-    const m = Map({a: {b: {c: 10}}});
-    expect(
-      m.updateIn(['x'], 100, map => map + 1).toJS(),
-    ).toEqual(
-      {a: {b: {c: 10}}, x: 101},
-    );
+    const m = Map({ a: { b: { c: 10 } } });
+    expect(m.updateIn(['x'], 100, map => map + 1).toJS()).toEqual({
+      a: { b: { c: 10 } },
+      x: 101
+    });
   });
 
   it('update with notSetValue when non-existing key in raw JS', () => {
-    const m = {a: {b: {c: 10}}};
-    expect(
-      updateIn(m, ['x'], 100, map => map + 1),
-    ).toEqual(
-      {a: {b: {c: 10}}, x: 101},
-    );
+    const m = { a: { b: { c: 10 } } };
+    expect(updateIn(m, ['x'], 100, map => map + 1)).toEqual({
+      a: { b: { c: 10 } },
+      x: 101
+    });
   });
 
   it('updates self for empty path', () => {
-    const m = fromJS({a: 1, b: 2, c: 3});
-    expect(
-      m.updateIn([], map => map.set('b', 20)).toJS(),
-    ).toEqual(
-      {a: 1, b: 20, c: 3},
-    );
+    const m = fromJS({ a: 1, b: 2, c: 3 });
+    expect(m.updateIn([], map => map.set('b', 20)).toJS()).toEqual({
+      a: 1,
+      b: 20,
+      c: 3
+    });
   });
 
   it('does not perform edit when new value is the same as old value', () => {
-    const m = fromJS({a: {b: {c: 10}}});
+    const m = fromJS({ a: { b: { c: 10 } } });
     const m2 = m.updateIn(['a', 'b', 'c'], id => id);
     expect(m2).toBe(m);
   });
 
   it('does not perform edit when new value is the same as old value in raw JS', () => {
-    const m = {a: {b: {c: 10}}};
+    const m = { a: { b: { c: 10 } } };
     const m2 = updateIn(m, ['a', 'b', 'c'], id => id);
     expect(m2).toBe(m);
   });
@@ -209,15 +176,14 @@ describe('updateIn', () => {
   });
 
   describe('setIn', () => {
-
     it('provides shorthand for updateIn to set a single value', () => {
       const m = Map().setIn(['a', 'b', 'c'], 'X');
-      expect(m).toEqual(fromJS({a: {b: {c: 'X'}}}));
+      expect(m).toEqual(fromJS({ a: { b: { c: 'X' } } }));
     });
 
     it('accepts a list as a keyPath', () => {
       const m = Map().setIn(fromJS(['a', 'b', 'c']), 'X');
-      expect(m).toEqual(fromJS({a: {b: {c: 'X'}}}));
+      expect(m).toEqual(fromJS({ a: { b: { c: 'X' } } }));
     });
 
     it('returns value when setting empty path', () => {
@@ -227,22 +193,22 @@ describe('updateIn', () => {
 
     it('can setIn undefined', () => {
       const m = Map().setIn(['a', 'b', 'c'], undefined);
-      expect(m).toEqual(Map({a: Map({b: Map({c: undefined})})}));
+      expect(m).toEqual(Map({ a: Map({ b: Map({ c: undefined }) }) }));
     });
 
     it('returns self for a no-op', () => {
-      const m = fromJS({ a: { b: { c: 123} } } );
+      const m = fromJS({ a: { b: { c: 123 } } });
       expect(m.setIn(['a', 'b', 'c'], 123)).toBe(m);
     });
 
     it('provides shorthand for updateIn to set a single value in raw JS', () => {
       const m = setIn({}, ['a', 'b', 'c'], 'X');
-      expect(m).toEqual({a: {b: {c: 'X'}}});
+      expect(m).toEqual({ a: { b: { c: 'X' } } });
     });
 
     it('accepts a list as a keyPath in raw JS', () => {
       const m = setIn({}, fromJS(['a', 'b', 'c']), 'X');
-      expect(m).toEqual({a: {b: {c: 'X'}}});
+      expect(m).toEqual({ a: { b: { c: 'X' } } });
     });
 
     it('returns value when setting empty path in raw JS', () => {
@@ -251,26 +217,28 @@ describe('updateIn', () => {
 
     it('can setIn undefined in raw JS', () => {
       const m = setIn({}, ['a', 'b', 'c'], undefined);
-      expect(m).toEqual({a: {b: {c: undefined}}});
+      expect(m).toEqual({ a: { b: { c: undefined } } });
     });
 
     it('returns self for a no-op in raw JS', () => {
-      const m = { a: { b: { c: 123} } };
+      const m = { a: { b: { c: 123 } } };
       expect(setIn(m, ['a', 'b', 'c'], 123)).toBe(m);
     });
-
   });
 
   describe('removeIn', () => {
-
     it('provides shorthand for updateIn to remove a single value', () => {
-      const m = fromJS({a: {b: {c: 'X', d: 'Y'}}});
-      expect(m.removeIn(['a', 'b', 'c']).toJS()).toEqual({a: {b: {d: 'Y'}}});
+      const m = fromJS({ a: { b: { c: 'X', d: 'Y' } } });
+      expect(m.removeIn(['a', 'b', 'c']).toJS()).toEqual({
+        a: { b: { d: 'Y' } }
+      });
     });
 
     it('accepts a list as a keyPath', () => {
-      const m = fromJS({a: {b: {c: 'X', d: 'Y'}}});
-      expect(m.removeIn(fromJS(['a', 'b', 'c'])).toJS()).toEqual({a: {b: {d: 'Y'}}});
+      const m = fromJS({ a: { b: { c: 'X', d: 'Y' } } });
+      expect(m.removeIn(fromJS(['a', 'b', 'c'])).toJS()).toEqual({
+        a: { b: { d: 'Y' } }
+      });
     });
 
     it('does not create empty maps for an unset path', () => {
@@ -284,9 +252,9 @@ describe('updateIn', () => {
     });
 
     it('removes values from a Set', () => {
-      const m = Map({ set: Set([ 1, 2, 3 ]) });
-      const m2 = m.removeIn([ 'set', 2 ]);
-      expect(m2.toJS()).toEqual({ set: [ 1, 3 ] });
+      const m = Map({ set: Set([1, 2, 3]) });
+      const m2 = m.removeIn(['set', 2]);
+      expect(m2.toJS()).toEqual({ set: [1, 3] });
     });
 
     it('returns undefined when removing an empty path in raw JS', () => {
@@ -294,33 +262,31 @@ describe('updateIn', () => {
     });
 
     it('can removeIn in raw JS', () => {
-      const m = removeIn({a: {b: {c: 123} } }, ['a', 'b', 'c']);
-      expect(m).toEqual({a: {b: {c: undefined}}});
+      const m = removeIn({ a: { b: { c: 123 } } }, ['a', 'b', 'c']);
+      expect(m).toEqual({ a: { b: { c: undefined } } });
     });
 
     it('returns self for a no-op in raw JS', () => {
-      const m = { a: { b: { c: 123} } };
+      const m = { a: { b: { c: 123 } } };
       expect(removeIn(m, ['a', 'b', 'd'])).toBe(m);
     });
-
   });
 
   describe('mergeIn', () => {
-
     it('provides shorthand for updateIn to merge a nested value', () => {
-      const m1 = fromJS({x: {a: 1, b: 2, c: 3}});
-      const m2 = fromJS({d: 10, b: 20, e: 30});
-      expect(m1.mergeIn(['x'], m2).toJS()).toEqual(
-        {x: {a: 1, b: 20, c: 3, d: 10, e: 30}},
-      );
+      const m1 = fromJS({ x: { a: 1, b: 2, c: 3 } });
+      const m2 = fromJS({ d: 10, b: 20, e: 30 });
+      expect(m1.mergeIn(['x'], m2).toJS()).toEqual({
+        x: { a: 1, b: 20, c: 3, d: 10, e: 30 }
+      });
     });
 
     it('accepts a list as a keyPath', () => {
-      const m1 = fromJS({x: {a: 1, b: 2, c: 3}});
-      const m2 = fromJS({d: 10, b: 20, e: 30});
-      expect(m1.mergeIn(fromJS(['x']), m2).toJS()).toEqual(
-        {x: {a: 1, b: 20, c: 3, d: 10, e: 30}},
-      );
+      const m1 = fromJS({ x: { a: 1, b: 2, c: 3 } });
+      const m2 = fromJS({ d: 10, b: 20, e: 30 });
+      expect(m1.mergeIn(fromJS(['x']), m2).toJS()).toEqual({
+        x: { a: 1, b: 20, c: 3, d: 10, e: 30 }
+      });
     });
 
     it('does not create empty maps for a no-op merge', () => {
@@ -329,41 +295,39 @@ describe('updateIn', () => {
     });
 
     it('merges into itself for empty path', () => {
-      const m = Map({a: 1, b: 2, c: 3});
-      expect(
-        m.mergeIn([], Map({d: 10, b: 20, e: 30})).toJS(),
-      ).toEqual(
-        {a: 1, b: 20, c: 3, d: 10, e: 30},
-      );
+      const m = Map({ a: 1, b: 2, c: 3 });
+      expect(m.mergeIn([], Map({ d: 10, b: 20, e: 30 })).toJS()).toEqual({
+        a: 1,
+        b: 20,
+        c: 3,
+        d: 10,
+        e: 30
+      });
     });
 
     it('merges into plain JS Object and Array', () => {
-      const m = Map({a: {x: [1, 2, 3]}});
-      expect(
-        m.mergeIn(['a', 'x'], [4, 5, 6]),
-      ).toEqual(
-        Map({a: {x: [1, 2, 3, 4, 5, 6]}}),
+      const m = Map({ a: { x: [1, 2, 3] } });
+      expect(m.mergeIn(['a', 'x'], [4, 5, 6])).toEqual(
+        Map({ a: { x: [1, 2, 3, 4, 5, 6] } })
       );
     });
-
   });
 
   describe('mergeDeepIn', () => {
-
     it('provides shorthand for updateIn to merge a nested value', () => {
-      const m1 = fromJS({x: {a: 1, b: 2, c: 3}});
-      const m2 = fromJS({d: 10, b: 20, e: 30});
-      expect(m1.mergeDeepIn(['x'], m2).toJS()).toEqual(
-        {x: {a: 1, b: 20, c: 3, d: 10, e: 30}},
-      );
+      const m1 = fromJS({ x: { a: 1, b: 2, c: 3 } });
+      const m2 = fromJS({ d: 10, b: 20, e: 30 });
+      expect(m1.mergeDeepIn(['x'], m2).toJS()).toEqual({
+        x: { a: 1, b: 20, c: 3, d: 10, e: 30 }
+      });
     });
 
     it('accepts a list as a keyPath', () => {
-      const m1 = fromJS({x: {a: 1, b: 2, c: 3}});
-      const m2 = fromJS({d: 10, b: 20, e: 30});
-      expect(m1.mergeDeepIn(fromJS(['x']), m2).toJS()).toEqual(
-        {x: {a: 1, b: 20, c: 3, d: 10, e: 30}},
-      );
+      const m1 = fromJS({ x: { a: 1, b: 2, c: 3 } });
+      const m2 = fromJS({ d: 10, b: 20, e: 30 });
+      expect(m1.mergeDeepIn(fromJS(['x']), m2).toJS()).toEqual({
+        x: { a: 1, b: 20, c: 3, d: 10, e: 30 }
+      });
     });
 
     it('does not create empty maps for a no-op merge', () => {
@@ -372,23 +336,21 @@ describe('updateIn', () => {
     });
 
     it('merges into itself for empty path', () => {
-      const m = Map({a: 1, b: 2, c: 3});
-      expect(
-        m.mergeDeepIn([], Map({d: 10, b: 20, e: 30})).toJS(),
-      ).toEqual(
-        {a: 1, b: 20, c: 3, d: 10, e: 30},
-      );
+      const m = Map({ a: 1, b: 2, c: 3 });
+      expect(m.mergeDeepIn([], Map({ d: 10, b: 20, e: 30 })).toJS()).toEqual({
+        a: 1,
+        b: 20,
+        c: 3,
+        d: 10,
+        e: 30
+      });
     });
 
     it('merges deep into plain JS Object and Array', () => {
-      const m = Map({a: {x: [1, 2, 3]}});
-      expect(
-        m.mergeDeepIn(['a'], {x: [4, 5, 6]}),
-      ).toEqual(
-        Map({a: {x: [1, 2, 3, 4, 5, 6]}}),
+      const m = Map({ a: { x: [1, 2, 3] } });
+      expect(m.mergeDeepIn(['a'], { x: [4, 5, 6] })).toEqual(
+        Map({ a: { x: [1, 2, 3, 4, 5, 6] } })
       );
     });
-
   });
-
 });

--- a/__tests__/zip.ts
+++ b/__tests__/zip.ts
@@ -13,13 +13,12 @@ jasmineCheck.install();
 import { Collection, List, Range, Seq } from '../';
 
 describe('zip', () => {
-
   it('zips lists into a list of tuples', () => {
     expect(
-      Seq([1, 2, 3]).zip(Seq([4, 5, 6])).toArray(),
-    ).toEqual(
-      [[1, 4], [2, 5], [3, 6]],
-    );
+      Seq([1, 2, 3])
+        .zip(Seq([4, 5, 6]))
+        .toArray()
+    ).toEqual([[1, 4], [2, 5], [3, 6]]);
   });
 
   it('zip results can be converted to JS', () => {
@@ -30,24 +29,18 @@ describe('zip', () => {
       List([
         [List([1]), List([4])],
         [List([2]), List([5])],
-        [List([3]), List([6])],
-      ]),
+        [List([3]), List([6])]
+      ])
     );
-    expect(zipped.toJS()).toEqual(
-      [
-        [[1], [4]],
-        [[2], [5]],
-        [[3], [6]],
-      ],
-    );
+    expect(zipped.toJS()).toEqual([[[1], [4]], [[2], [5]], [[3], [6]]]);
   });
 
   it('zips with infinite lists', () => {
     expect(
-      Range().zip(Seq(['A', 'B', 'C'])).toArray(),
-    ).toEqual(
-      [[0, 'A'], [1, 'B'], [2, 'C']],
-    );
+      Range()
+        .zip(Seq(['A', 'B', 'C']))
+        .toArray()
+    ).toEqual([[0, 'A'], [1, 'B'], [2, 'C']]);
   });
 
   it('has unknown size when zipped with unknown size', () => {
@@ -57,95 +50,84 @@ describe('zip', () => {
     expect(zipped.count()).toBe(5);
   });
 
-  check.it('is always the size of the smaller sequence',
-    [gen.notEmpty(gen.array(gen.posInt))], lengths => {
+  check.it(
+    'is always the size of the smaller sequence',
+    [gen.notEmpty(gen.array(gen.posInt))],
+    lengths => {
       const ranges = lengths.map(l => Range(0, l));
       const first = ranges.shift();
       const zipped = first.zip.apply(first, ranges);
       const shortestLength = Math.min.apply(Math, lengths);
       expect(zipped.size).toBe(shortestLength);
-  });
+    }
+  );
 
   describe('zipWith', () => {
-
     it('zips with a custom function', () => {
       expect(
-        Seq([1, 2, 3]).zipWith<number, number>(
-          (a, b) => a + b,
-          Seq([4, 5, 6]),
-        ).toArray(),
-      ).toEqual(
-        [5, 7, 9],
-      );
+        Seq([1, 2, 3])
+          .zipWith<number, number>((a, b) => a + b, Seq([4, 5, 6]))
+          .toArray()
+      ).toEqual([5, 7, 9]);
     });
 
     it('can zip to create immutable collections', () => {
       expect(
-        Seq([1, 2, 3]).zipWith(
-          function() { return List(arguments); },
-          Seq([4, 5, 6]),
-          Seq([7, 8, 9]),
-        ).toJS(),
-      ).toEqual(
-        [[1, 4, 7], [2, 5, 8], [3, 6, 9]],
-      );
+        Seq([1, 2, 3])
+          .zipWith(
+            function() {
+              return List(arguments);
+            },
+            Seq([4, 5, 6]),
+            Seq([7, 8, 9])
+          )
+          .toJS()
+      ).toEqual([[1, 4, 7], [2, 5, 8], [3, 6, 9]]);
     });
-
   });
 
   describe('zipAll', () => {
-
     it('fills in the empty zipped values with undefined', () => {
       expect(
-        Seq([1, 2, 3]).zipAll(Seq([4])).toArray(),
-      ).toEqual(
-        [[1, 4], [2, undefined], [3, undefined]],
-      );
+        Seq([1, 2, 3])
+          .zipAll(Seq([4]))
+          .toArray()
+      ).toEqual([[1, 4], [2, undefined], [3, undefined]]);
     });
 
-    check.it('is always the size of the longest sequence', [gen.notEmpty(gen.array(gen.posInt))], lengths => {
-      const ranges = lengths.map(l => Range(0, l));
-      const first = ranges.shift();
-      const zipped = first.zipAll.apply(first, ranges);
-      const longestLength = Math.max.apply(Math, lengths);
-      expect(zipped.size).toBe(longestLength);
-    });
-
+    check.it(
+      'is always the size of the longest sequence',
+      [gen.notEmpty(gen.array(gen.posInt))],
+      lengths => {
+        const ranges = lengths.map(l => Range(0, l));
+        const first = ranges.shift();
+        const zipped = first.zipAll.apply(first, ranges);
+        const longestLength = Math.max.apply(Math, lengths);
+        expect(zipped.size).toBe(longestLength);
+      }
+    );
   });
 
   describe('interleave', () => {
-
     it('interleaves multiple collections', () => {
       expect(
-        Seq([1, 2, 3]).interleave(
-          Seq([4, 5, 6]),
-          Seq([7, 8, 9]),
-        ).toArray(),
-      ).toEqual(
-        [1, 4, 7, 2, 5, 8, 3, 6, 9],
-      );
+        Seq([1, 2, 3])
+          .interleave(Seq([4, 5, 6]), Seq([7, 8, 9]))
+          .toArray()
+      ).toEqual([1, 4, 7, 2, 5, 8, 3, 6, 9]);
     });
 
     it('stops at the shortest collection', () => {
-      const i = Seq([1, 2, 3]).interleave(
-        Seq([4, 5]),
-        Seq([7, 8, 9]),
-      );
+      const i = Seq([1, 2, 3]).interleave(Seq([4, 5]), Seq([7, 8, 9]));
       expect(i.size).toBe(6);
-      expect(i.toArray()).toEqual(
-        [1, 4, 7, 2, 5, 8],
-      );
+      expect(i.toArray()).toEqual([1, 4, 7, 2, 5, 8]);
     });
 
     it('with infinite lists', () => {
       const r: Seq.Indexed<any> = Range();
       const i = r.interleave(Seq(['A', 'B', 'C']));
       expect(i.size).toBe(6);
-      expect(i.toArray()).toEqual(
-        [0, 'A', 1, 'B', 2, 'C'],
-      );
+      expect(i.toArray()).toEqual([0, 'A', 1, 'B', 2, 'C']);
     });
-
   });
-
 });

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint": "run-s lint:*",
     "lint:ts": "tslint \"__tests__/**/*.ts\"",
     "lint:js": "eslint \"{__tests__,src,pages/src,pages/lib}/**/*.js\"",
-    "format": "prettier --single-quote --write \"{__tests__,src,pages/src,pages/lib}/**/*.js\"",
+    "format": "prettier --single-quote --write \"{__tests__,src,pages/src,pages/lib}/**/*{js,ts}\"",
     "testonly": "./resources/jest",
     "test": "run-s format build lint testonly test:types:*",
     "test:travis": "npm run test && ./resources/check-changes",

--- a/tslint.json
+++ b/tslint.json
@@ -13,6 +13,7 @@
     "no-conditional-assignment": false,
     "one-variable-per-declaration": false,
     "max-classes-per-file": false,
+    "trailing-comma": false,
     "arrow-parens": [
       true,
       "ban-single-arg-parens"


### PR DESCRIPTION
When working on projects that use prettier, I enable the format-on-save
option in my editor of choice which run prettier whenever I save a file.

This always updated the formatting of the tests files when working on
Immutable.js, since those files were not formatted using prettier yet.
Prettier added [typescript support][1] in the mean time, so I thought
it was a good idea to keep the whole code base consistent and to allow
everyone to use format-on-save without getting annoyed.

Since there are not a lot of PRs open, I think it's a good time to merge
this.

[1]: https://github.com/prettier/prettier/releases/tag/1.4.0