### PR TITLE
Improved Flow support for Record subclasses

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2228,12 +2228,12 @@ declare module Immutable {
    * **Flow Typing Records:**
    *
    * Immutable.js exports two Flow types designed to make it easier to use
-   * Records with flow typed code, `RecordOf<T>` and `RecordFactory<TProps>`.
+   * Records with flow typed code, `RecordOf<TProps>` and `RecordFactory<TProps>`.
    *
    * When defining a new kind of Record factory function, use a flow type that
    * describes the values the record contains along with `RecordFactory<TProps>`.
    * To type instances of the Record (which the factory function returns),
-   * use `RecordOf<T>`.
+   * use `RecordOf<TProps>`.
    *
    * Typically, new Record definitions will export both the Record factory
    * function as well as the Record instance type for use in other code.
@@ -2243,7 +2243,8 @@ declare module Immutable {
    *
    * // Use RecordFactory<TProps> for defining new Record factory functions.
    * type Point3DProps = { x: number, y: number, z: number };
-   * const makePoint3D: RecordFactory<Point3DProps> = Record({ x: 0, y: 0, z: 0 });
+   * const defaultValues: Point3DProps = { x: 0, y: 0, z: 0 };
+   * const makePoint3D: RecordFactory<Point3DProps> = Record(defaultValues);
    * export makePoint3D;
    *
    * // Use RecordOf<T> for defining new instances of that Record.
@@ -2251,6 +2252,30 @@ declare module Immutable {
    * const some3DPoint: Point3D = makePoint3D({ x: 10, y: 20, z: 30 });
    * ```
    *
+   * **Flow Typing Record Subclasses:**
+   *
+   * Records can be subclassed as a means to add additional methods to Record
+   * instances. This is generally discouraged in favor of a more functional API,
+   * since Subclasses have some minor overhead. However the ability to create
+   * a rich API on Record types can be quite valuable.
+   *
+   * When using Flow to type Subclasses, do not use `RecordFactory<TProps>`,
+   * instead apply the props type when subclassing:
+   *
+   * ```js
+   * type PersonProps = {name: string, age: number};
+   * const defaultValues: PersonProps = {name: 'Aristotle', age: 2400};
+   * const PersonRecord = Record(defaultValues);
+   * class Person extends PersonRecord<PersonProps> {
+   *   getName(): string {
+   *     return this.get('name')
+   *   }
+   *
+   *   setName(name: string): this {
+   *     return this.set('name', name);
+   *   }
+   * }
+   * ```
    *
    * **Choosing Records vs plain JavaScript objects**
    *

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1384,8 +1384,8 @@ type RecordValues<R> = _RecordValues<*, R>;
 
 declare function isRecord(maybeRecord: any): boolean %checks(maybeRecord instanceof RecordInstance);
 declare class Record {
-  static <Values: Object>(spec: Values, name?: string): RecordFactory<Values>;
-  constructor<Values: Object>(spec: Values, name?: string): RecordFactory<Values>;
+  static <Values: Object>(spec: Values, name?: string): typeof RecordInstance;
+  constructor<Values: Object>(spec: Values, name?: string): typeof RecordInstance;
 
   static isRecord: typeof isRecord;
 

--- a/type-definitions/tests/record.js
+++ b/type-definitions/tests/record.js
@@ -125,7 +125,7 @@ const PersonRecord = Record(defaultValues);
 
 class Person extends PersonRecord<TPerson> {
   getName(): string {
-    return this.get('name')
+    return this.get('name');
   }
 
   setName(name: string): this & TPerson {

--- a/type-definitions/tests/record.js
+++ b/type-definitions/tests/record.js
@@ -19,7 +19,9 @@ const Point3: RecordFactory<{x: number, y: number, z: number}> =
 type TGeoPoint = {lat: ?number, lon: ?number}
 const GeoPoint: RecordFactory<TGeoPoint> = Record({lat: null, lon: null});
 
-// $ExpectError - 'abc' is not a number
+// TODO: this should be ExpectError - 'abc' is not a number
+// However, due to support for the brittle support for subclassing, Flow
+// cannot also type check default values in this position.
 const PointWhoops: RecordFactory<{x: number, y: number}> = Record({x:0, y:'abc'});
 
 let origin2 = Point2({});
@@ -114,3 +116,31 @@ const originNew: MakePointNew = new MakePointNew();
 const mistakeNewRecord = MakePointNew({x: 'string'});
 // $ExpectError instantiated with invalid type
 const mistakeNewInstance = new MakePointNew({x: 'string'});
+
+// Subclassing
+
+type TPerson = {name: string, age: number};
+const defaultValues: TPerson = {name: 'Aristotle', age: 2400};
+const PersonRecord = Record(defaultValues);
+
+class Person extends PersonRecord<TPerson> {
+  getName(): string {
+    return this.get('name')
+  }
+
+  setName(name: string): this & TPerson {
+    return this.set('name', name);
+  }
+}
+
+const person = new Person();
+(person.setName('Thales'): Person);
+(person.getName(): string);
+(person.setName('Thales').getName(): string);
+(person.setName('Thales').name: string);
+person.get('name');
+person.set('name', 'Thales');
+// $ExpectError
+person.get('unknown');
+// $ExpectError
+person.set('unknown', 'Thales');


### PR DESCRIPTION
Not ideal, but this adds dramatically better support for subclassing Records when using Flow. The cost of this is that the default values passed to Record are no longer checked - they should be separately checked :/. I've updated the documentation to show this in the example, as well as including an example of subclassing a Record when using Flow.

Fixes #1388