### PR TITLE
Update flow types to allow property access on Record subclass

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1372,11 +1372,11 @@ declare class Stack<+T> extends IndexedCollection<T> {
 declare function Range(start?: number, end?: number, step?: number): IndexedSeq<number>;
 declare function Repeat<T>(value: T, times?: number): IndexedSeq<T>;
 
-// The type of a Record factory function.
-type RecordFactory<Values: Object> = Class<RecordInstance<Values>>;
-
 // The type of runtime Record instances.
 type RecordOf<Values: Object> = RecordInstance<Values> & Values;
+
+// The type of a Record factory function.
+type RecordFactory<Values: Object> = Class<RecordOf<Values>>;
 
 // The values of a Record instance.
 type _RecordValues<T, R: RecordInstance<T> | T> = R;


### PR DESCRIPTION
This PR allows the following snippet to pass Flow type checks, where it was incorrectly failing before.

    //@flow
    import { Record } from 'immutable'
    import type { RecordFactory } from 'immutable';

    class ARecord extends (Record({a: 0}): RecordFactory<{a: number}>) {
    }

    const record = new ARecord();
    console.log(a.a);
