### PR TITLE
revert export type of RecordInstance

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1655,6 +1655,7 @@ export type {
   SetSeq,
   RecordFactory,
   RecordOf,
+  RecordInstance,
   ValueObject,
 
   $KeyOf,


### PR DESCRIPTION
Nice to meet you ! I always appreciate the wonderful module. The flow-type definition of `RecordFactory<T>` added from v4.0.0-rc.5 is amazing.

Today I made a PR to revert the abolition of the type definition export of `RecordInstance<T>` that was deleted at that time. I usually use an abstract Class that inherits Record like the following repository.(using v4.0.0-rc.4)

https://github.com/takefumi-yoshii/immutablejs-record-oop-example/blob/master/src/abstract.js

`RecordFactory<T>` gives us simplicity, but without the definition of `RecordInstance<T>`, we can not extends SuperClass.That repository solved all type checks. Best regurd !