### PR TITLE
Add safe refs for no-op 'map' for List and Map

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -513,6 +513,12 @@ describe('List', () => {
     expect(r.toArray()).toEqual(['A', 'B', 'C']);
   });
 
+  it('map no-ops return the same reference', () => {
+    const v = List.of('a', 'b', 'c');
+    const r = v.map(value => value);
+    expect(r).toBe(v);
+  });
+
   it('filters values', () => {
     const v = List.of('a', 'b', 'c', 'd', 'e', 'f');
     const r = v.filter((value, index) => index % 2 === 1);

--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -255,6 +255,12 @@ describe('Map', () => {
     expect(r.toObject()).toEqual({ A: 'a', B: 'b', C: 'c' });
   });
 
+  it('maps no-ops return the same reference', () => {
+    const m = Map({ a: 'a', b: 'b', c: 'c' });
+    const r = m.map(value => value);
+    expect(r).toBe(m);
+  });
+
   it('filters values', () => {
     const m = Map({ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6 });
     const r = m.filter(value => value % 2 === 1);

--- a/src/List.js
+++ b/src/List.js
@@ -171,6 +171,14 @@ export class List extends IndexedCollection {
     return setListBounds(this, 0, size);
   }
 
+  map(mapper, context) {
+    return this.withMutations(list => {
+      for (let i = 0; i < this.size; i++) {
+        list.set(i, mapper.call(context, list.get(i), i, list));
+      }
+    });
+  }
+
   // @pragma Iteration
 
   slice(begin, end) {

--- a/src/Map.js
+++ b/src/Map.js
@@ -126,6 +126,14 @@ export class Map extends KeyedCollection {
     return OrderedMap(sortFactory(this, comparator, mapper));
   }
 
+  map(mapper, context) {
+    return this.withMutations(map => {
+      map.forEach((value, key) => {
+        map.set(key, mapper.call(context, value, key, map));
+      });
+    });
+  }
+
   // @pragma Mutability
 
   __iterator(type, reverse) {

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -556,9 +556,6 @@ declare module Immutable {
      * List([ 1, 2 ]).map(x => 10 * x)
      * // List [ 10, 20 ]
      * ```
-     *
-     * Note: `map()` always returns a new instance, even if it produced the same
-     * value at every step.
      */
     map<M>(
       mapper: (value: T, key: number, iter: this) => M,
@@ -1325,9 +1322,6 @@ declare module Immutable {
      *
      *     Map({ a: 1, b: 2 }).map(x => 10 * x)
      *     // Map { a: 10, b: 20 }
-     *
-     * Note: `map()` always returns a new instance, even if it produced the same
-     * value at every step.
      */
     map<M>(
       mapper: (value: V, key: K, iter: this) => M,


### PR DESCRIPTION
This is a resubmission of #1189 

This makes it so that the `map` methods on List and Map are "safe" and will return the original collection if no modifications were made. It relies on `withMutations` which appears to already do what is desired. I did do some performance testing this time, and the changes seem to actually improve the performance.

I wasn't sure the best benchmarks to use, so let me know of any particular cases I should look more closely at.

Here are the benchmarks I ran and their results:

```
describe('List', function() {
  describe('maps values', function() {
    var array1024 = [];
    for (var ii = 0; ii < 1024; ii++) {
      array1024[ii] = ii;
    }
    var list = Immutable.List(array1024);

    it('noops', function() {
      list.map(x => x);
    });

    it('squares', function() {
      list.map(x => x * x);
    });

    it('squares evens', function() {
      list.map(x => (x % 2 === 0 ? x * x : x));
    });

    it('squares first half', function() {
      list.map(x => (x < 512 ? x * x : x));
    });

    it('squares second half', function() {
      list.map(x => (x >= 512 ? x * x : x));
    });
  });
});
```

```
describe('Map', function() {
  describe('maps values', function() {
    var obj = {};

    for (var ii = 0; ii < 1024; ii++) {
      obj['x' + ii] = ii;
    }

    var map = Immutable.Map(obj);

    it('noops', function() {
      map.map(x => x);
    });

    it('squares', function() {
      map.map(x => x * x);
    });

    it('squares evens', function() {
      map.map(x => (x % 2 === 0 ? x * x : x));
    });

    it('squares first half', function() {
      map.map(x => (x < 512 ? x * x : x));
    });

    it('squares second half', function() {
      map.map(x => (x >= 512 ? x * x : x));
    });
  });
});
```

```
yarn run v1.3.2
$ node ./resources/bench.js
List > maps values noops
  Old:     8,781     9,079     9,398 ops/sec
  New:    15,475    15,568    15,661 ops/sec
  compare: -1 1
  diff: 71.46%
  rme: 2.43%
List > maps values squares
  Old:     8,602     8,865     9,143 ops/sec
  New:    10,565    10,632    10,700 ops/sec
  compare: -1 1
  diff: 19.94%
  rme: 2.2%
List > maps values squares evens
  Old:     8,535     8,847     9,182 ops/sec
  New:     9,000     9,310     9,642 ops/sec
  compare: -1 1
  diff: 5.23%
  rme: 3.54%
List > maps values squares first half
  Old:     8,709     8,990     9,289 ops/sec
  New:    12,350    12,450    12,552 ops/sec
  compare: -1 1
  diff: 38.48%
  rme: 2.34%
List > maps values squares second half
  Old:     8,828     9,141     9,478 ops/sec
  New:     9,482     9,761    10,058 ops/sec
  compare: 0 0
  diff: 6.77%
  rme: 3.26%
Map > maps values noops
  Old:     1,702     1,912     2,181 ops/sec
  New:     8,012     8,045     8,079 ops/sec
  compare: -1 1
  diff: 320.64%
  rme: 8.71%
Map > maps values squares
  Old:     1,444     1,519     1,602 ops/sec
  New:     3,030     3,053     3,076 ops/sec
  compare: -1 1
  diff: 100.97%
  rme: 3.7%
Map > maps values squares evens
  Old:     1,463     1,548     1,643 ops/sec
  New:     3,378     3,389     3,400 ops/sec
  compare: -1 1
  diff: 118.86%
  rme: 4.1%
Map > maps values squares first half
  Old:     1,485     1,563     1,649 ops/sec
  New:     3,724     3,812     3,903 ops/sec
  compare: -1 1
  diff: 143.79%
  rme: 4.04%
Map > maps values squares second half
  Old:     2,587     2,975     3,499 ops/sec
  New:     3,593     3,731     3,880 ops/sec
  compare: 1 -1
  diff: 25.4%
  rme: 10.93%
all done
Done in 109.94s.
```