### PR TITLE
Fix runnable examples for Map.getIn

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -3800,7 +3800,7 @@ declare module Immutable {
      * ```js
      * const { Map, List } = require('immutable')
      * const deepData = Map({ x: List([ Map({ y: 123 }) ]) });
-     * getIn(deepData, ['x', 0, 'y']) // 123
+     * deepData.getIn(['x', 0, 'y']) // 123
      * ```
      *
      * Plain JavaScript Object or Arrays may be nested within an Immutable.js
@@ -3810,7 +3810,7 @@ declare module Immutable {
      * ```js
      * const { Map, List } = require('immutable')
      * const deepData = Map({ x: [ { y: 123 } ] });
-     * getIn(deepData, ['x', 0, 'y']) // 123
+     * deepData.getIn(['x', 0, 'y']) // 123
      * ```
      */
     getIn(searchKeyPath: Iterable<any>, notSetValue?: any): any;


### PR DESCRIPTION
`Map.getIn` does not take the data as its first argument, instead it is operating directly on the Map. The examples showed it correctly and weren't executable.