### PR TITLE
Make notSetValue optional for typed Records

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2432,6 +2432,7 @@ declare module Immutable {
      * produce an error when using Flow or TypeScript.
      */
     get<K extends keyof TProps>(key: K, notSetValue?: any): TProps[K];
+    get<T>(key: string, notSetValue: T): T;
 
     // Reading deep values
 

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2431,7 +2431,7 @@ declare module Immutable {
      * notSetValue will be returned if provided. Note that this scenario would
      * produce an error when using Flow or TypeScript.
      */
-    get<K extends keyof TProps>(key: K, notSetValue: any): TProps[K];
+    get<K extends keyof TProps>(key: K, notSetValue?: any): TProps[K];
 
     // Reading deep values
 


### PR DESCRIPTION
Tiny change to the type definitions.

First of all type-safe immutable records are glorious, thank you! I am a huge fan of what you are doing here. Secondly, your type declarations throw compiler errors for using the API as per the documentation. In your [documentation for Record](https://facebook.github.io/immutable-js/docs/#/Record). You use `get` like so:

```JavaScript
const { Record } = require('immutable@4.0.0-rc.9')
const ABRecord = Record({ a: 1, b: 2 })
const myRecord = new ABRecord({ b: 3 })

myRecord.get('a') // 1
```

Doing this with the current type definition produces the following error: `Expected 2 arguments, but got 1`

My new type definition will give you the following behavior:

```Typescript
const { Record } = require('immutable@4.0.0-rc.9')
const ABRecord = Record({ a: 1, b: 2 })
const myRecord = new ABRecord({ b: 3 })

myRecord.get('a') // Type: number
myRecord.get('a', 'a') // Type: number
myRecord.get('v', 'a') // Type: string
myRecord.get('v') // Error: 
// Argument of type '"v"' is not assignable to parameter of type '"a" | "b"'
```

This seems to capture the API pretty well. 

### Dicussion

With type safe records you could forbid the `notSetValue` entirely. Since we can force `key` to be a key of `TProps` we should never need a `notSetValue`. Using one in these cases will probably be unintentional. But this means there are ways to validly use the API in JS that you can't in TypeScript, which is understandable not to want.