### PR TITLE
Fix “Github” typos on Immutable.js website

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,10 +383,10 @@ contains articles on specific topics. Can&#39;t find something? Open an <a href=
 <h2 id="testing">Testing</h2>
 <p>If you are using the <a href="http://chaijs.com/">Chai Assertion Library</a>, <a href="https://github.com/astorije/chai-immutable">Chai Immutable</a> provides a set of assertions to use against Immutable.js collections.</p>
 <h2 id="contribution">Contribution</h2>
-<p>Use <a href="https://github.com/facebook/immutable-js/issues">Github issues</a> for requests.</p>
+<p>Use <a href="https://github.com/facebook/immutable-js/issues">GitHub issues</a> for requests.</p>
 <p>We actively welcome pull requests, learn how to <a href="./.github/CONTRIBUTING.md">contribute</a>.</p>
 <h2 id="changelog">Changelog</h2>
-<p>Changes are tracked as <a href="https://github.com/facebook/immutable-js/releases">Github releases</a>.</p>
+<p>Changes are tracked as <a href="https://github.com/facebook/immutable-js/releases">GitHub releases</a>.</p>
 <h2 id="thanks">Thanks</h2>
 <p><a href="https://www.youtube.com/watch?v=K2NYwP90bNs">Phil Bagwell</a>, for his inspiration
 and research in persistent data structures.</p>


### PR DESCRIPTION
There are two occurrences of `Github` (instead of `GitHub`) on the official [Immutable.js website](https://facebook.github.io/immutable-js/).

This pull requests fixes both typos.