### PR TITLE
Hashing functions as objects

### DIFF
--- a/__tests__/hash.ts
+++ b/__tests__/hash.ts
@@ -29,6 +29,24 @@ describe('hash', () => {
     expect(hash(123.4567)).toBe(887769707);
   });
 
+  it('generates different hashes for different objects', () => {
+    const objA = {};
+    const objB = {};
+    expect(hash(objA)).toBe(hash(objA));
+    expect(hash(objA)).not.toBe(hash(objB));
+  });
+
+  it('generates different hashes for different functions', () => {
+    const funA = () => {
+      return;
+    };
+    const funB = () => {
+      return;
+    };
+    expect(hash(funA)).toBe(hash(funA));
+    expect(hash(funA)).not.toBe(hash(funB));
+  });
+
   const genValue = gen.oneOf([gen.string, gen.int]);
 
   check.it('generates unsigned 31-bit integers', [genValue], value => {

--- a/src/Hash.js
+++ b/src/Hash.js
@@ -44,7 +44,7 @@ export function hash(o) {
     // Drop any high bits from accidentally long hash codes.
     return smi(o.hashCode());
   }
-  if (type === 'object') {
+  if (type === 'object' || type === 'function') {
     return hashJSObj(o);
   }
   if (typeof o.toString === 'function') {


### PR DESCRIPTION
Right now there is no logic for hashing functions and Immutable.js uses `.toString()` to compare them.
I'd suggest to perceive functions as objects and use `hashJSObj`.