### PR TITLE
Documentation: correct the default reviver

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -4686,7 +4686,7 @@ declare module Immutable {
    * ```js
    * const { fromJS, isKeyed } = require('immutable')
    * function (key, value) {
-   *   return isKeyed(value) ? value.Map() : value.toList()
+   *   return isKeyed(value) ? value.toMap() : value.toList()
    * }
    * ```
    *


### PR DESCRIPTION
`Seq.Keyed` does not have `.Map`, and [the default reviver](https://github.com/facebook/immutable-js/blob/master/src/fromJS.js#L49) indeed uses `.toMap`.