### PR TITLE
fix: fix typo in docs. ES3 -> ES5

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -80,7 +80,7 @@
  *
  *
  * Note: All examples are presented in the modern [ES2015][] version of
- * JavaScript. To run in older browsers, they need to be translated to ES3.
+ * JavaScript. To run in older browsers, they need to be translated to ES5.
  *
  * For example:
  *

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -80,7 +80,7 @@
  *
  *
  * Note: All examples are presented in the modern [ES2015][] version of
- * JavaScript. To run in older browsers, they need to be translated to ES5.
+ * JavaScript. Use tools like Babel to support older browsers.
  *
  * For example:
  *


### PR DESCRIPTION
## Fix the typo in Immutable.d.ts

* ES3 should be ES5

![2018-03-06 5 00 05](https://user-images.githubusercontent.com/12542369/37023107-ddda3372-215f-11e8-8cde-65c1aaddf3d1.png)


