### PR TITLE
Add API documentation to OrderedMap.set()

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -1430,6 +1430,27 @@ declare module Immutable {
     readonly size: number;
 
     /**
+     * Returns a new OrderedMap also containing the new key, value pair. If an equivalent
+     * key already exists in this OrderedMap, it will be replaced while maintaining the
+     * existing order.
+     *
+     * <!-- runkit:activate -->
+     * ```js
+     * const { OrderedMapMap } = require('immutable')
+     * const originalMap = Immutable.OrderedMap({a:1, b:1, c:1})
+     * const updatedMap = originalMap.set('b', 2)
+     *
+     * originalMap
+     * // OrderedMap {a: 1, b: 1, c: 1}
+     * updatedMap
+     * // OrderedMap {a: 1, b: 2, c: 1}
+     * ```
+     *
+     * Note: `set` can be used in `withMutations`.
+     */
+    set(key: K, value: V): this;
+
+    /**
      * Returns a new OrderedMap resulting from merging the provided Collections
      * (or JS objects) into this OrderedMap. In other words, this takes each
      * entry of each collection and sets it on this OrderedMap.


### PR DESCRIPTION
Add specific documentation to `OrderedMap.set` stating that it returns a new OrderedMap and maintains the existing order.

This attempts to avoid confusion between users as the current documentation for this method inherits from `Immutable.Map` which can be understood like an `OrderedMap.set() => Map`, which is wrong, and might lead to uncertainty about the order of the entries. This Pull Request adds the missing bit to the documentation.

[Link to relevant documentation part of OrderedMap.set()](https://facebook.github.io/immutable-js/docs/#/OrderedMap/set)