### PR TITLE
Fix docs website style

### DIFF
--- a/pages/src/docs/src/style.less
+++ b/pages/src/docs/src/style.less
@@ -27,7 +27,6 @@
   text-align: center;
   font-size: 0.8em;
   position: relative;
-  z-index: 1;
 }
 
 @media only screen and (max-width: 680px) {


### PR DESCRIPTION
Remove css rule `z-index` for `.disclaimer` selector.
***

I noticed the problem (for example [on page](https://facebook.github.io/immutable-js/docs/#/is)):
![ashampoo_snap_21 2018 _15h47m47s_008_](https://user-images.githubusercontent.com/6622187/37705892-438c6ea4-2d1f-11e8-8c72-571353e7cca0.png)

The rule (`z-index: 1`) was added in #873 and after merged #891 this rule no longer required.
I deleted the rule fixed stacking context.