### PR TITLE
Typo fix for code sample in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,8 +556,8 @@ Any collection can be converted to a lazy Seq with `Seq()`.
 
 <!-- runkit:activate -->
 ```js
-const { Map } = require('immutable')
-const map = Map({ a: 1, b: 2, c: 3 }
+const { Map, Seq } = require('immutable')
+const map = Map({ a: 1, b: 2, c: 3 })
 const lazySeq = Seq(map)
 ```
 


### PR DESCRIPTION
Existing code sample was missing an import and had a syntax error.