### PR TITLE
Fix collection size check in merge

### DIFF
--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -15,6 +15,7 @@ import {
   merge,
   mergeDeep,
   mergeDeepWith,
+  Record,
   Set,
 } from '../';
 
@@ -228,5 +229,10 @@ describe('merge', () => {
     expect(merged).toEqual(
       Map([[a, Map([[b, Map([[c, 10], [d, 2], [e, 20], [f, 30], [g, 40]])]])]])
     );
+  });
+
+  it('merges records with a size property set to 0', () => {
+    const Sizable = Record({ size: 0 });
+    expect(Sizable().merge({ size: 123 }).size).toBe(123);
   });
 });

--- a/src/methods/merge.js
+++ b/src/methods/merge.js
@@ -28,7 +28,11 @@ function mergeIntoKeyedWith(collection, collections, merger) {
   if (iters.length === 0) {
     return collection;
   }
-  if (collection.size === 0 && !collection.__ownerID && iters.length === 1) {
+  if (
+    collection.toSeq().size === 0 &&
+    !collection.__ownerID &&
+    iters.length === 1
+  ) {
     return collection.constructor(iters[0]);
   }
   return collection.withMutations(collection => {


### PR DESCRIPTION
Fixes #1490

Records can have a size property (`collection.size`, in the [existing code](https://github.com/facebook/immutable-js/blob/master/src/methods/merge.js#L31)) that is independent of the calculated immutable Collection `size` property; using `toSeq()` ensures that the Collection.size property is checked instead. Also added a test case to verify the edge case that this resolves.

In debugging the original issue, I found that adding `return this;` to the end of the `RecordType` function in Record.js (https://github.com/facebook/immutable-js/blob/master/src/Record.js#L76) also deals with #1490. This is because that function was getting erroneously invoked from `mergeIntoKeyedWith` when called on a record with `{size: 0}` from `return collection.constructor(iters[0]);`, and adding the final return ensures that `collection.constructor(iters[0])` still returns the correct thing. I wasn’t sure if there is any other code path that could lead to that function being invoked with the expectation of getting the record instance returned, but if so, I’d be happy to add the final `return this;` to this PR.