### PR TITLE
mergeDeepWith merger is untypable.

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -1047,7 +1047,7 @@ declare module Immutable {
      * Note: `mergeDeepWith` can be used in `withMutations`.
      */
     mergeDeepWith(
-      merger: (oldVal: V, newVal: V, key: K) => V,
+      merger: (oldVal: any, newVal: any, key: any) => any,
       ...collections: Array<Iterable<[K, V]> | {[key: string]: V}>
     ): this;
 

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -896,10 +896,10 @@ declare class Map<K, +V> extends KeyedCollection<K, V> mixins UpdatableInCollect
     ...collections: (Iterable<[K_, V_]> | PlainObjInput<K_, V_>)[]
   ): Map<K | K_, V | V_>;
 
-  mergeDeepWith<K_, W, X>(
-    merger: (oldVal: V, newVal: W, key: K) => X,
-    ...collections: (Iterable<[K_, W]> | PlainObjInput<K_, W>)[]
-  ): Map<K | K_, V | W | X>;
+  mergeDeepWith<K_, V_>(
+    merger: (oldVal: any, newVal: any, key: any) => mixed,
+    ...collections: (Iterable<[K_, V_]> | PlainObjInput<K_, V_>)[]
+  ): Map<K | K_, V | V_>;
 
   mergeIn(
     keyPath: Iterable<mixed>,
@@ -982,10 +982,10 @@ declare class OrderedMap<K, +V> extends Map<K, V> mixins UpdatableInCollection<K
     ...collections: (Iterable<[K_, V_]> | PlainObjInput<K_, V_>)[]
   ): OrderedMap<K | K_, V | V_>;
 
-  mergeDeepWith<K_, W, X>(
-    merger: (oldVal: V, newVal: W, key: K) => X,
-    ...collections: (Iterable<[K_, W]> | PlainObjInput<K_, W>)[]
-  ): OrderedMap<K | K_, V | W | X>;
+  mergeDeepWith<K_, V_>(
+    merger: (oldVal: any, newVal: any, key: any) => mixed,
+    ...collections: (Iterable<[K_, V_]> | PlainObjInput<K_, V_>)[]
+  ): OrderedMap<K | K_, V | V_>;
 
   mergeIn(
     keyPath: Iterable<mixed>,

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -337,18 +337,6 @@ import { Map, List } from '../../';
   Map<number, number>().mergeDeepWith((prev: number, next: number, key: number) => 1, Map<number, number>());
 
   // $ExpectError
-  Map<number, number>().mergeDeepWith((prev: string, next: number, key: number) => 1, Map<number, number>());
-
-  // $ExpectError
-  Map<number, number>().mergeDeepWith((prev: number, next: string, key: number) => 1, Map<number, number>());
-
-  // $ExpectError
-  Map<number, number>().mergeDeepWith((prev: number, next: number, key: string) => 1, Map<number, number>());
-
-  // $ExpectError
-  Map<number, number>().mergeDeepWith((prev: number, next: number, key: number) => 'a', Map<number, number>());
-
-  // $ExpectError
   Map<number, number>().mergeDeepWith((prev: number, next: number, key: number) => 1, Map<number, string>());
 
   // $ExpectType Map<string, number>

--- a/type-definitions/ts-tests/ordered-map.ts
+++ b/type-definitions/ts-tests/ordered-map.ts
@@ -337,18 +337,6 @@ import { OrderedMap, List } from '../../';
   OrderedMap<number, number>().mergeDeepWith((prev: number, next: number, key: number) => 1, OrderedMap<number, number>());
 
   // $ExpectError
-  OrderedMap<number, number>().mergeDeepWith((prev: string, next: number, key: number) => 1, OrderedMap<number, number>());
-
-  // $ExpectError
-  OrderedMap<number, number>().mergeDeepWith((prev: number, next: string, key: number) => 1, OrderedMap<number, number>());
-
-  // $ExpectError
-  OrderedMap<number, number>().mergeDeepWith((prev: number, next: number, key: string) => 1, OrderedMap<number, number>());
-
-  // $ExpectError
-  OrderedMap<number, number>().mergeDeepWith((prev: number, next: number, key: number) => 'a', OrderedMap<number, number>());
-
-  // $ExpectError
   OrderedMap<number, number>().mergeDeepWith((prev: number, next: number, key: number) => 1, OrderedMap<number, string>());
 
   // $ExpectType OrderedMap<string, number>


### PR DESCRIPTION
Because it can be called at any layer in a datastructure merge, we cannot know apriori what types may be considered. For convenience we just use `any`.

Fixes #1513