### PR TITLE
isPalinObj not detect a object like {constructor: 'Adam'} as plain ob…

### DIFF
--- a/src/utils/isPlainObj.js
+++ b/src/utils/isPlainObj.js
@@ -1,16 +1,16 @@
 export default function isPlainObj(value) {
   // Basic check for Type object that's not null
-  if (typeof value == 'object' && value !== null) {
+  if (typeof value === 'object' && value !== null) {
 
     // If Object.getPrototypeOf supported, use it
-    if (typeof Object.getPrototypeOf == 'function') {
-      var proto = Object.getPrototypeOf(value);
+    if (typeof Object.getPrototypeOf === 'function') {
+      const proto = Object.getPrototypeOf(value);
       return proto === Object.prototype || proto === null;
     }
     
     // Otherwise, use internal class
     // This should be reliable as if getPrototypeOf not supported, is pre-ES5
-    return Object.prototype.toString.call(value) == '[object Object]';
+    return Object.prototype.toString.call(value) === '[object Object]';
   }
   
   // Not an object

--- a/src/utils/isPlainObj.js
+++ b/src/utils/isPlainObj.js
@@ -1,18 +1,17 @@
 export default function isPlainObj(value) {
   // Basic check for Type object that's not null
   if (typeof value === 'object' && value !== null) {
-
     // If Object.getPrototypeOf supported, use it
     if (typeof Object.getPrototypeOf === 'function') {
       const proto = Object.getPrototypeOf(value);
       return proto === Object.prototype || proto === null;
     }
-    
+
     // Otherwise, use internal class
     // This should be reliable as if getPrototypeOf not supported, is pre-ES5
     return Object.prototype.toString.call(value) === '[object Object]';
   }
-  
+
   // Not an object
   return false;
 }

--- a/src/utils/isPlainObj.js
+++ b/src/utils/isPlainObj.js
@@ -1,12 +1,18 @@
-/**
- * Copyright (c) 2014-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 export default function isPlainObj(value) {
-  return (
-    value && (value.constructor === Object || value.constructor === undefined)
-  );
+  // Basic check for Type object that's not null
+  if (typeof value == 'object' && value !== null) {
+
+    // If Object.getPrototypeOf supported, use it
+    if (typeof Object.getPrototypeOf == 'function') {
+      var proto = Object.getPrototypeOf(value);
+      return proto === Object.prototype || proto === null;
+    }
+    
+    // Otherwise, use internal class
+    // This should be reliable as if getPrototypeOf not supported, is pre-ES5
+    return Object.prototype.toString.call(value) == '[object Object]';
+  }
+  
+  // Not an object
+  return false;
 }


### PR DESCRIPTION
…ject

In according to https://stackoverflow.com/questions/5876332/how-can-i-differentiate-between-an-object-literal-other-javascript-objects
I propose next fix.