### PR TITLE
Create nested records on Record construction

### DIFF
--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -146,6 +146,52 @@ describe('Record', () => {
     expect(t4).toBe(t2);
   });
 
+  it('creates nested records when when default value is a record', () => {
+    const MyDeepInnerType = Record({
+      oneFish: 'twoFish',
+      redFish: 'blueFish',
+      blackFish: 'blueFish',
+      oldFish: 'newFish',
+    });
+    const MyInnerType = Record({
+      a: 1,
+      b: 2,
+      c: 3,
+      deep: MyDeepInnerType({ redFish: 'snapper' }),
+    });
+    const MyOuterType = Record({
+      one: 1,
+      two: 2,
+      inner: MyInnerType({
+        a: 99,
+        deep: {
+          blackFish: 'Brynden Tully',
+        } as any,
+      }),
+    });
+    const t = MyOuterType({
+      two: 4,
+      inner: { b: 3, deep: { oldFish: 'stinky' } } as any,
+    });
+    expect(t.inner instanceof MyInnerType).toBe(true);
+    expect(t.inner.deep instanceof MyDeepInnerType).toBe(true);
+    expect(t.toJS()).toEqual({
+      one: 1,
+      two: 4,
+      inner: {
+        a: 99,
+        b: 3,
+        c: 3,
+        deep: {
+          oneFish: 'twoFish',
+          redFish: 'snapper',
+          blackFish: 'Brynden Tully',
+          oldFish: 'stinky',
+        },
+      },
+    });
+  });
+
   it('returns record when setting values', () => {
     const MyType = Record({ a: 1, b: 2 });
     const t1 = MyType();

--- a/src/Record.js
+++ b/src/Record.js
@@ -71,7 +71,15 @@ export class Record {
       this._values = List().withMutations(l => {
         l.setSize(this._keys.length);
         KeyedCollection(values).forEach((v, k) => {
-          l.set(this._indices[k], v === this._defaultValues[k] ? undefined : v);
+          const listIndex = this._indices[k];
+          const defaultValue = this._defaultValues[k];
+          if (v === defaultValue) {
+            v = undefined;
+          }
+          if (typeof v === 'object' && isRecord(defaultValue)) {
+            v = defaultValue.mergeDeep(v);
+          }
+          l.set(listIndex, v);
         });
       });
     };


### PR DESCRIPTION
If a default value for a key(`innerKey`) of a record type (`OuterRecordType`) is another record (`innerRecord`), upon construction of `OuterRecordType`, if the `innerKey` is set to a plain Javascript object (`innerObject`), the constructed record (`outerRecord`) will have a value for `innerKey` that is the result of deeply merging the `innerObject` into the `innerRecord`.

```javascript
import Immutable from 'immmutable';

const InnerRecordType = Immutable.Record({
  a: 10,
  b: 20,
  c: 30,
});

const OuterRecordType = Immutable.Record({
  one: 1,
  two: 2,
  innerKey: InnerRecordType({ a: 0 }),
});

const outerRecord = OuterRecordType({ innerKey: { c: 40 } });

outerRecord.innerKey instanceof InnerRecordType // true
outerRecord.innerKey.a // 0
outerRecord.innerKey.b // 20
outerRecord.innerKey.c // 40
```

Records can also be deeply nested