### PR TITLE
type-definitions: fix has() for TypeScript 2.9

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2440,7 +2440,7 @@ declare module Immutable {
 
     // Reading values
 
-    has(key: string): key is keyof TProps;
+    has(key: string | number | Symbol): key is keyof TProps;
 
     /**
      * Returns the value associated with the provided key, which may be the


### PR DESCRIPTION
I'm not sure this is the _right_ fix, but it is _a_ fix.  TypeScript
2.9 (in RC, due out soon AIUI) has a breaking change around `keyof`:

> TypeScript 2.9 changes the behavior of `keyof` to factor in both unique symbols as well as numeric literal types. ([announcement](https://blogs.msdn.microsoft.com/typescript/2018/05/16/announcing-typescript-2-9-rc/))

This PR fixes things, but I'm not sure of compatability with <= 2.8?
Happy to revise or look into this further.