### PR TITLE
throw error in mergeWith method if no merger is passed (#1503)

### DIFF
--- a/__tests__/merge.ts
+++ b/__tests__/merge.ts
@@ -40,6 +40,12 @@ describe('merge', () => {
     );
   });
 
+  it('throws typeError without merge function', () => {
+    const m1 = Map({ a: 1, b: 2, c: 3 });
+    const m2 = Map({ d: 10, b: 20, e: 30 });
+    expect(() => m1.mergeWith(1, m2)).toThrowError(TypeError);
+  });
+
   it('provides key as the third argument of merge function', () => {
     const m1 = Map({ id: 'temp', b: 2, c: 3 });
     const m2 = Map({ id: 10, b: 20, e: 30 });

--- a/src/functional/merge.js
+++ b/src/functional/merge.js
@@ -38,7 +38,8 @@ export function mergeWithSources(collection, sources, merger) {
     );
   }
   if (isImmutable(collection)) {
-    return collection.mergeWith
+    const shouldMergeWith = collection.mergeWith && merger instanceof Function;
+    return shouldMergeWith
       ? collection.mergeWith(merger, ...sources)
       : collection.concat(...sources);
   }

--- a/src/functional/merge.js
+++ b/src/functional/merge.js
@@ -38,10 +38,14 @@ export function mergeWithSources(collection, sources, merger) {
     );
   }
   if (isImmutable(collection)) {
-    const shouldMergeWith = collection.mergeWith && merger instanceof Function;
-    return shouldMergeWith
-      ? collection.mergeWith(merger, ...sources)
-      : collection.concat(...sources);
+    const mergerIsFunction = merger instanceof Function;
+    const shouldMergeWith = collection.mergeWith && mergerIsFunction;
+    if (shouldMergeWith) {
+      return collection.mergeWith(merger, ...sources);
+    } else if (collection.merge && !mergerIsFunction) {
+      return collection.merge(...sources);
+    }
+    return collection.concat(...sources);
   }
   const isArray = Array.isArray(collection);
   let merged = collection;

--- a/src/methods/merge.js
+++ b/src/methods/merge.js
@@ -14,7 +14,10 @@ export function merge(...iters) {
 }
 
 export function mergeWith(merger, ...iters) {
-  return mergeIntoKeyedWith(this, iters, merger);
+  if (merger instanceof Function) {
+    return mergeIntoKeyedWith(this, iters, merger);
+  }
+  throw new TypeError('Invalid merger: Expected Function');
 }
 
 function mergeIntoKeyedWith(collection, collections, merger) {


### PR DESCRIPTION
This ensures users get an informative error when calling `mergeWith` without a merge function

Details can be found at https://github.com/facebook/immutable-js/issues/1503.