### PR TITLE
differentiate falsy values when hashing (#1547)

### DIFF
--- a/__tests__/Equality.ts
+++ b/__tests__/Equality.ts
@@ -147,5 +147,8 @@ describe('Equality', () => {
     it('differentiates decimals', () => {
       expect(Seq([1.5]).hashCode()).not.toBe(Seq([1.6]).hashCode());
     });
+    it('differentiates falsy values', () => {
+      expect(Seq([undefined]).hashCode()).not.toBe(Seq([false]).hashCode());
+    });
   });
 });

--- a/__tests__/hash.ts
+++ b/__tests__/hash.ts
@@ -15,10 +15,10 @@ import { hash } from '../';
 describe('hash', () => {
   it('stable hash of well known values', () => {
     expect(hash(true)).toBe(1);
-    expect(hash(false)).toBe(0);
+    expect(hash(false)).toBe(64711720);
     expect(hash(0)).toBe(0);
-    expect(hash(null)).toBe(0);
-    expect(hash(undefined)).toBe(0);
+    expect(hash(null)).toBe(-1023368385);
+    expect(hash(undefined)).toBe(-1038130864);
     expect(hash('a')).toBe(97);
     expect(hash('immutable-js')).toBe(510203252);
     expect(hash(123)).toBe(123);

--- a/src/Hash.js
+++ b/src/Hash.js
@@ -9,7 +9,7 @@ import { smi } from './Math';
 
 export function hash(o) {
   if (o === false || o === null || o === undefined) {
-    return 0;
+    return cachedHashString(typeof o);
   }
   if (typeof o.valueOf === 'function') {
     o = o.valueOf();


### PR DESCRIPTION
this PR fixes https://github.com/facebook/immutable-js/issues/1547

