### PR TITLE
Update isPlainObj to workaround Safari bug

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.fb.com/codeofconduct/) so that you can understand what actions will and will not be tolerated.

--- a/src/utils/isPlainObj.js
+++ b/src/utils/isPlainObj.js
@@ -7,6 +7,8 @@
 
 export default function isPlainObj(value) {
   return (
-    value && (value.constructor === Object || value.constructor === undefined)
+    value &&
+    ((value.constructor && value.constructor.name === 'Object') ||
+      value.constructor === undefined)
   );
 }


### PR DESCRIPTION
While debugging an issue in the wild with our library [boomerang](https://github.com/akamai/boomerang), we uncovered a [bug in webkit](https://bugs.webkit.org/show_bug.cgi?id=187411) that causes `xhr.response` to no longer work with Immutable.js.

You can see the issue reproduce here: 
https://cvazac.netlify.com/xhr-response-constructor-immutable

This small code change works around version 605.1.15 of Safari.