### PR TITLE
Set "size" is wrong when deduplicating complex objects

### DIFF
--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -8,7 +8,7 @@
 ///<reference path='../resources/jest.d.ts'/>
 
 declare var Symbol: any;
-import { is, List, Map, OrderedSet, Seq, Set } from '../';
+import { fromJS, is, List, Map, OrderedSet, Seq, Set } from '../';
 
 describe('Set', () => {
   it('accepts array of values', () => {
@@ -303,5 +303,45 @@ describe('Set', () => {
     expect(set.count()).toEqual(5);
     expect(set.count(x => x % 2 === 0)).toEqual(2);
     expect(set.count(x => true)).toEqual(5);
+  });
+
+  describe('"size" should correctly reflect the number of elements in a Set', () => {
+    describe('deduplicating custom classes that invoke fromJS() as part of equality check', () => {
+      class Entity {
+        constructor(entityId, entityKey) {
+          this.entityId = entityId;
+          this.entityKey = entityKey;
+        }
+        asImmutable() {
+          return fromJS({
+            entityId: this.entityId,
+            entityKey: this.entityKey,
+          });
+        }
+        valueOf() {
+          return this.asImmutable().toString();
+        }
+      }
+
+      it('with mutations', () => {
+        const testSet = Set().withMutations(mutableSet => {
+          mutableSet.add(new Entity('hello', 'world'));
+          mutableSet.add(new Entity('testing', 'immutable'));
+          mutableSet.add(new Entity('hello', 'world'));
+        });
+        expect(testSet.size).toEqual(2);
+      });
+
+      it('without mutations', () => {
+        const testSet0 = Set();
+        const testSet1 = testSet0.add(new Entity('hello', 'world'));
+        const testSet2 = testSet1.add(new Entity('testing', 'immutable'));
+        const testSet3 = testSet2.add(new Entity('hello', 'world'));
+        expect(testSet0.size).toEqual(0);
+        expect(testSet1.size).toEqual(1);
+        expect(testSet2.size).toEqual(2);
+        expect(testSet3.size).toEqual(2);
+      });
+    });
   });
 });

--- a/src/TrieUtils.js
+++ b/src/TrieUtils.js
@@ -23,7 +23,7 @@ export const DID_ALTER = { value: false };
 
 export function MakeRef(ref) {
   ref.value = false;
-  return ref;
+  return Object.assign({}, ref);
 }
 
 export function SetRef(ref) {


### PR DESCRIPTION
I think I've discovered a bug with `TrieUtils.MakeRef()` while exploring using `Immutable.Set` as a way to deduplicate complex objects / custom class instances. As an example:
```
class Entity {
  constructor(entityId, entityKey) {
    this.entityId = entityId;
    this.entityKey = entityKey;
  }
  asImmutable() {
    return fromJS({
      entityId: this.entityId,
      entityKey: this.entityKey,
    });
  }
  valueOf() {
    // this seems to be problematic
    return this.asImmutable().toString(); 

    // this seems to be problematic as well
    // return this.asImmutable().hashCode();

    // this does not trigger the bug
    // return JSON.stringify({ entityId: this.entityId, entityKey: this.entityKey });
  }
}
```
When `Entity` objects are added to a `Set`, `immutable-js` eventually invokes `valueOf()` as part of the equality check. To my surprise, any implementation of `valueOf()` that ends up invoking `Immutable.fromJS()` results in a set with the wrong `size` property, though it has the correct number of elements.

After further digging into this, it seems to me that `TrieUtils.MakeRef()` is at the root of this issue.

Let's debug:
```
const testSet = Set().withMutations(mutableSet => {
  mutableSet.add(new Entity('hello', 'world'));
  mutableSet.add(new Entity('testing', 'immutable'));
  mutableSet.add(new Entity('hello', 'world'));
});
```
1. When the third `.add()` is invoked, `immutable-js` eventually gets to `Map.js > updateMap()` where it calls `MakeRef(CHANGE_LENGTH)` and `MakeRef(DID_ALTER)`: 
https://github.com/facebook/immutable-js/blob/master/src/Map.js#L659
At this point, we have `didAlter: {value: false}` and `didChangeSize: {value: false}`.

2. Next, `immutable-js` gets to `Map.js > ArrayMapNode > update()`, where it invokes `is()` for equality check.
https://github.com/facebook/immutable-js/blob/master/src/Map.js#L227

3. Next, `is()` will call `valueOf()` on both objects being compared, which means the custom `valueOf()` implementation on the `Entity` class above will be executed.
https://github.com/facebook/immutable-js/blob/master/src/is.js#L75

4. Next, `valueOf()` invokes `Immutable.fromJS()`, and eventually, this leads us to the `Immutable.Map` constructor, which leads back to `Map.js > updateMap()`, then again to `Map.js > ArrayMapNode > update()`. `immutable-js` proceeds to call `SetRef(didAlter)` and `SetRef(didChangeSize)`
https://github.com/facebook/immutable-js/blob/master/src/Map.js#L237
https://github.com/facebook/immutable-js/blob/master/src/Map.js#L238

5. Next, as we pop out of the callstack, we end up back in `Map.js > ArrayMapNode > update()`, where we have just completed the for loop for the equality check. Remember, before we started the equality check, we had `didAlter: {value: false}` and `didChangeSize: {value: false}`. After the for loop has completed, `exists` is correctly set to `true` because we have indeed tried to add a duplicate item, **BUT**, now we have `didAlter: {value: true}` and `didChangeSize: {value: true}`. The values have changed from `false` to `true`.

6. Next, we step to `SetRef(didAlter);` followed by the next line `(removed || !exists) && SetRef(didChangeSize);`
https://github.com/facebook/immutable-js/blob/master/src/Map.js#L238
Here, `SetRef(didChangeSize)` was **NOT** called, which is correct, however, `didChangeSize` already has been set to `true` previously, which is not expected.

7. Next, we pop out of the callstack back to `Map.js > updateMap()`, where `didChangeSize` is checked, and `newSize` is incorrectly incremented by 1.
https://github.com/facebook/immutable-js/blob/master/src/Map.js#L674

At this point, we have a Set where the backing/internal map has `size: 3`, but `_root.entries` has only 2 elements.

![screen shot 2018-07-18 at 1 03 09 pm](https://user-images.githubusercontent.com/440299/42904828-2092fd2c-8a8b-11e8-8523-f0e63e846580.png)

It seems that since `MakeRef()` is updating and returning the `ref` param, it actually is mutating the same object from further up in the callstack. I'm not sure if this is intentional or not, but it seems like it results in an undesired side effect.

As a workaround, I can get the desired behavior if I change the `valueOf()` implementation to this:
```
valueOf() {
  return JSON.stringify({
    entityId: this.entityId,
    entityKey: this.entityKey
  });
}
```
In conclusion, I'm not certain that the fix I'm submitting is the correct approach for fixing this bug. I've added a test case to cover this scenario exactly. It'd be great to get feedback on the fix, as well as any suggestions around how to correctly use a `Set` to avoid duplicates with classes similar to `Entity`.