### PR TITLE
FIX Broken link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ Contribution
 
 Use [Github issues](https://github.com/facebook/immutable-js/issues) for requests.
 
-We actively welcome pull requests, learn how to [contribute](./.github/CONTRIBUTING.md).
+We actively welcome pull requests, learn how to [contribute](https://github.com/facebook/immutable-js/blob/master/.github/CONTRIBUTING.md).
 
 
 Changelog


### PR DESCRIPTION
While reading immutable-js web docs I've found a broken link under contribution section. 

_We actively welcome pull requests, learn how to contribute._

The link path works on Github. However, that same link is broken on the web docs.

I have updated the link accordingly and it now works on both Github docs and web docs on https://facebook.github.io/immutable-js/.
