### PR TITLE
Fix TypeScript issue with `Record` `has` method.

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2440,7 +2440,7 @@ declare module Immutable {
 
     // Reading values
 
-    has(key: string): key is keyof TProps;
+    has<K extends keyof TProps>(key: K): boolean;
 
     /**
      * Returns the value associated with the provided key, which may be the


### PR DESCRIPTION
The old version was causing type errors with my TypeScript configuration due to key being `string` / `number` / `Symbol`.

**The issue:**
![image](https://user-images.githubusercontent.com/424694/44294818-07ff7400-a252-11e8-88f1-81f7577627c3.png)

- This is closer to the `get` function definition below it:
```ts
has<K extends keyof TProps>(key: K): boolean;
```

**After the fix:**
![image](https://user-images.githubusercontent.com/424694/44294792-d1c1f480-a251-11e8-886b-3a6d86ac5b00.png)
