### PR TITLE
Add `RecordOf<TProps>` type alias for TypeScript

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2565,7 +2565,7 @@ declare module Immutable {
    * 
    * This is equivalent to an instance of a record created by a Record Factory.
    */
-  export type RecordOf<TProps extends Object> = Record<TProps> & TProps;
+  export type RecordOf<TProps extends Object> = Record<TProps> & ReadOnly<TProps>;
 
   /**
    * `Seq` describes a lazy operation, allowing them to efficiently chain

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2559,6 +2559,14 @@ declare module Immutable {
     [Symbol.iterator](): IterableIterator<[keyof TProps, TProps[keyof TProps]]>;
   }
 
+  /** 
+   * RecordOf<T> is used in TypeScript to define interfaces expecting an
+   * instance of record with type T.
+   * 
+   * This is equivalent to an instance of a record created by a Record Factory.
+   */
+  export type RecordOf<TProps extends Object> = Record<TProps> & TProps;
+
   /**
    * `Seq` describes a lazy operation, allowing them to efficiently chain
    * use of all the higher-order collection methods (such as `map` and `filter`)

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2559,13 +2559,14 @@ declare module Immutable {
     [Symbol.iterator](): IterableIterator<[keyof TProps, TProps[keyof TProps]]>;
   }
 
-  /** 
+  /**
    * RecordOf<T> is used in TypeScript to define interfaces expecting an
    * instance of record with type T.
-   * 
+   *
    * This is equivalent to an instance of a record created by a Record Factory.
    */
-  export type RecordOf<TProps extends Object> = Record<TProps> & ReadOnly<TProps>;
+  export type RecordOf<TProps extends Object> = Record<TProps> &
+    Readonly<TProps>;
 
   /**
    * `Seq` describes a lazy operation, allowing them to efficiently chain


### PR DESCRIPTION
The `Record.Factory` API is great but the current definitions lack a simple way to reference instances of a record (created from a record factory). This adds a `RecordOf<TProps>` which can be used to create interfaces containing records:

```ts
import { Record, RecordOf } from "immutable";

interface Foo {
    flag: boolean;
    message: string;
}

const FooRecord = Record<Foo>({
    flag: false,
    message: "DEFAULT"
});

interface Bar {
    foo: RecordOf<Foo>;
}

const bar: Bar = {
    foo: new FooRecord({ flag: true })
}
```

Currently I've been creating this type in every library so that I can refer to instances and I think Flow has support for something similar.