### PR TITLE
Enable flow strict

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -25,7 +25,7 @@
  *
  *     takesASeq(someSeq)
  *
- * @flow
+ * @flow strict
  */
 
 // Helper type that represents plain objects allowed as arguments to


### PR DESCRIPTION
Allows downstream dependencies to enable the flow nonstrict-import rule