### PR TITLE
[BREAKING] Move sort() to ordered collections

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -21,7 +21,6 @@ import {
 } from './TrieUtils';
 import { hash } from './Hash';
 import { Iterator, iteratorValue, iteratorDone } from './Iterator';
-import { sortFactory } from './Operations';
 import arrCopy from './utils/arrCopy';
 import assertNotInfinite from './utils/assertNotInfinite';
 import { setIn } from './methods/setIn';
@@ -36,8 +35,6 @@ import { withMutations } from './methods/withMutations';
 import { asMutable } from './methods/asMutable';
 import { asImmutable } from './methods/asImmutable';
 import { wasAltered } from './methods/wasAltered';
-
-import { OrderedMap } from './OrderedMap';
 
 export class Map extends KeyedCollection {
   // @pragma Construction
@@ -114,16 +111,6 @@ export class Map extends KeyedCollection {
   }
 
   // @pragma Composition
-
-  sort(comparator) {
-    // Late binding
-    return OrderedMap(sortFactory(this, comparator));
-  }
-
-  sortBy(mapper, comparator) {
-    // Late binding
-    return OrderedMap(sortFactory(this, comparator, mapper));
-  }
 
   map(mapper, context) {
     return this.withMutations(map => {

--- a/src/OrderedMap.js
+++ b/src/OrderedMap.js
@@ -10,6 +10,7 @@ import { IS_ORDERED_SYMBOL } from './predicates/isOrdered';
 import { isOrderedMap } from './predicates/isOrderedMap';
 import { Map, emptyMap } from './Map';
 import { emptyList } from './List';
+import { reify, sortFactory } from './Operations';
 import { DELETE, NOT_SET, SIZE } from './TrieUtils';
 import assertNotInfinite from './utils/assertNotInfinite';
 
@@ -64,6 +65,16 @@ export class OrderedMap extends Map {
 
   remove(k) {
     return updateOrderedMap(this, k, NOT_SET);
+  }
+
+  // @pragma Composition
+
+  sort(comparator) {
+    return reify(this, sortFactory(this, comparator));
+  }
+
+  sortBy(mapper, comparator) {
+    return reify(this, sortFactory(this, comparator, mapper));
   }
 
   wasAltered() {

--- a/src/OrderedSet.js
+++ b/src/OrderedSet.js
@@ -10,6 +10,7 @@ import { IS_ORDERED_SYMBOL } from './predicates/isOrdered';
 import { isOrderedSet } from './predicates/isOrderedSet';
 import { IndexedCollectionPrototype } from './CollectionImpl';
 import { Set } from './Set';
+import { reify, sortFactory } from './Operations';
 import { emptyOrderedMap } from './OrderedMap';
 import assertNotInfinite from './utils/assertNotInfinite';
 
@@ -34,6 +35,16 @@ export class OrderedSet extends Set {
 
   static fromKeys(value) {
     return this(KeyedCollection(value).keySeq());
+  }
+
+  // Composition
+
+  sort(comparator) {
+    return reify(this, sortFactory(this, comparator));
+  }
+
+  sortBy(mapper, comparator) {
+    return reify(this, sortFactory(this, comparator, mapper));
   }
 
   toString() {

--- a/src/Set.js
+++ b/src/Set.js
@@ -10,13 +10,10 @@ import { isOrdered } from './predicates/isOrdered';
 import { IS_SET_SYMBOL, isSet } from './predicates/isSet';
 import { emptyMap } from './Map';
 import { DELETE } from './TrieUtils';
-import { sortFactory } from './Operations';
 import assertNotInfinite from './utils/assertNotInfinite';
 import { asImmutable } from './methods/asImmutable';
 import { asMutable } from './methods/asMutable';
 import { withMutations } from './methods/withMutations';
-
-import { OrderedSet } from './OrderedSet';
 
 export class Set extends SetCollection {
   // @pragma Construction
@@ -134,16 +131,6 @@ export class Set extends SetCollection {
         set.remove(value);
       });
     });
-  }
-
-  sort(comparator) {
-    // Late binding
-    return OrderedSet(sortFactory(this, comparator));
-  }
-
-  sortBy(mapper, comparator) {
-    // Late binding
-    return OrderedSet(sortFactory(this, comparator, mapper));
   }
 
   wasAltered() {


### PR DESCRIPTION
Map.sort() returns an OrderedMap (same for Set and OrderedSet) which creates a circular dependency between them and makes it impossible to tree shake away the ordered variants.

WORK IN PROGRESS:
* Move the sort() and sortBy() dts and flow to Seq, List, Ordered*, Stack?
* Move generic definition on CollectionImpl to each usage
* Use method/function pattern?