### PR TITLE
fix: set.map produces valid underlying map

### DIFF
--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -98,6 +98,14 @@ describe('Set', () => {
     expect(r).toBe(s);
   });
 
+  it('maps should produce new set if values changed', () => {
+    const s = Set([1, 2, 3]);
+    expect(s.has(4)).toBe(false);
+
+    const m = s.map(v => v + 1);
+    expect(m.has(4)).toBe(true);
+  });
+
   it('unions an unknown collection of Sets', () => {
     const abc = Set(['a', 'b', 'c']);
     const cat = Set(['c', 'a', 't']);

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -101,9 +101,14 @@ describe('Set', () => {
   it('maps should produce new set if values changed', () => {
     const s = Set([1, 2, 3]);
     expect(s.has(4)).toBe(false);
+    expect(s.size).toBe(3);
 
     const m = s.map(v => v + 1);
+    expect(m.has(1)).toBe(false);
+    expect(m.has(2)).toBe(true);
+    expect(m.has(3)).toBe(true);
     expect(m.has(4)).toBe(true);
+    expect(m.size).toBe(3);
   });
 
   it('unions an unknown collection of Sets', () => {

--- a/src/Set.js
+++ b/src/Set.js
@@ -83,13 +83,17 @@ export class Set extends SetCollection {
 
   map(mapper, context) {
     return this.withMutations(set => {
+      const removes = [];
+      const adds = [];
       this.forEach(value => {
         const mapped = mapper.call(context, value, value, set);
         if (mapped !== value) {
-          set.remove(value);
-          set.add(mapped);
+          removes.push(value);
+          adds.push(mapped);
         }
       });
+      removes.forEach(value => set.remove(value));
+      adds.forEach(value => set.add(value));
     });
   }
 

--- a/src/Set.js
+++ b/src/Set.js
@@ -82,13 +82,15 @@ export class Set extends SetCollection {
   // @pragma Composition
 
   map(mapper, context) {
-    return updateSet(
-      this,
-      this._map.mapEntries(([, v]) => {
-        const mapped = mapper(v, v, this);
-        return [mapped, mapped];
-      }, context)
-    );
+    return this.withMutations(set => {
+      this.forEach(value => {
+        const mapped = mapper.call(context, value, value, set);
+        if (mapped !== value) {
+          set.remove(value);
+          set.add(mapped);
+        }
+      });
+    });
   }
 
   union(...iters) {
@@ -206,7 +208,7 @@ function updateSet(set, newMap) {
     set._map = newMap;
     return set;
   }
-  return newMap.equals(set._map)
+  return newMap === set._map
     ? set
     : newMap.size === 0
       ? set.__empty()

--- a/src/Set.js
+++ b/src/Set.js
@@ -82,16 +82,16 @@ export class Set extends SetCollection {
   // @pragma Composition
 
   map(mapper, context) {
+    const removes = [];
+    const adds = [];
+    this.forEach(value => {
+      const mapped = mapper.call(context, value, value, this);
+      if (mapped !== value) {
+        removes.push(value);
+        adds.push(mapped);
+      }
+    });
     return this.withMutations(set => {
-      const removes = [];
-      const adds = [];
-      this.forEach(value => {
-        const mapped = mapper.call(context, value, value, set);
-        if (mapped !== value) {
-          removes.push(value);
-          adds.push(mapped);
-        }
-      });
       removes.forEach(value => set.remove(value));
       adds.forEach(value => set.add(value));
     });

--- a/src/Set.js
+++ b/src/Set.js
@@ -82,7 +82,13 @@ export class Set extends SetCollection {
   // @pragma Composition
 
   map(mapper, context) {
-    return updateSet(this, this._map.map(v => mapper(v, v, this), context));
+    return updateSet(
+      this,
+      this._map.mapEntries(([, v]) => {
+        const mapped = mapper(v, v, this);
+        return [mapped, mapped];
+      }, context)
+    );
   }
 
   union(...iters) {
@@ -200,7 +206,7 @@ function updateSet(set, newMap) {
     set._map = newMap;
     return set;
   }
-  return newMap === set._map
+  return newMap.equals(set._map)
     ? set
     : newMap.size === 0
       ? set.__empty()


### PR DESCRIPTION
Fixes https://github.com/facebook/immutable-js/issues/1604

As explained in issue, `set.map` would produce a set whose underlying `_map` had mismatched key-value pairs (expected to always be equal for sets). The original code only mapped the value and kept the original set's keys which caused `has` checks (which uses the `_map` keys) to be incorrect.

- Updated the code to use `mapEntries` on the underlying `_map`
- `updateSet` uses `equals` instead of `===` since `mapEntries` produces a different map reference
- Added test to check for this case