### PR TITLE
New Option type

### DIFF
--- a/__tests__/Option.ts
+++ b/__tests__/Option.ts
@@ -1,26 +1,303 @@
 ///<reference path='../resources/jest.d.ts'/>
 
 declare var Symbol: any;
-import { None, Option, Set, Some } from '../';
+import { List, None, Option, Set, Some } from '../';
 
 describe('Option', function() {
-  it('should return a None if null is given on instantiation', () => {
-    const result = Option(null);
-    expect(result instanceof None).toEqual(true);
-  });
+  describe('instantiation', () => {
+    it('should return a None if null is given on instantiation', () => {
+      const result = Option(null);
+      expect(result instanceof None).toEqual(true);
+    });
 
-  it('should return a None if no value is given on instantiation', () => {
-    const result = Option(undefined);
-    expect(result instanceof None).toEqual(true);
-  });
+    it('should return a None if no value is given on instantiation', () => {
+      const result = Option(undefined);
+      expect(result instanceof None).toEqual(true);
+    });
 
-  it('should return a Some if any other type is passed on instantiation', () => {
-    const instanceTypes = [2, 'string', 0, false, true, '', [], {}, Set([1, 2, 3, 4])];
-    instanceTypes.forEach(_ => {
-      const result = Option(_);
-      expect(result instanceof Some).toEqual(true);
+    it('should return a Some if any other type is passed on instantiation', () => {
+      const instanceTypes = [
+        2,
+        'string',
+        0,
+        false,
+        true,
+        '',
+        [],
+        {},
+        Set([1, 2, 3, 4]),
+      ];
+      instanceTypes.forEach(_ => {
+        const result = Option(_);
+        expect(result instanceof Some).toEqual(true);
+      });
     });
   });
 
+  describe('Some', () => {
+    it('should return a None if null is given on instantiation', () => {
+      const result = Option(null);
+      expect(result instanceof None).toEqual(true);
+    });
 
+    it('should return a None if no value is given on instantiation', () => {
+      const result = Option(undefined);
+      expect(result instanceof None).toEqual(true);
+    });
+
+    it('should return a Some if any other type is passed on instantiation', () => {
+      const instanceTypes = [
+        2,
+        'string',
+        0,
+        false,
+        true,
+        '',
+        [],
+        {},
+        Set([1, 2, 3, 4]),
+      ];
+      instanceTypes.forEach(_ => {
+        const result = Option(_);
+        expect(result instanceof Some).toEqual(true);
+      });
+    });
+
+    it('should be instantiatable without new', () => {
+      const result = Some(55);
+      expect(result instanceof Some).toEqual(true);
+    });
+
+    describe('map', () => {
+      let instance;
+
+      beforeEach(() => {
+        instance = Some(56);
+      });
+
+      it('should apply the passed predicate to the value and return a new instance of Some', () => {
+        const result = instance.map(_ => 2 * _);
+
+        expect(result instanceof Some).toEqual(true);
+        expect(result).not.toBe(instance);
+      });
+
+      it('should throw an exceptioni if no parameter is passed', () => {
+        const testFct = () => {
+          const result = instance.map();
+        };
+        expect(testFct).toThrow();
+      });
+
+      it('should throw an exception if a parameter other than a function is passed', () => {
+        const testFct = () => {
+          const result = instance.map(45);
+        };
+        expect(testFct).toThrow();
+      });
+
+      it('should return a None if the predicate returns null', () => {
+        const result = instance.map(() => null);
+        expect(result instanceof None).toEqual(true);
+      });
+
+      it('should return a None if a predicate returns NaN', () => {
+        const result = instance.map(() => parseInt('a string', 10));
+        expect(result instanceof None).toEqual(true);
+      });
+
+      it('should not return None if result is a valid number', () => {
+        const test = Some('');
+        expect(test.map(x => x.length)).toEqual(Some(0));
+      });
+
+      it('should accept a List as parameter', () => {
+        const stringInstance = Some('a splittable string');
+        const modifier = x => List(x.split(' '));
+
+        expect(stringInstance.map(modifier)).toEqual(
+          Some(List.of('a', 'splittable', 'string'))
+        );
+      });
+
+      it('should not automatically flatten is the result of map is another Some', () => {
+        const result = instance.map(_ => Some(1 / _));
+        expect(result).toEqual(Some(Some(1 / 56)));
+      });
+
+      it('should not automatically flatten is the result of map is a None', () => {
+        const result = instance.map(_ => None());
+        expect(result).toEqual(Some(None()));
+      });
+
+      it('should return a result that can be flattened', () => {
+        const result = instance.map(_ => Some(1 / _));
+        const expectation = Some(1 / 56);
+        expect(result.flatten(true)).toEqual(expectation);
+      });
+
+      it('should flatten several levels deep', () => {
+        const test = Some(Some(Some(Some('test'))));
+        expect(test.flatten(false)).toEqual(Some('test'));
+      });
+
+      it('should throw an exception if trying to flatten a list in an option', () => {
+        const test = Some(List([1, 2, 3]));
+        const testFct = function() {
+          test.flatten(true);
+        };
+
+        expect(testFct).toThrow();
+      });
+    });
+
+    describe('flatMap', () => {
+      it('should flatten nested Options', () => {
+        const test = Some('test');
+        const modifier = x => Some(x + x);
+
+        expect(test.flatMap(modifier)).toEqual(Some('testtest'));
+      });
+
+      it('should return a None if the passed function returns a None', () => {
+        const test = Some('test');
+        const modifier = x => None();
+
+        expect(test.flatMap(modifier)).toEqual(None());
+      });
+
+      it('should throw an exception when trying to flatten a collection in a Some', () => {
+        const nextInstance = Some(45);
+        const modifier = x => List([2 * x, x / 2]);
+        const testFct = () => {
+          nextInstance.flatMap(modifier);
+        };
+
+        expect(testFct).toThrow();
+      });
+    });
+
+    describe('getOrElse', () => {
+      it('should return the value in the instance', () => {
+        const otherInstance = Some('a longer string');
+        expect(otherInstance.getOrElse('alternative')).toEqual(
+          'a longer string'
+        );
+      });
+    });
+
+    describe('filter', () => {
+      it('should return a similar Some if the filter predicate returns true', () => {
+        const otherInstance = Some(56);
+        const predicate = x => true;
+
+        const res = otherInstance.filter(predicate);
+        expect(res).toEqual(otherInstance);
+        expect(res).not.toBe(otherInstance);
+      });
+
+      it('should return a None if the filter predicate returns false', () => {
+        const otherInstance = Some(56);
+        const predicate = x => false;
+
+        expect(otherInstance.filter(predicate)).toEqual(None());
+      });
+    });
+  });
+
+  describe('None', () => {
+    let instance;
+
+    beforeEach(() => {
+      instance = new None();
+    });
+
+    it('should be instantiated by function without new', () => {
+      const result = None();
+      expect(result).toEqual(instance);
+      expect(result instanceof None).toEqual(true);
+    });
+
+    it('should return itself on a call to map', () => {
+      expect(instance.map(x => x * 2)).toBe(instance);
+    });
+
+    it('should return itself on a call to flatMap', () => {
+      expect(instance.flatMap(x => x * 2)).toBe(instance);
+    });
+
+    it('should return itself on a call to flatten', () => {
+      expect(instance.flatten(false)).toBe(instance);
+    });
+
+    it('should return the Else value for getOrElse()', () => {
+      expect(instance.getOrElse('alternative')).toEqual('alternative');
+    });
+
+    it('should return a new instance of None if the predicate to filter returns true', () => {
+      const predicate = x => true;
+      const result = instance.filter(predicate);
+
+      expect(result).toEqual(instance);
+      expect(result).not.toBe(instance);
+    });
+
+    it('should return a new instance of None if the predicate to filter returns false', () => {
+      const predicate = x => false;
+      const result = instance.filter(predicate);
+
+      expect(result).not.toBe(instance);
+    });
+  });
+
+  describe('List interop', () => {
+    it('should remove None from a flatMap', () => {
+      const initialList = List([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      const newList = initialList.flatMap(
+        _ => (_ % 2 === 0 ? Some(2 * _) : None())
+      );
+
+      expect(newList.toArray()).toEqual([4, 8, 12, 16]);
+    });
+
+    it('should keep the Options on a map', () => {
+      const initialList = List([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      const newList = initialList.map(
+        _ => (_ % 2 === 0 ? Some(2 * _) : None())
+      );
+
+      expect(newList.toArray().slice(0, 2)).toEqual([None(), Some(4)]);
+    });
+
+    it('should not break a list with None and Some', () => {
+      const initialList = List([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      const newList = initialList
+        .map(_ => (_ % 2 === 0 ? Some(2 * _) : None()))
+        .map(_ => _.map(x => 1 / x));
+
+      expect(newList).toEqual(
+        List.of(
+          None(),
+          Some(0.25),
+          None(),
+          Some(0.125),
+          None(),
+          Some(1 / 12),
+          None(),
+          Some(1 / 16),
+          None()
+        )
+      );
+    });
+
+    it('should be able to create a flattenable list', () => {
+      const initialList = List([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      const newList = initialList
+        .map(_ => (_ % 2 === 0 ? Some(2 * _) : None()))
+        .map(_ => _.map(x => 1 / x))
+        .flatten(true);
+
+      expect(newList).toEqual(List.of(0.25, 0.125, 1 / 12, 0.0625));
+    });
+  });
 });

--- a/__tests__/Option.ts
+++ b/__tests__/Option.ts
@@ -1,0 +1,26 @@
+///<reference path='../resources/jest.d.ts'/>
+
+declare var Symbol: any;
+import { None, Option, Set, Some } from '../';
+
+describe('Option', function() {
+  it('should return a None if null is given on instantiation', () => {
+    const result = Option(null);
+    expect(result instanceof None).toEqual(true);
+  });
+
+  it('should return a None if no value is given on instantiation', () => {
+    const result = Option(undefined);
+    expect(result instanceof None).toEqual(true);
+  });
+
+  it('should return a Some if any other type is passed on instantiation', () => {
+    const instanceTypes = [2, 'string', 0, false, true, '', [], {}, Set([1, 2, 3, 4])];
+    instanceTypes.forEach(_ => {
+      const result = Option(_);
+      expect(result instanceof Some).toEqual(true);
+    });
+  });
+
+
+});

--- a/src/Immutable.js
+++ b/src/Immutable.js
@@ -7,6 +7,7 @@
 
 import { Seq } from './Seq';
 import { OrderedMap } from './OrderedMap';
+import { Option, None, Some } from './Option';
 import { List } from './List';
 import { Map } from './Map';
 import { Stack } from './Stack';
@@ -63,6 +64,9 @@ export default {
   Seq: Seq,
   Map: Map,
   OrderedMap: OrderedMap,
+  Option: Option,
+  None: None,
+  Some: Some,
   List: List,
   Stack: Stack,
   Set: Set,
@@ -118,6 +122,9 @@ export {
   Seq,
   Map,
   OrderedMap,
+  Option,
+  None,
+  Some,
   List,
   Stack,
   Set,

--- a/src/Option.js
+++ b/src/Option.js
@@ -1,51 +1,114 @@
 import { SetCollection } from './Collection';
+import { flattenFactory, reify } from './Operations';
 import { IS_SET_SYMBOL, isSet } from './predicates/isSet';
+import { isSeq } from './predicates/isSeq';
 
 export class Option extends SetCollection {
-
   constructor(value) {
-    if (value === null || value === undefined) return Object.create(NonePrototype);
-    else return Some(value);
+    const instance =
+      value === null || value === undefined ? new None() : new Some(value);
+    return instance;
   }
 
-  __iterator(type, reverse) {
-    return this._map.__iterator(type, reverse);
+  __iterator() {
+    return this._val[Symbol.iterator]();
   }
 
+  __iterate(fn, reverse) {
+    return !Array.isArray(this._val)
+      ? this._val
+      : this._val.map(k => fn(k, k, this), reverse);
+  }
 }
 
 Option.isSet = isSet;
 
 const OptionPrototype = Option.prototype;
 OptionPrototype[IS_SET_SYMBOL] = true;
-
+OptionPrototype._isNone = function() {
+  return !this._val || this._val[0] === null || this._val[0] === undefined;
+};
+OptionPrototype.getOrElse = function(elseVal) {
+  return this._isNone() ? elseVal : this._val[0];
+};
+OptionPrototype.filter = function(predicate) {
+  return this._isNone() || predicate(this._val[0]) === false
+    ? None()
+    : Some(this._val[0]);
+};
 
 export class None extends Option {
+  constructor() {
+    if (this instanceof None) {
+      this._val = [undefined];
+      return this;
+    }
+    return new None();
+  }
 
-  constructor() {}
+  __iterate() {}
+
+  toString() {
+    return 'None';
+  }
 }
 None.isSet = isSet;
 
 const NonePrototype = None.prototype;
 NonePrototype[IS_SET_SYMBOL] = true;
+NonePrototype.map = function() {
+  return this;
+};
+NonePrototype.flatMap = function() {
+  return this;
+};
+NonePrototype.flatten = function() {
+  return this;
+};
 
 // =-=-=-=-=-=--=-=
 
 export class Some extends Option {
-
   constructor(value) {
-    if (value === null || value === undefined) return Object.create(NonePrototype);
-    else {
-      return SomePrototype.create(value);
+    if (this instanceof Some) {
+      if (value === null || value === undefined) return new None();
+      this._val = [value];
+      return this;
     }
+    return new Some(value);
+  }
+
+  toString() {
+    return `Some(${this._val})`;
   }
 }
 Some.isSet = isSet;
 
 const SomePrototype = Some.prototype;
 SomePrototype[IS_SET_SYMBOL] = true;
-SomePrototype.create = function(value) {
-  const some = Object.create(SomePrototype);
-  some._val = value;
-  return some;
+SomePrototype._create = function(value) {
+  return new Some(value);
+};
+SomePrototype.map = function(predicate) {
+  if (typeof predicate !== 'function') throw new Error('Expected Function');
+  else {
+    const result = predicate(this._val[0]);
+    // eslint-disable-next-line no-restricted-globals
+    return typeof result === 'number' && isNaN(result)
+      ? new None()
+      : new Some(result);
+  }
+};
+SomePrototype.flatten = function(doDeepFlatten) {
+  const flatResult = flattenFactory(this, doDeepFlatten, true);
+  if (isSeq(flatResult)) {
+    // flatResult.size returns undefined here
+    const numEntries = flatResult.toArray().length;
+    if (numEntries === 0) return None();
+    if (numEntries === 1) return reify(this, flatResult.toArray()[0]);
+  }
+  throw new Error('TypeError: Expected Seq of type Option.');
+};
+SomePrototype.flatMap = function(predicate) {
+  return this.map(predicate).flatten(false);
 };

--- a/src/Option.js
+++ b/src/Option.js
@@ -1,0 +1,51 @@
+import { SetCollection } from './Collection';
+import { IS_SET_SYMBOL, isSet } from './predicates/isSet';
+
+export class Option extends SetCollection {
+
+  constructor(value) {
+    if (value === null || value === undefined) return Object.create(NonePrototype);
+    else return Some(value);
+  }
+
+  __iterator(type, reverse) {
+    return this._map.__iterator(type, reverse);
+  }
+
+}
+
+Option.isSet = isSet;
+
+const OptionPrototype = Option.prototype;
+OptionPrototype[IS_SET_SYMBOL] = true;
+
+
+export class None extends Option {
+
+  constructor() {}
+}
+None.isSet = isSet;
+
+const NonePrototype = None.prototype;
+NonePrototype[IS_SET_SYMBOL] = true;
+
+// =-=-=-=-=-=--=-=
+
+export class Some extends Option {
+
+  constructor(value) {
+    if (value === null || value === undefined) return Object.create(NonePrototype);
+    else {
+      return SomePrototype.create(value);
+    }
+  }
+}
+Some.isSet = isSet;
+
+const SomePrototype = Some.prototype;
+SomePrototype[IS_SET_SYMBOL] = true;
+SomePrototype.create = function(value) {
+  const some = Object.create(SomePrototype);
+  some._val = value;
+  return some;
+};

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -100,6 +100,28 @@
 declare module Immutable {
 
   /**
+   * Options are Object wrappers which indicate the presence or absence of a value.
+   * Typically returned from get() methods, these monads offer all the collection methods
+   * of collections and allow to postpone the evaluation of whether a value was returned
+   * or not until the end od the calculation.
+   *
+   * Option is the generic type, with subclasses Some (for an existing value) and None
+   * (indicating the absence of a value)
+   */
+  export module Option {
+
+    function getOrElse<T>(defaultValue: T): T;
+  }
+
+  export function Option(value: any): Option<any>;
+
+  export module None {}
+  export function None(): None;
+
+  export module Some{}
+  export function Some<T>(val: T): Some<T>;
+
+  /**
    * Lists are ordered indexed dense collections, much like a JavaScript
    * Array.
    *

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -115,11 +115,44 @@ declare module Immutable {
 
   export function Option(value: any): Option<any>;
 
+  export interface Option<T> {
+
+    map<M>(mapper: (value: T, key?: number, iter?: this) => M): Option<M>;
+
+    flatMap<M>(mapper: (value: T, key?: number) => Option<M>): Option<M>;
+
+    filter(predicate: (value: T) => boolean): Option<T>;
+
+    getOrElse(elseValue: T): T;
+  }
+
   export module None {}
   export function None(): None;
 
-  export module Some{}
+  export interface None {
+
+    map<T, M>(mapper: (value: T, key?: number, iter?: this) => M): None;
+
+    flatMap<T, M>(mapper: (value: T, key?: number) => Option<M>): None;
+
+    filter<T>(predicate: (value: T) => boolean): None;
+
+    getOrElse<T>(elseValue: T): T;
+  }
+
+  export module Some {}
   export function Some<T>(val: T): Some<T>;
+
+  export interface Some<T> extends Option<T> {
+
+    map<M>(mapper: (value: T, key?: number, iter?: this) => M): Option<M>;
+
+    flatMap<M>(mapper: (value: T, key?: number) => Option<M>): Option<M>;
+
+    filter(predicate: (value: T) => boolean): Option<T>;
+
+    getOrElse(elseValue: T): T;
+  }
 
   /**
    * Lists are ordered indexed dense collections, much like a JavaScript


### PR DESCRIPTION
This PR is a proof-of-concept for a new data type which I've been missing in Immutable: the Option type. Coming from a Scala background, I'm used to returning an Option from get requests and use it throughout my computations. 

The implementation here is not complete, and might need some modifications to align better with your coding patterns. I'm making this PR to gauge your interest in pursuing this further. I added unit tests for the currently implemented behavior as well as tests demonstrating the interoperability with the Immutable List, which should demonstrate how I imagine the three new types Option, None and Some to be used.