### PR TITLE
Remove unhelpful Map constructor type signature

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -759,7 +759,6 @@ declare module Immutable {
    * not altered.
    */
   export function Map<K, V>(collection: Iterable<[K, V]>): Map<K, V>;
-  export function Map<T>(collection: Iterable<Iterable<T>>): Map<T, T>;
   export function Map<V>(obj: {[key: string]: V}): Map<string, V>;
   export function Map<K, V>(): Map<K, V>;
   export function Map(): Map<any, any>;


### PR DESCRIPTION
I don't see what the point of supporting this is. It's going to return something with an incorrect type every time that K and V aren't identical. That would then force the library user to do casts everywhere. Also the flow types do not have such a constructor overload.