### PR TITLE
Give Records a displayName

### DIFF
--- a/__tests__/Record.ts
+++ b/__tests__/Record.ts
@@ -32,6 +32,7 @@ describe('Record', () => {
     const me = Person({ name: 'My Name' });
     expect(me.toString()).toEqual('Person { name: "My Name" }');
     expect(Record.getDescriptiveName(me)).toEqual('Person');
+    expect(Person.displayName).toBe('Person');
   });
 
   it('passes through records of the same type', () => {

--- a/__tests__/RecordJS.js
+++ b/__tests__/RecordJS.js
@@ -52,6 +52,14 @@ describe('Record', () => {
     expect(t instanceof Alphabet);
     expect(t.soup()).toBe(6);
     expect(t2.soup()).toBe(204);
+
+    // Uses class name as descriptive name
+    expect(Record.getDescriptiveName(t)).toBe('Alphabet');
+
+    // Uses display name over class name
+    class NotADisplayName extends Record({ x: 1 }, 'DisplayName') {}
+    const t3 = new NotADisplayName();
+    expect(Record.getDescriptiveName(t3)).toBe('DisplayName');
   });
 
   it('can be cleared', () => {

--- a/src/Record.js
+++ b/src/Record.js
@@ -44,6 +44,9 @@ export class Record {
         hasInitialized = true;
         const keys = Object.keys(defaultValues);
         const indices = (RecordTypePrototype._indices = {});
+        // Deprecated: left to attempt not to break any external code which
+        // relies on a ._name property existing on record instances.
+        // Use Record.getDescriptiveName() instead
         RecordTypePrototype._name = name;
         RecordTypePrototype._keys = keys;
         RecordTypePrototype._defaultValues = defaultValues;
@@ -80,6 +83,10 @@ export class Record {
       RecordPrototype
     ));
     RecordTypePrototype.constructor = RecordType;
+
+    if (name) {
+      RecordType.displayName = name;
+    }
 
     return RecordType;
   }
@@ -220,7 +227,7 @@ function makeRecord(likeRecord, values, ownerID) {
 }
 
 function recordName(record) {
-  return record._name || record.constructor.name || 'Record';
+  return record.constructor.displayName || record.constructor.name || 'Record';
 }
 
 function recordSeq(record) {

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2446,6 +2446,12 @@ declare module Immutable {
     export interface Factory<TProps extends Object> {
       (values?: Partial<TProps> | Iterable<[string, any]>): Record<TProps> & Readonly<TProps>;
       new (values?: Partial<TProps> | Iterable<[string, any]>): Record<TProps> & Readonly<TProps>;
+
+      /**
+       * The name provided to `Record(values, name)` can be accessed with
+       * `displayName`.
+       */
+      displayName: string;
     }
 
     export function Factory<TProps extends Object>(values?: Partial<TProps> | Iterable<[string, any]>): Record<TProps> & Readonly<TProps>;


### PR DESCRIPTION
This ensures Records are printed correctly in debugging contexts and provides a better mechanism for accessing a Record class's record name.

Deprecates the _name field on Record instances