### PR TITLE
BREAKING: Remove Iterable<T> as tuple from Map constructor types

### DIFF
--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -759,7 +759,6 @@ declare module Immutable {
    * not altered.
    */
   export function Map<K, V>(collection: Iterable<[K, V]>): Map<K, V>;
-  export function Map<T>(collection: Iterable<Iterable<T>>): Map<T, T>;
   export function Map<V>(obj: {[key: string]: V}): Map<string, V>;
   export function Map<K, V>(): Map<K, V>;
   export function Map(): Map<any, any>;
@@ -1419,7 +1418,6 @@ declare module Immutable {
    * the `new` keyword during construction.
    */
   export function OrderedMap<K, V>(collection: Iterable<[K, V]>): OrderedMap<K, V>;
-  export function OrderedMap<T>(collection: Iterable<Iterable<T>>): OrderedMap<T, T>;
   export function OrderedMap<V>(obj: {[key: string]: V}): OrderedMap<string, V>;
   export function OrderedMap<K, V>(): OrderedMap<K, V>;
   export function OrderedMap(): OrderedMap<any, any>;

--- a/type-definitions/ts-tests/map.ts
+++ b/type-definitions/ts-tests/map.ts
@@ -12,20 +12,17 @@ import { Map, List } from '../../';
   // $ExpectType Map<{}, {}>
   Map();
 
-  // $ExpectType Map<number, number>
-  Map([[1, 1]]);
+  // $ExpectType Map<number, string>
+  Map([[1, 'a']]);
+
+  // $ExpectType Map<number, string>
+  Map(List<[number, string]>([[1, 'a']]));
 
   // $ExpectType Map<string, number>
   Map({ a: 1 });
 
-  // $ExpectType Map<string, string>
-  Map(List.of(List(['a', 'b'])));
-
-  // $ExpectType Map<number, number>
-  Map(List.of(List([1, 2])));
-
-  // $ExpectType Map<string | number, string | number>
-  Map(List.of(List(['a', 1])));
+  // $ExpectError - TypeScript does not support Lists as tuples
+  Map(List([List(['a', 'b'])]));
 
   // $ExpectError
   const invalidNumberMap: Map<number, number> = Map();

--- a/type-definitions/ts-tests/ordered-map.ts
+++ b/type-definitions/ts-tests/ordered-map.ts
@@ -12,20 +12,17 @@ import { OrderedMap, List } from '../../';
   // $ExpectType OrderedMap<{}, {}>
   OrderedMap();
 
-  // $ExpectType OrderedMap<number, number>
-  OrderedMap([[1, 1]]);
+  // $ExpectType OrderedMap<number, string>
+  OrderedMap([[1, 'a']]);
+
+  // $ExpectType OrderedMap<number, string>
+  OrderedMap(List<[number, string]>([[1, 'a']]));
 
   // $ExpectType OrderedMap<string, number>
   OrderedMap({ a: 1 });
 
-  // $ExpectType OrderedMap<string, string>
-  OrderedMap(List.of(List(['a', 'b'])));
-
-  // $ExpectType OrderedMap<number, number>
-  OrderedMap(List.of(List([1, 2])));
-
-  // $ExpectType OrderedMap<string | number, string | number>
-  OrderedMap(List.of(List(['a', 1])));
+// $ExpectError - TypeScript does not support Lists as tuples
+  OrderedMap(List([List(['a', 'b'])]));
 
   // $ExpectError
   const invalidNumberOrderedMap: OrderedMap<number, number> = OrderedMap();


### PR DESCRIPTION
These have caused more issues with typing than they fixed, unfortunately. While the runtime behavior is still supported, TypeScript types can't capture immutable List as Tuple.

Closes #1611