### PR TITLE
FIX: support isPlainObj with constructor keys

### DIFF
--- a/src/utils/isPlainObj.js
+++ b/src/utils/isPlainObj.js
@@ -8,7 +8,7 @@
 export default function isPlainObj(value) {
   return (
     value &&
-    ((value.constructor && value.constructor.name === 'Object') ||
-      value.constructor === undefined)
+    (typeof value.constructor !== 'function' ||
+      value.constructor.name === 'Object')
   );
 }


### PR DESCRIPTION
Specifically look for a function instead of any value

Closes #1623