### PR TITLE
Fix flow RecordFactory type usage

### DIFF
--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1393,8 +1393,8 @@ type RecordValues<R> = _RecordValues<*, R>;
 
 declare function isRecord(maybeRecord: any): boolean %checks(maybeRecord instanceof RecordInstance);
 declare class Record {
-  static <Values: Object>(spec: Values, name?: string): typeof RecordInstance;
-  constructor<Values: Object>(spec: Values, name?: string): typeof RecordInstance;
+  static <Values: Object>(spec: Values, name?: string): RecordFactory<Values>;
+  constructor<Values: Object>(spec: Values, name?: string): RecordFactory<Values>;
 
   static isRecord: typeof isRecord;
 


### PR DESCRIPTION
This ensures use of Records result in appropriate flow types

Tested by ensuring the flow type tests continue to pass.