### PR TITLE
[BREAKING] Rename forEach to forSome, add forEach matching spec

### DIFF
--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -660,17 +660,30 @@ describe('List', () => {
     expect(a).toEqual([0, 1, 2, 3, 4]);
   });
 
-  it('forEach iteration terminates when callback returns false', () => {
+  it('forSome iteration terminates when callback returns false', () => {
     const a: Array<any> = [];
     function count(x) {
+      a.push(x);
+      if (x >= 2) {
+        return false;
+      }
+    }
+    const v = List.of(0, 1, 2, 3, 4);
+    v.forSome(count);
+    expect(a).toEqual([0, 1, 2]);
+  });
+
+  it('forEach iteration does not terminate when callback returns false', () => {
+    const a: Array<any> = [];
+    function count(x) {
+      a.push(x);
       if (x > 2) {
         return false;
       }
-      a.push(x);
     }
     const v = List.of(0, 1, 2, 3, 4);
     v.forEach(count);
-    expect(a).toEqual([0, 1, 2]);
+    expect(a).toEqual([0, 1, 2, 3, 4]);
   });
 
   it('concat works like Array.prototype.concat', () => {

--- a/__tests__/flatten.ts
+++ b/__tests__/flatten.ts
@@ -28,7 +28,7 @@ describe('flatten', () => {
   it('gives the correct iteration count', () => {
     const nested = fromJS([[1, 2, 3], [4, 5, 6]]);
     const flat = nested.flatten();
-    expect(flat.forEach(x => x < 4)).toEqual(4);
+    expect(flat.forSome(x => x < 4)).toEqual(4);
   });
 
   type SeqType = number | Array<number> | Collection<number, number>;

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -223,6 +223,13 @@ mixin(Collection, {
 
   forEach(sideEffect, context) {
     assertNotInfinite(this.size);
+    this.__iterate((...args) => {
+      sideEffect.apply(context, args);
+    });
+  },
+
+  forSome(sideEffect, context) {
+    assertNotInfinite(this.size);
     return this.__iterate(context ? sideEffect.bind(context) : sideEffect);
   },
 

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -4296,12 +4296,20 @@ declare module Immutable {
 
     /**
      * The `sideEffect` is executed for every entry in the Collection.
+     */
+    forEach(
+      sideEffect: (value: V, key: K, iter: this) => any,
+      context?: any
+    ): this;
+
+    /**
+     * The `sideEffect` is executed for every entry in the Collection.
      *
-     * Unlike `Array#forEach`, if any call of `sideEffect` returns
+     * Unlike `#forEach`, if any call of `sideEffect` returns
      * `false`, the iteration will stop. Returns the number of entries iterated
      * (including the last iteration which returned false).
      */
-    forEach(
+    forSome(
       sideEffect: (value: V, key: K, iter: this) => any,
       context?: any
     ): number;

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -116,6 +116,11 @@ declare class _Collection<K, +V> implements ValueObject {
   forEach(
     sideEffect: (value: V, key: K, iter: this) => any,
     context?: mixed
+  ): this;
+
+  forSome(
+    sideEffect: (value: V, key: K, iter: this) => any,
+    context?: mixed
   ): number;
 
   slice(begin?: number, end?: number): this;


### PR DESCRIPTION
This is an attempt to make Immutable more spec compliant. Currently a naive user would assume that `forEach` has the same implementation as the `forEach` function on native types, which does not involve early exit.

Also since this forEach now returns this, it can be chained!