### PR TITLE
Fix flip() example under "Seq is lazy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,7 +576,7 @@ lazySeq
   .flip()
   .map(key => key.toUpperCase())
   .flip();
-// Seq { A: 1, B: 1, C: 1 }
+// Seq { A: 1, B: 2, C: 3 }
 ```
 
 As well as expressing logic that would otherwise seem memory or time


### PR DESCRIPTION
The `Seq` example using `flip()` has an incorrect result (all 1s).