### PR TITLE
Add 3 new Data structures

### DIFF
--- a/__tests__/IterateUntil.ts
+++ b/__tests__/IterateUntil.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+///<reference path='../resources/jest.d.ts'/>
+
+import { IterateUntil } from '../';
+
+describe('IterateUntil', () => {
+  it('fixed iterateuntil', () => {
+    const v = IterateUntil(n => n + 1, a => a < 5);
+    expect(v.size).toBe(3);
+    expect(v.first()).toBe(2);
+    expect(v.rest().toArray()).toEqual([3, 4]);
+    expect(v.last()).toBe(4);
+    expect(v.butLast().toArray()).toEqual([2, 3]);
+    expect(v.toArray()).toEqual([2, 3, 4]);
+  });
+
+  it('defined seed', () => {
+    const v = IterateUntil(n => n + 1, a => a < 10, 3);
+    expect(v.size).toBe(6);
+    expect(v.first()).toBe(4);
+    expect(v.rest().toArray()).toEqual([5, 6, 7, 8, 9]);
+    expect(v.last()).toBe(9);
+    expect(v.butLast().toArray()).toEqual([4, 5, 6, 7, 8]);
+    expect(v.toArray()).toEqual([4, 5, 6, 7, 8, 9]);
+  });
+});

--- a/__tests__/Stretch.ts
+++ b/__tests__/Stretch.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+///<reference path='../resources/jest.d.ts'/>
+
+import * as jasmineCheck from 'jasmine-check';
+jasmineCheck.install();
+
+import { Stretch } from '../';
+
+describe('Stretch', () => {
+  it('fixed stretch', () => {
+    const v = Stretch(5, 3);
+    expect(v.size).toBe(3);
+    expect(v.first()).toBe(2);
+    expect(v.rest().toArray()).toEqual([5, 8]);
+    expect(v.last()).toBe(8);
+    expect(v.butLast().toArray()).toEqual([2, 5]);
+    expect(v.toArray()).toEqual([2, 5, 8]);
+  });
+
+  it('ends and front', () => {
+    const v = Stretch(5, 3, 4);
+    expect(v.size).toBe(3);
+    expect(v.first()).toBe(2);
+    expect(v.rest().toArray()).toEqual([5, 9]);
+    expect(v.last()).toBe(9);
+    expect(v.butLast().toArray()).toEqual([2, 5]);
+    expect(v.toArray()).toEqual([2, 5, 9]);
+  });
+
+  it('slices stretch', () => {
+    const v = Stretch(5, 3, 4);
+    const s = v.slice(0, 2);
+    expect(s.size).toBe(2);
+    expect(s.toArray()).toEqual([2, 5]);
+  });
+
+  it('one value', () => {
+    const v = Stretch(5, 3, 4);
+    const s = v.slice(0, 1);
+    expect(s.size).toBe(1);
+    expect(s.toArray()).toEqual([2]);
+  });
+
+  it('maps values', () => {
+    const r = Stretch(5, 3).map(v => v * v);
+    expect(r.toArray()).toEqual([4, 25, 64]);
+  });
+
+  it('reduces values', () => {
+    const v = Stretch(5, 3);
+    const r = v.reduce<number>((a, b) => a + b, 0);
+    expect(r).toEqual(15);
+  });
+
+  it('can be float', () => {
+    const v = Stretch(3.5, 1.5, 2.5);
+    expect(v.size).toBe(3);
+    expect(v.toArray()).toEqual([2, 3.5, 6]);
+  });
+
+  it('can be negative', () => {
+    const v = Stretch(-5, -5, -6);
+    expect(v.size).toBe(3);
+    expect(v.toArray()).toEqual([0, -5, -11]);
+  });
+});

--- a/__tests__/Times.ts
+++ b/__tests__/Times.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+///<reference path='../resources/jest.d.ts'/>
+
+import { Times } from '../';
+
+describe('Times', () => {
+  it('fixed times', () => {
+    const v = Times(5, n => n + 1);
+    expect(v.size).toBe(5);
+    expect(v.first()).toBe(2);
+    expect(v.rest().toArray()).toEqual([3, 4, 5, 6]);
+    expect(v.last()).toBe(6);
+    expect(v.butLast().toArray()).toEqual([2, 3, 4, 5]);
+    expect(v.toArray()).toEqual([2, 3, 4, 5, 6]);
+  });
+
+  it('defined seed', () => {
+    const v = Times(5, n => n + 1, 2);
+    expect(v.size).toBe(5);
+    expect(v.first()).toBe(3);
+    expect(v.rest().toArray()).toEqual([4, 5, 6, 7]);
+    expect(v.last()).toBe(7);
+    expect(v.butLast().toArray()).toEqual([3, 4, 5, 6]);
+    expect(v.toArray()).toEqual([3, 4, 5, 6, 7]);
+  });
+});

--- a/src/Immutable.js
+++ b/src/Immutable.js
@@ -14,7 +14,10 @@ import { OrderedSet } from './OrderedSet';
 import { Set } from './Set';
 import { Record } from './Record';
 import { Range } from './Range';
+import { Stretch } from './Stretch';
 import { Repeat } from './Repeat';
+import { Times } from './Times';
+import { IterateUntil } from './IterateUntil';
 import { is } from './is';
 import { fromJS } from './fromJS';
 
@@ -70,7 +73,10 @@ export default {
 
   Record: Record,
   Range: Range,
+  Stretch: Stretch,
   Repeat: Repeat,
+  Times: Times,
+  IterateUntil: IterateUntil,
 
   is: is,
   fromJS: fromJS,
@@ -124,7 +130,10 @@ export {
   OrderedSet,
   Record,
   Range,
+  Stretch,
   Repeat,
+  Times,
+  IterateUntil,
   is,
   fromJS,
   hash,

--- a/src/IterateUntil.js
+++ b/src/IterateUntil.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//import { wrapIndex, wholeSlice, resolveBegin, resolveEnd } from './TrieUtils';
+import { ArraySeq } from './Seq';
+//import { Iterator, iteratorValue, iteratorDone } from './Iterator';
+
+import deepEqual from './utils/deepEqual';
+
+/**
+ * Takes a function that's used as a result generator and a function used as
+ * a condition to check the result and returns an array of each generated
+ * result, seed is passed as the initial value to func and then the result is
+ * passed to func until the condition returns false
+ * func and condition are required and seed defaults to 1
+ */
+export class IterateUntil extends ArraySeq {
+  constructor(func, condition, seed) {
+    if (!(this instanceof IterateUntil)) {
+      return new IterateUntil(func, condition, seed);
+    }
+    const source = [];
+    seed = seed || 1;
+    this._func = func;
+    this._condition = condition;
+    this._seed = seed;
+    let result = func(seed);
+    while (condition(result)) {
+      source.push(result);
+      result = func(result);
+    }
+    super(source);
+    if (this.size === 0) {
+      if (EMPTY_TIMES) {
+        return EMPTY_TIMES;
+      }
+      EMPTY_TIMES = this;
+    }
+  }
+  //i wrote tests but i still have to figure out the type definitions
+  toString() {
+    if (this.size === 0) {
+      return 'IterateUntil []';
+    }
+    return this.toArray().toString();
+  }
+  equals(other) {
+    return other instanceof IterateUntil
+      ? this._func === other._func &&
+          this._condition === other._condition &&
+          this._seed === other._seed
+      : deepEqual(this, other);
+  }
+}
+
+let EMPTY_TIMES;

--- a/src/Stretch.js
+++ b/src/Stretch.js
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { wholeSlice, resolveBegin, resolveEnd } from './TrieUtils';
+import { IndexedSeq } from './Seq';
+import invariant from './utils/invariant';
+import deepEqual from './utils/deepEqual';
+import { Iterator, iteratorValue, iteratorDone } from './Iterator';
+
+/**
+ * Returns a lazy seq of base - ends, base, base + front,
+ * if front is not provided it returns base + ends,
+ * `base` and `ends` both default to 1
+ */
+export class Stretch {
+  constructor(base, ends, front) {
+    if (!(this instanceof Stretch)) {
+      return new Stretch(base, ends, front);
+    }
+    invariant(
+      base !== Infinity || ends !== Infinity || front !== Infinity,
+      `Must be a finite number`
+    );
+    invariant(base !== undefined, `Base is required`);
+    ends = ends === undefined ? 1 : ends;
+    front = front === undefined ? ends : front;
+    this._base = base;
+    this._start = base - ends;
+    this._end = base + front;
+    this.size = 3;
+    /*when i tried extending IndexedSeq or ArraySeq and calling super
+    the tests __tests__/Stretch.ts returned [5, 8, undefined] instead of 2, 5, 8]
+    and [5, 9, undefined] instead of [2, 5, 9]*/
+    return new IndexedSeq([this._start, this._base, this._end]);
+  }
+  toString() {
+    return `[${this._start}, ${this._base}, ${this._end}]`;
+  }
+
+  get(index, notSetValue) {
+    return index === 0
+      ? this._start
+      : index === 1
+        ? this._base
+        : index === 2
+          ? this._end
+          : notSetValue;
+  }
+
+  includes(searchValue) {
+    return (
+      searchValue === this._start ||
+      searchValue === this._base ||
+      searchValue === this._end
+    );
+  }
+
+  slice(begin, end) {
+    if (wholeSlice(begin, end, this.size)) {
+      return this;
+    }
+    begin = resolveBegin(begin, this.size);
+    end = resolveEnd(end, this.size);
+    return end <= begin
+      ? new IndexedSeq([])
+      : end - begin === 1
+        ? new IndexedSeq([this.get(begin)])
+        : new IndexedSeq([this.get(begin), this.get(begin + 1)]);
+  }
+
+  indexOf(searchValue) {
+    return searchValue === this._start
+      ? 0
+      : searchValue === this._base
+        ? 1
+        : searchValue === this._end
+          ? 2
+          : -1;
+  }
+  /*we can't return indexOf for lastIndexOf because ends and front can
+be be different values*/
+  lastIndexOf(searchValue) {
+    return searchValue === this._end
+      ? 2
+      : searchValue === this._base
+        ? 1
+        : searchValue === this._start
+          ? 0
+          : -1;
+  }
+
+  __iterate(fn, reverse) {
+    const size = 3;
+    let value = reverse ? this._end : this._start;
+    let i = 0;
+    value += reverse ? -(this._end - this._base) : this._base - this._start;
+    if (fn(value, reverse ? size - ++i : i++, this) === false) {
+      return i;
+    }
+    value += reverse ? -(this._base - this._start) : this._end - this._base;
+    if (fn(value, reverse ? size - ++i : i++, this) === false) {
+      return i;
+    }
+    return i;
+  }
+
+  __iterator(type, reverse) {
+    const array = [this._start, this._base, this._end];
+    const size = 3;
+    let i = 0;
+    return new Iterator(() => {
+      if (i === size) {
+        return iteratorDone();
+      }
+      const ii = reverse ? size - ++i : i++;
+      return iteratorValue(type, ii, array[ii]);
+    });
+  }
+
+  reverse() {
+    return new Stretch(this._base, -this._ends, -this._front);
+  }
+
+  interpose(separator) {
+    return new IndexedSeq([
+      this._start,
+      separator,
+      this._base,
+      separator,
+      this._end,
+    ]);
+  }
+
+  rest() {
+    return new IndexedSeq([this._base, this._end]);
+  }
+
+  butLast() {
+    return new IndexedSeq([this._start, this._base]);
+  }
+
+  equals(other) {
+    return other instanceof Stretch
+      ? this._start === other._start &&
+          this._end === other._end &&
+          this._base === other._base
+      : deepEqual(this, other);
+  }
+}

--- a/src/Times.js
+++ b/src/Times.js
@@ -12,7 +12,8 @@ import { ArraySeq } from './Seq';
 import deepEqual from './utils/deepEqual';
 
 /**
- * Calls func with seed as the argument and returns an Seq.Indexed of the results,
+ * Calls func with seed as the argument and passes the result to func and
+ * repeats it times number of times and returns a Seq.Indexed of each result 
  * times and func are required and seed defaults to 1
  */
 export class Times extends ArraySeq {

--- a/src/Times.js
+++ b/src/Times.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//import { wrapIndex, wholeSlice, resolveBegin, resolveEnd } from './TrieUtils';
+import { ArraySeq } from './Seq';
+//import { Iterator, iteratorValue, iteratorDone } from './Iterator';
+
+import deepEqual from './utils/deepEqual';
+
+/**
+ * Calls func with seed as the argument and returns an Seq.Indexed of the results,
+ * times and func are required and seed defaults to 1
+ */
+export class Times extends ArraySeq {
+  constructor(times, func, seed) {
+    if (!(this instanceof Times)) {
+      return new Times(times, func, seed);
+    }
+    const source = [];
+    seed = seed || 1;
+    times = Math.max(0, times);
+    this._times = times;
+    this._seed = seed;
+    this._func = func;
+    while (times > 0) {
+      seed = func(seed);
+      source.push(seed);
+      times--;
+    }
+    super(source);
+    if (this.size === 0) {
+      if (EMPTY_TIMES) {
+        return EMPTY_TIMES;
+      }
+      EMPTY_TIMES = this;
+    }
+  }
+  toString() {
+    if (this.size === 0) {
+      return 'Times []';
+    }
+    return this.toArray().toString();
+  }
+  equals(other) {
+    return other instanceof Times
+      ? this._times === other._times &&
+          this._seed === other._seed &&
+          this._func === other._func
+      : deepEqual(this, other);
+  }
+}
+
+let EMPTY_TIMES;

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2220,7 +2220,8 @@ declare module Immutable {
   export function Repeat<T>(value: T, times?: number): Seq.Indexed<T>;
 
   /**
-   * Calls func with seed as the argument and returns an Seq.Indexed of the results,
+   * Calls func with seed as the argument and passes the result to func and
+   * repeats it times number of times and returns a Seq.Indexed of each result
    * times and func are required and seed defaults to 1
    *
    * Note: `Times` is a factory function and not a class, and does not use the

--- a/type-definitions/Immutable.d.ts
+++ b/type-definitions/Immutable.d.ts
@@ -2187,6 +2187,22 @@ declare module Immutable {
    */
   export function Range(start?: number, end?: number, step?: number): Seq.Indexed<number>;
 
+  /**
+     * Returns a Seq.Indexed with `base` - `ends`, `base`, and `base` + `front`, if
+     * front is not provided it returns `base` + `ends`, `base` is required and `ends`
+     * defaults to 1
+     *
+     * Note: `Stretch` is a factory function and not a class, and does not use the
+     * `new` keyword during construction.
+     *
+     * ```js
+     * const { Stretch } = require('immutable')
+     * Stretch(10, 5) // [5, 10, 15]
+     * Stretch(10, 5, 3) // [5, 10, 13]
+     * Stretch(5) // [4, 5, 6]
+     * ```
+     */
+    export function Stretch(base: number, ends?: number, front?: number): Seq.Indexed<number>;
 
   /**
    * Returns a Seq.Indexed of `value` repeated `times` times. When `times` is
@@ -2202,6 +2218,43 @@ declare module Immutable {
    * ```
    */
   export function Repeat<T>(value: T, times?: number): Seq.Indexed<T>;
+
+  /**
+   * Calls func with seed as the argument and returns an Seq.Indexed of the results,
+   * times and func are required and seed defaults to 1
+   *
+   * Note: `Times` is a factory function and not a class, and does not use the
+   * `new` keyword during construction.
+   *
+   * ```js
+   * const { Times } = require('immutable')
+   * Times(5, n => n + 1) // [2, 3, 4, 5, 6]
+   * Times(5, n => n + 1, 3) // [4, 5, 6, 7, 8]
+   * ```
+   */
+   /*i used any because seed could be anything and we might have a case where we return the
+   Seq.Indexed has a different type than seed*/
+  export function Times<T>(times: number, func: Function, seed?: any): Seq.Indexed<any>;
+
+  /**
+   * Takes a function that's used as a result generator and a function used as
+   * a condition to check the result and returns an array of each generated
+   * result seed is passed as the initial value to func and then the result is
+   * passed to func until the condition returns false
+   * func and condition are required and seed defaults to 1
+   *
+   * Note: `IterateUntil` is a factory function and not a class, and does not use the
+   * `new` keyword during construction.
+   *
+   * ```js
+   * const { IterateUntil } = require('immutable')
+   * IterateUntil(n => n + 1, a => a < 5) // [2, 3, 4]
+   * IterateUntil(n => n + 1, a => a < 10, 3) // [4, 5, 6, 7, 8, 9]
+   * ```
+   */
+   /*i used any because seed could be anything and we might have a case where we return the
+   Seq.Indexed has a different type than seed*/
+  export function IterateUntil<T>(func: Function, condition: Function, seed?: any): Seq.Indexed<any>;
 
 
   /**
@@ -2635,7 +2688,7 @@ declare module Immutable {
    * <!-- runkit:activate -->
    * ```js
    * const { Map } = require('immutable')
-   * const map = Map({ a: 1, b: 2, c: 3 })
+   * const map = Map({ a: 1, b: 2, c: 3 }
    * const lazySeq = Seq(map)
    * ```
    *

--- a/type-definitions/immutable.js.flow
+++ b/type-definitions/immutable.js.flow
@@ -1379,7 +1379,12 @@ declare class Stack<+T> extends IndexedCollection<T> {
 }
 
 declare function Range(start?: number, end?: number, step?: number): IndexedSeq<number>;
+declare function Stretch(base: number, ends?: number, front?: number): IndexedSeq<number>;
 declare function Repeat<T>(value: T, times?: number): IndexedSeq<T>;
+declare function Times<T>(times: number, func: Function, seed?: any): IndexedSeq<any>;
+declare function IterateUntil<T>(func: Function, condition: Function, seed?: any): IndexedSeq<any>;
+/*i used any because seed could be anything and we might have a case where we return the
+Seq.Indexed has a different type than seed*/
 
 // The type of a Record factory function.
 type RecordFactory<Values: Object> = Class<RecordInstance<Values>>;
@@ -1580,7 +1585,10 @@ export {
   OrderedMap,
   OrderedSet,
   Range,
+  Stretch,
   Repeat,
+  Times,
+  IterateUntil,
   Record,
   Set,
   Stack,
@@ -1623,7 +1631,10 @@ export default {
   OrderedMap,
   OrderedSet,
   Range,
+  Stretch,
   Repeat,
+  Times,
+  IterateUntil,
   Record,
   Set,
   Stack,

--- a/type-definitions/tests/immutable-flow.js
+++ b/type-definitions/tests/immutable-flow.js
@@ -17,7 +17,10 @@ import Immutable, {
   Set,
   Seq,
   Range,
+  Stretch,
   Repeat,
+  Times,
+  IterateUntil,
   Record,
   OrderedMap,
   OrderedSet,
@@ -63,7 +66,10 @@ const ImmutableStack = Immutable.Stack
 const ImmutableSet = Immutable.Set
 const ImmutableKeyedCollection: KeyedCollection<*, *> = Immutable.Collection.Keyed()
 const ImmutableRange = Immutable.Range
+const ImmutableStretch = Immutable.Stretch
 const ImmutableRepeat = Immutable.Repeat
+const ImmutableTimes = Immutable.Times
+const ImmutableIterateUntil = Immutable.IterateUntil
 const ImmutableIndexedSeq: IndexedSeq<*> = Immutable.Seq.Indexed()
 
 const Immutable2List = Immutable2.List
@@ -72,7 +78,10 @@ const Immutable2Stack = Immutable2.Stack
 const Immutable2Set = Immutable2.Set
 const Immutable2KeyedCollection: Immutable2.KeyedCollection<*, *> = Immutable2.Collection.Keyed()
 const Immutable2Range = Immutable2.Range
+const Immutable2Stretch = Immutable2.Stretch
 const Immutable2Repeat = Immutable2.Repeat
+const Immutable2Times = Immutable2.Times
+const Immutable2IterateUntil = Immutable2.IterateUntil
 const Immutable2IndexedSeq: Immutable2.IndexedSeq<*> = Immutable2.Seq.Indexed()
 
 var defaultExport: List<*> = Immutable.List();
@@ -889,12 +898,15 @@ numberStack = Stack(['a']).flatten()
 // `{}` provide namespaces
 { const numberSequence: IndexedSeq<number> = Range(0, 0, 0) }
 { const numberSequence: IndexedSeq<number> = Repeat(1, 5) }
+{ const numberSequence: IndexedSeq<number> = Stretch(10, 5) }
 
 { const stringSequence: IndexedSeq<string> = Repeat('a', 5) }
 // $ExpectError
 { const stringSequence: IndexedSeq<string> = Repeat(0, 1) }
 // $ExpectError
 { const stringSequence: IndexedSeq<string> = Range(0, 0, 0) }
+// $ExpectError
+{ const stringSequence: IndexedSeq<string> = Stretch(Infinity) }
 
 /* Seq */
 

--- a/type-definitions/ts-tests/exports.ts
+++ b/type-definitions/ts-tests/exports.ts
@@ -14,7 +14,10 @@ import {
     OrderedMap,
     OrderedSet,
     Range,
+    Stretch,
     Repeat,
+    Times,
+    IterateUntil,
     Seq,
     Set,
     Stack,
@@ -27,7 +30,10 @@ OrderedMap; // $ExpectType typeof OrderedMap
 OrderedSet; // $ExpectType typeof OrderedSet
 // TODO: Turn on once https://github.com/Microsoft/dtslint/issues/19 is resolved.
 Range; // $ ExpectType (start?: number | undefined, end?: number | undefined, step?: number | undefined) => Indexed<number>
+Stretch; // $ ExpectType (base: number, ends?: number | undefined, front?: number | undefined) => Indexed<number>
 Repeat; // $ExpectType <T>(value: T, times?: number | undefined) => Indexed<T>
+Times; // $ExpectType <T>(times: number, func: Function, seed?: any) => Indexed<any>
+IterateUntil; // $ExpectType <T>(func: Function, condition: Function, seed?: any) => Indexed<any>
 Seq; // $ExpectType typeof Seq
 Set; // $ExpectType typeof Set
 Stack; // $ExpectType typeof Stack
@@ -42,7 +48,12 @@ Immutable.OrderedMap; // $ExpectType typeof OrderedMap
 Immutable.OrderedSet; // $ExpectType typeof OrderedSet
 // TODO: Turn on once https://github.com/Microsoft/dtslint/issues/19 is resolved.
 Immutable.Range; // $ ExpectType (start?: number | undefined, end?: number | undefined, step?: number | undefined) => Indexed<number>
+Immutable.Stretch; // $ ExpectType (base: number, ends?: number | undefined, front?: number | undefined) => Indexed<number>
 Immutable.Repeat; // $ExpectType <T>(value: T, times?: number | undefined) => Indexed<T>
+Immutable.Times; // $ExpectType <T>(times: number, func: Function, seed?: any) => Indexed<any>
+Immutable.IterateUntil; // $ExpectType <T>(func: Function, condition: Function, seed?: any) => Indexed<any>
+/*i used any because seed could be anything and we might have a case where we return the
+Seq.Indexed has a different type than seed*/
 Immutable.Seq; // $ExpectType typeof Seq
 Immutable.Set; // $ExpectType typeof Set
 Immutable.Stack; // $ExpectType typeof Stack

--- a/type-definitions/ts-tests/stretch.ts
+++ b/type-definitions/ts-tests/stretch.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Stretch } from '../../';
+
+{  // #constructor
+
+    // $ExpectType Indexed<number>
+    Stretch(1, 1, 1);
+
+    // $ExpectError
+    Stretch('b', 1, 1);
+}


### PR DESCRIPTION
Add 3 new Data structures that inherit from IndexedSeq called Times, Stretch, and iterateUntil

Times(times, func, seed): Calls func with seed as the argument and passes the result to func and repeats it times number of times and returns a Seq.Indexed of each result 

Stretch(base, ends, front): Returns a lazy seq of base - ends, base, base + front, if front is not provided it returns base + ends,

IterateUntil(func, condition, seed): Takes a function that's used as a result generator and a function used as a condition to check the result and returns a Seq.Indexed of each generated result, seed is passed as the initial value to func and then the result is passed to func until the condition returns false