### PR TITLE
reverse empty argument check in constructors

### DIFF
--- a/src/List.js
+++ b/src/List.js
@@ -31,7 +31,7 @@ export class List extends IndexedCollection {
 
   constructor(value) {
     const empty = emptyList();
-    if (value === null || value === undefined) {
+    if (value === undefined || value === null) {
       return empty;
     }
     if (isList(value)) {

--- a/src/Map.js
+++ b/src/Map.js
@@ -36,7 +36,7 @@ export class Map extends KeyedCollection {
   // @pragma Construction
 
   constructor(value) {
-    return value === null || value === undefined
+    return value === undefined || value === null
       ? emptyMap()
       : isMap(value) && !isOrdered(value)
       ? value

--- a/src/OrderedMap.js
+++ b/src/OrderedMap.js
@@ -10,7 +10,7 @@ export class OrderedMap extends Map {
   // @pragma Construction
 
   constructor(value) {
-    return value === null || value === undefined
+    return value === undefined || value === null
       ? emptyOrderedMap()
       : isOrderedMap(value)
       ? value

--- a/src/OrderedSet.js
+++ b/src/OrderedSet.js
@@ -10,7 +10,7 @@ export class OrderedSet extends Set {
   // @pragma Construction
 
   constructor(value) {
-    return value === null || value === undefined
+    return value === undefined || value === null
       ? emptyOrderedSet()
       : isOrderedSet(value)
       ? value

--- a/src/Seq.js
+++ b/src/Seq.js
@@ -23,7 +23,7 @@ import isArrayLike from './utils/isArrayLike';
 
 export class Seq extends Collection {
   constructor(value) {
-    return value === null || value === undefined
+    return value === undefined || value === null
       ? emptySequence()
       : isImmutable(value)
       ? value.toSeq()
@@ -85,7 +85,7 @@ export class Seq extends Collection {
 
 export class KeyedSeq extends Seq {
   constructor(value) {
-    return value === null || value === undefined
+    return value === undefined || value === null
       ? emptySequence().toKeyedSeq()
       : isCollection(value)
       ? isKeyed(value)
@@ -103,7 +103,7 @@ export class KeyedSeq extends Seq {
 
 export class IndexedSeq extends Seq {
   constructor(value) {
-    return value === null || value === undefined
+    return value === undefined || value === null
       ? emptySequence()
       : isCollection(value)
       ? isKeyed(value)

--- a/src/Set.js
+++ b/src/Set.js
@@ -15,7 +15,7 @@ export class Set extends SetCollection {
   // @pragma Construction
 
   constructor(value) {
-    return value === null || value === undefined
+    return value === undefined || value === null
       ? emptySet()
       : isSet(value) && !isOrdered(value)
       ? value

--- a/src/Stack.js
+++ b/src/Stack.js
@@ -13,7 +13,7 @@ export class Stack extends IndexedCollection {
   // @pragma Construction
 
   constructor(value) {
-    return value === null || value === undefined
+    return value === undefined || value === null
       ? emptyStack()
       : isStack(value)
       ? value


### PR DESCRIPTION
The most common way to call a constructor to make an empty collection is to call it without arguments, then value is undefined.

With this commit the first check to see if the value passed to the constructor is not set is for undefined, the most common way to call it.

This way the condition will only have to evaluate the left side for the common case.