### PR TITLE
Array copy method: use `.slice()` instead of creating a new array by hand.

### DIFF
--- a/src/utils/arrCopy.ts
+++ b/src/utils/arrCopy.ts
@@ -1,12 +1,3 @@
-// http://jsperf.com/copy-array-inline
-
-export default function arrCopy<I>(arr: Array<I>, offset?: number): Array<I> {
-  offset = offset || 0;
-  const len = Math.max(0, arr.length - offset);
-  const newArr: Array<I> = new Array(len);
-  for (let ii = 0; ii < len; ii++) {
-    // @ts-expect-error We may want to guard for undefined values with `if (arr[ii + offset] !== undefined`, but ths should not happen by design
-    newArr[ii] = arr[ii + offset];
-  }
-  return newArr;
+export default function arrCopy<I>(arr: Array<I>, offset = 0): Array<I> {
+  return arr.slice(offset);
 }


### PR DESCRIPTION
Fixes #2098



<details>
<summary>Comparing performances with v6:</summary>

```
List > builds from array of 2
  Old:   151,435   153,868   156,380 ops/sec
  New:   146,736   149,974   153,357 ops/sec
  compare: 1 -1
  diff: -2.54%
  rme: 1.92%
List > builds from array of 8
  Old:   145,796   149,987   154,426 ops/sec
  New:   149,422   151,907   154,475 ops/sec
  compare: 0 0
  diff: 1.27%
  rme: 2.34%
List > builds from array of 32
  Old:   130,096   134,803   139,863 ops/sec
  New:   138,429   140,713   143,073 ops/sec
  compare: 0 0
  diff: 4.38%
  rme: 2.81%
List > builds from array of 1024
  Old:    11,567    11,937    12,330 ops/sec
  New:    12,318    12,518    12,724 ops/sec
  compare: -1 1
  diff: 4.87%
  rme: 2.53%
List > pushes into 2 times
  Old:   374,044   386,609   400,047 ops/sec
  New:   361,399   370,743   380,585 ops/sec
  compare: 1 -1
  diff: -4.11%
  rme: 2.99%
List > pushes into 8 times
  Old:   126,366   131,302   136,639 ops/sec
  New:   123,648   126,617   129,732 ops/sec
  compare: 1 -1
  diff: -3.57%
  rme: 3.24%
List > pushes into 32 times
  Old:    34,740    35,760    36,842 ops/sec
  New:    32,428    33,203    34,016 ops/sec
  compare: 1 -1
  diff: -7.15%
  rme: 2.67%
List > pushes into 1024 times
  Old:     1,094     1,149     1,209 ops/sec
  New:     1,080     1,097     1,114 ops/sec
  compare: 1 -1
  diff: -4.48%
  rme: 3.67%
List > pushes into transient 2 times
  Old:   502,344   509,941   517,772 ops/sec
  New:   497,304   503,983   510,843 ops/sec
  compare: 1 -1
  diff: -1.17%
  rme: 1.43%
List > pushes into transient 8 times
  Old:   327,320   338,149   349,720 ops/sec
  New:   324,194   331,845   339,866 ops/sec
  compare: 1 -1
  diff: -1.87%
  rme: 2.87%
List > pushes into transient 32 times
  Old:   147,689   152,033   156,640 ops/sec
  New:   152,527   154,916   157,381 ops/sec
  compare: 0 0
  diff: 1.89%
  rme: 2.35%
List > pushes into transient 1024 times
  Old:     6,430     6,539     6,652 ops/sec
  New:     6,651     6,776     6,907 ops/sec
  compare: -1 1
  diff: 3.63%
  rme: 1.79%
List > some 100 000 items
  Old:        13        13        14 ops/sec
  New:        11        12        12 ops/sec
  compare: 1 -1
  diff: -13.49%
  rme: 3.49%
Map > builds from an object of 2
  Old:   103,000   106,567   110,389 ops/sec
  New:   107,201   108,702   110,246 ops/sec
  compare: 0 0
  diff: 2%
  rme: 2.64%
Map > builds from an object of 8
  Old:    40,374    41,213    42,087 ops/sec
  New:    37,889    38,754    39,660 ops/sec
  compare: 1 -1
  diff: -5.97%
  rme: 2.18%
Map > builds from an object of 32
  Old:    20,464    20,809    21,165 ops/sec
  New:    19,998    20,610    21,260 ops/sec
  compare: 0 0
  diff: -0.96%
  rme: 2.46%
Map > builds from an object of 1024
  Old:     1,414     1,460     1,508 ops/sec
  New:     1,494     1,517     1,541 ops/sec
  compare: 0 0
  diff: 3.9%
  rme: 2.52%
Map > builds from an array of 2
  Old:   123,717   126,815   130,072 ops/sec
  New:   119,045   124,272   129,980 ops/sec
  compare: 0 0
  diff: -2.01%
  rme: 3.57%
Map > builds from an array of 8
  Old:    31,534    32,623    33,791 ops/sec
  New:    33,424    34,199    35,010 ops/sec
  compare: -1 1
  diff: 4.82%
  rme: 2.94%
Map > builds from an array of 32
  Old:    13,028    13,267    13,515 ops/sec
  New:    12,770    13,005    13,249 ops/sec
  compare: 1 -1
  diff: -1.98%
  rme: 1.83%
Map > builds from an array of 1024
  Old:       619       630       642 ops/sec
  New:       630       638       647 ops/sec
  compare: 0 0
  diff: 1.28%
  rme: 1.63%
Map > builds from a List of 2
  Old:   128,692   131,261   133,935 ops/sec
  New:   127,044   129,135   131,296 ops/sec
  compare: 1 -1
  diff: -1.62%
  rme: 1.82%
Map > builds from a List of 8
  Old:    31,318    32,501    33,777 ops/sec
  New:    33,175    33,772    34,391 ops/sec
  compare: 0 0
  diff: 3.91%
  rme: 2.95%
Map > builds from a List of 32
  Old:    12,404    12,741    13,097 ops/sec
  New:    11,129    11,642    12,205 ops/sec
  compare: 1 -1
  diff: -8.63%
  rme: 3.78%
Map > builds from a List of 1024
  Old:       567       577       587 ops/sec
  New:       560       579       599 ops/sec
  compare: -1 1
  diff: 0.3%
  rme: 2.7%
Map > merge a map of 2
  Old:   196,185   200,316   204,626 ops/sec
  New:   246,448   251,713   257,209 ops/sec
  compare: -1 1
  diff: 25.65%
  rme: 2.12%
Map > merge a map of 8
  Old:    47,517    49,074    50,736 ops/sec
  New:    53,852    54,574    55,316 ops/sec
  compare: -1 1
  diff: 11.2%
  rme: 2.5%
Map > merge a map of 32
  Old:    39,684    40,920    42,235 ops/sec
  New:    94,509    96,882    99,377 ops/sec
  compare: -1 1
  diff: 136.75%
  rme: 2.82%
Map > merge a map of 1024
  Old:     1,591     1,648     1,710 ops/sec
  New:     4,022     4,091     4,163 ops/sec
  compare: -1 1
  diff: 148.18%
  rme: 2.83%
Record > builds from an object of 2
  Old:   114,211   117,861   121,754 ops/sec
  New:   120,417   122,183   124,003 ops/sec
  compare: 0 0
  diff: 3.66%
  rme: 2.48%
Record > builds from an object of 5
  Old:   114,375   115,809   117,279 ops/sec
  New:   108,963   112,217   115,673 ops/sec
  compare: 0 0
  diff: -3.11%
  rme: 2.29%
Record > builds from an object of 10
  Old:   107,730   109,190   110,690 ops/sec
  New:   101,625   104,112   106,725 ops/sec
  compare: 1 -1
  diff: -4.65%
  rme: 1.97%
Record > builds from an object of 100
  Old:    37,064    37,824    38,615 ops/sec
  New:    38,315    38,845    39,389 ops/sec
  compare: 0 0
  diff: 2.69%
  rme: 1.74%
Record > builds from an object of 1000
  Old:     3,380     3,479     3,584 ops/sec
  New:     3,582     3,647     3,715 ops/sec
  compare: -1 1
  diff: 4.83%
  rme: 2.44%
Record > update random using set() of 2
  Old:   569,758   580,255   591,147 ops/sec
  New:   549,542   563,541   578,271 ops/sec
  compare: 1 -1
  diff: -2.89%
  rme: 2.22%
Record > update random using set() of 5
  Old:   507,733   516,212   524,979 ops/sec
  New:   530,281   537,319   544,547 ops/sec
  compare: -1 1
  diff: 4.08%
  rme: 1.5%
Record > update random using set() of 10
  Old:   508,019   517,004   526,313 ops/sec
  New:   517,158   525,725   534,579 ops/sec
  compare: 0 0
  diff: 1.68%
  rme: 1.71%
Record > update random using set() of 100
  Old:   497,564   505,856   514,430 ops/sec
  New:   480,820   497,295   514,940 ops/sec
  compare: 0 0
  diff: -1.7%
  rme: 2.69%
Record > update random using set() of 1000
  Old:   432,121   451,523   472,750 ops/sec
  New:   456,024   471,957   489,043 ops/sec
  compare: 0 0
  diff: 4.52%
  rme: 4.02%
Record > access random using get() of 2
  Old: 23,729,363 24,644,873 25,633,861 ops/sec
  New: 25,637,001 26,168,418 26,722,333 ops/sec
  compare: -1 1
  diff: 6.18%
  rme: 3.09%
Record > access random using get() of 5
  Old: 13,110,108 13,398,740 13,700,367 ops/sec
  New: 12,792,530 13,359,037 13,978,044 ops/sec
  compare: -1 1
  diff: -0.3%
  rme: 3.49%
Record > access random using get() of 10
  Old: 11,775,849 12,091,213 12,423,933 ops/sec
  New: 11,647,874 12,073,740 12,531,928 ops/sec
  compare: 0 0
  diff: -0.15%
  rme: 3.2%
Record > access random using get() of 100
  Old: 11,505,263 11,774,700 12,057,059 ops/sec
  New: 11,559,526 11,813,851 12,079,618 ops/sec
  compare: 0 0
  diff: 0.33%
  rme: 2.27%
Record > access random using get() of 1000
  Old: 6,214,206 6,314,159 6,417,380 ops/sec
  New: 7,000,379 7,249,167 7,516,291 ops/sec
  compare: -1 1
  diff: 14.8%
  rme: 2.75%
Record > access random using property of 2
  Old: 14,787,347 15,136,868 15,503,312 ops/sec
  New: 17,034,978 17,542,846 18,081,926 ops/sec
  compare: -1 1
  diff: 15.89%
  rme: 2.69%
Record > access random using property of 5
  Old: 7,763,196 8,047,626 8,353,691 ops/sec
  New: 7,655,169 7,859,619 8,075,290 ops/sec
  compare: 1 -1
  diff: -2.34%
  rme: 3.2%
Record > access random using property of 10
  Old: 6,652,674 6,905,986 7,179,352 ops/sec
  New: 7,293,029 7,509,974 7,740,223 ops/sec
  compare: -1 1
  diff: 8.74%
  rme: 3.41%
Record > access random using property of 100
  Old: 7,551,915 7,722,948 7,901,908 ops/sec
  New: 7,311,475 7,558,304 7,822,381 ops/sec
  compare: 0 0
  diff: -2.14%
  rme: 2.87%
Record > access random using property of 1000
  Old: 6,190,138 6,302,711 6,419,456 ops/sec
  New: 6,464,726 6,565,657 6,669,790 ops/sec
  compare: -1 1
  diff: 4.17%
  rme: 1.69%
toJS List of 32
  Old:  Infinity  Infinity  Infinity ops/sec
  New:  Infinity  Infinity  Infinity ops/sec
  compare: 1 1
  diff: NaN%
  rme: 0%
toJS Map of 32
  Old:  Infinity  Infinity  Infinity ops/sec
  New:  Infinity  Infinity  Infinity ops/sec
  compare: 1 1
  diff: NaN%
  rme: 0%
all done
```

</details>


It shows a small change on each operation (-5% / +5%), but it there is a really impressive on Map.merge (around +100%)