### PR TITLE
fix(src):fix some ts error hint

### DIFF
--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -107,9 +107,9 @@ export function KeyedCollection(
 
 export class KeyedCollectionImpl<K, V> extends CollectionImpl<K, V> {}
 
-export function IndexedCollection<T>(
-  value: Iterable<T> | ArrayLike<T>
-): IndexedCollectionImpl<T> {
+export function IndexedCollection(
+  value: Iterable<unknown> | ArrayLike<unknown>
+): IndexedCollectionImpl<unknown> {
   return isIndexed(value) ? value : IndexedSeq(value);
 }
 

--- a/src/predicates/isKeyed.ts
+++ b/src/predicates/isKeyed.ts
@@ -20,7 +20,7 @@ export function isKeyed(
 ): maybeKeyed is KeyedCollectionImpl<unknown, unknown> {
   return Boolean(
     maybeKeyed &&
-      // @ts-expect-error: maybeKeyed is typed as `{}`, need to change in 6.0 to `maybeKeyed && typeof maybeKeyed === 'object' && IS_KEYED_SYMBOL in maybeKeyed`
-      maybeKeyed[IS_KEYED_SYMBOL]
-  );
+    typeof maybeKeyed === 'object' &&
+    IS_KEYED_SYMBOL in maybeKeyed
+  )
 }

--- a/src/utils/mixin.ts
+++ b/src/utils/mixin.ts
@@ -5,16 +5,12 @@ type Constructor<T = object> = new (...args: unknown[]) => T;
  */
 export default function mixin<C extends Constructor>(
   ctor: C,
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  methods: Record<string, Function>
+  methods: Record<PropertyKey, (...args: unknown[]) => unknown>
 ): C {
   const keyCopier = (key: string | symbol): void => {
-    // @ts-expect-error how to handle symbol ?
     ctor.prototype[key] = methods[key];
   };
   Object.keys(methods).forEach(keyCopier);
-  // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
-  Object.getOwnPropertySymbols &&
-    Object.getOwnPropertySymbols(methods).forEach(keyCopier);
+  Object.getOwnPropertySymbols(methods).forEach(keyCopier);
   return ctor;
 }


### PR DESCRIPTION
`src/Collection.ts`
I changed generic type `T` to `unknown`; otherwise, ts will lint a `Type '(Iterable<T> | ArrayLike<T>) & IndexedCollectionImpl<unknown>' is not assignable to type 'IndexedCollectionImpl<T>` error message.

`src/predicates/isKeyed.ts`
You left a to-do, so I changed it.

`src/utils/mixin.ts`
`PropertyKey` has a type of `number | string | symbol`.
I don't know why `Object.getOwnPropertySymbols` needs to be an assertion.
Removing it, the ESLint error message automatically disappears.