### PR TITLE
Remove empty collection singletons

### DIFF
--- a/__tests__/Map.ts
+++ b/__tests__/Map.ts
@@ -26,6 +26,13 @@ describe('Map', () => {
     expect(m.get('c')).toBe('C');
   });
 
+  it('constructor provides different instances', () => {
+    expect(Map()).not.toBe(Map());
+    expect(Map()).toEqual(Map());
+    expect(Map({ a: 'A' })).not.toBe(Map({ a: 'A' }));
+    expect(Map({ a: 'A' })).toEqual(Map({ a: 'A' }));
+  });
+
   it('constructor provides initial values', () => {
     const m = Map({ a: 'A', b: 'B', c: 'C' });
     expect(m.size).toBe(3);
@@ -205,7 +212,7 @@ describe('Map', () => {
           m = m.remove(ii);
           expect(m.size).toBe(ii);
         }
-        expect(m).toBe(Map());
+        expect(m).toEqual(Map());
       })
     );
   });
@@ -438,7 +445,7 @@ describe('Map', () => {
   it('chained mutations does not result in new empty map instance', () => {
     const v1 = Map<{ x?: number; y?: number }>({ x: 1 });
     const v2 = v1.withMutations((v) => v.set('y', 2).delete('x').delete('y'));
-    expect(v2).toBe(Map());
+    expect(v2).toEqual(Map());
   });
 
   it('expresses value equality with unordered sequences', () => {

--- a/__tests__/OrderedMap.ts
+++ b/__tests__/OrderedMap.ts
@@ -14,6 +14,13 @@ describe('OrderedMap', () => {
     ]);
   });
 
+  it('constructor provides different instances', () => {
+    expect(OrderedMap()).not.toBe(OrderedMap());
+    expect(OrderedMap()).toEqual(OrderedMap());
+    expect(OrderedMap({ a: 'A' })).not.toBe(OrderedMap({ a: 'A' }));
+    expect(OrderedMap({ a: 'A' })).toEqual(OrderedMap({ a: 'A' }));
+  });
+
   it('constructor provides initial values', () => {
     const m = OrderedMap({ a: 'A', b: 'B', c: 'C' });
     expect(m.get('a')).toBe('A');

--- a/__tests__/OrderedSet.ts
+++ b/__tests__/OrderedSet.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from '@jest/globals';
 import { Map, OrderedSet } from 'immutable';
 
 describe('OrderedSet', () => {
+  it('constructor provides different instances', () => {
+    expect(OrderedSet()).not.toBe(OrderedSet());
+    expect(OrderedSet()).toEqual(OrderedSet());
+    expect(OrderedSet(['A'])).not.toBe(OrderedSet(['A']));
+    expect(OrderedSet(['A'])).toEqual(OrderedSet(['A']));
+  });
+
   it('provides initial values in a mixed order', () => {
     const s = OrderedSet.of('C', 'B', 'A');
     expect(s.has('A')).toBe(true);

--- a/__tests__/Range.ts
+++ b/__tests__/Range.ts
@@ -3,6 +3,13 @@ import fc from 'fast-check';
 import { Range } from 'immutable';
 
 describe('Range', () => {
+  it('constructor provides different instances', () => {
+    expect(Range(0, 3)).not.toBe(Range(0, 3));
+    expect(Range(0, 3)).toEqual(Range(0, 3));
+    expect(Range(1, 10, 3)).not.toBe(Range(1, 10, 3));
+    expect(Range(1, 10, 3)).toEqual(Range(1, 10, 3));
+  });
+
   it('fixed range', () => {
     const v = Range(0, 3);
     expect(v.size).toBe(3);

--- a/__tests__/Repeat.ts
+++ b/__tests__/Repeat.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from '@jest/globals';
 import { Repeat } from 'immutable';
 
 describe('Repeat', () => {
+  it('constructor provides different instances', () => {
+    expect(Repeat('wtf')).not.toBe(Repeat('wtf'));
+    // Value equality is not computable for infinite Seq
+    expect(Repeat('wtf', 2)).not.toBe(Repeat('wtf', 2));
+    expect(Repeat('wtf', 2)).toEqual(Repeat('wtf', 2));
+  });
+
   it('fixed repeat', () => {
     const v = Repeat('wtf', 3);
     expect(v.size).toBe(3);

--- a/__tests__/Seq.ts
+++ b/__tests__/Seq.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from '@jest/globals';
 import { Seq, isCollection, isIndexed, isKeyed } from 'immutable';
 
 describe('Seq', () => {
+  it('constructor provides different instances', () => {
+    expect(Seq()).not.toBe(Seq());
+    expect(Seq()).toEqual(Seq());
+    expect(Seq([1])).not.toBe(Seq([1]));
+    expect(Seq([1])).toEqual(Seq([1]));
+  });
+
   it('returns undefined if empty and first is called without default argument', () => {
     expect(Seq().first()).toBeUndefined();
   });

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -2,6 +2,13 @@ import { describe, expect, it, jest } from '@jest/globals';
 import { List, Map, OrderedSet, Seq, Set, fromJS, is } from 'immutable';
 
 describe('Set', () => {
+  it('constructor provides different instances', () => {
+    expect(Set()).not.toBe(Set());
+    expect(Set()).toEqual(Set());
+    expect(Set([1])).not.toBe(Set([1]));
+    expect(Set([1])).toEqual(Set([1]));
+  });
+
   it('accepts array of values', () => {
     const s = Set([1, 2, 3]);
     expect(s.has(1)).toBe(true);
@@ -121,7 +128,7 @@ describe('Set', () => {
     const cat = Set(['c', 'a', 't']);
     expect(Set.union([abc, cat]).toArray()).toEqual(['c', 'a', 't', 'b']);
     expect(Set.union([abc])).toBe(abc);
-    expect(Set.union([])).toBe(Set());
+    expect(Set.union([])).toEqual(Set());
   });
 
   it('intersects an unknown collection of Sets', () => {
@@ -129,7 +136,7 @@ describe('Set', () => {
     const cat = Set(['c', 'a', 't']);
     expect(Set.intersect([abc, cat]).toArray()).toEqual(['c', 'a']);
     expect(Set.intersect([abc])).toBe(abc);
-    expect(Set.intersect([])).toBe(Set());
+    expect(Set.intersect([])).toEqual(Set());
   });
 
   it('concatenates strings using union', () => {
@@ -220,7 +227,7 @@ describe('Set', () => {
 
   it('deletes down to empty set', () => {
     const s = Set.of('A').remove('A');
-    expect(s).toBe(Set());
+    expect(s).toEqual(Set());
   });
 
   it('unions multiple sets', () => {

--- a/__tests__/Stack.ts
+++ b/__tests__/Stack.ts
@@ -11,6 +11,13 @@ function arrayOfSize(s: number): Array<number> {
 }
 
 describe('Stack', () => {
+  it('constructor provides different instances', () => {
+    expect(Stack()).not.toBe(Stack());
+    expect(Stack()).toEqual(Stack());
+    expect(Stack(['a'])).not.toBe(Stack(['a']));
+    expect(Stack(['a'])).toEqual(Stack(['a']));
+  });
+
   it('constructor provides initial values', () => {
     const s = Stack.of('a', 'b', 'c');
     expect(s.get(0)).toBe('a');

--- a/__tests__/updateIn.ts
+++ b/__tests__/updateIn.ts
@@ -263,7 +263,7 @@ describe('updateIn', () => {
     let spiedOnID;
     const m2 = m.updateIn(['a', 'b', 'c'], Set(), (id) => (spiedOnID = id));
     expect(m2).toBe(m);
-    expect(spiedOnID).toBe(Set());
+    expect(spiedOnID).toEqual(Set());
   });
 
   it('provides default notSetValue of undefined', () => {

--- a/src/Map.js
+++ b/src/Map.js
@@ -619,9 +619,8 @@ function makeMap(size, root, ownerID, hash) {
   return map;
 }
 
-let EMPTY_MAP;
 export function emptyMap() {
-  return EMPTY_MAP || (EMPTY_MAP = makeMap(0));
+  return makeMap(0);
 }
 
 function updateMap(map, k, v) {

--- a/src/OrderedMap.js
+++ b/src/OrderedMap.js
@@ -106,12 +106,8 @@ function makeOrderedMap(map, list, ownerID, hash) {
   return omap;
 }
 
-let EMPTY_ORDERED_MAP;
 export function emptyOrderedMap() {
-  return (
-    EMPTY_ORDERED_MAP ||
-    (EMPTY_ORDERED_MAP = makeOrderedMap(emptyMap(), emptyList()))
-  );
+  return makeOrderedMap(emptyMap(), emptyList());
 }
 
 function updateOrderedMap(omap, k, v) {

--- a/src/OrderedSet.js
+++ b/src/OrderedSet.js
@@ -53,9 +53,6 @@ function makeOrderedSet(map, ownerID) {
   return set;
 }
 
-let EMPTY_ORDERED_SET;
 function emptyOrderedSet() {
-  return (
-    EMPTY_ORDERED_SET || (EMPTY_ORDERED_SET = makeOrderedSet(emptyOrderedMap()))
-  );
+  return makeOrderedSet(emptyOrderedMap());
 }

--- a/src/Range.ts
+++ b/src/Range.ts
@@ -35,12 +35,6 @@ export const Range = (
     step = -step;
   }
   const size = Math.max(0, Math.ceil((end - start) / step - 1) + 1);
-  if (size === 0) {
-    if (!EMPTY_RANGE) {
-      EMPTY_RANGE = new RangeImpl(start, end, step, 0);
-    }
-    return EMPTY_RANGE;
-  }
   return new RangeImpl(start, end, step, size);
 };
 
@@ -157,5 +151,3 @@ export class RangeImpl extends IndexedSeqImpl implements Seq.Indexed<number> {
       : deepEqual(this, other);
   }
 }
-
-let EMPTY_RANGE: RangeImpl | undefined;

--- a/src/Repeat.js
+++ b/src/Repeat.js
@@ -10,12 +10,6 @@ import deepEqual from './utils/deepEqual';
  */
 export const Repeat = (value, times) => {
   const size = times === undefined ? Infinity : Math.max(0, times);
-  if (size === 0) {
-    if (!EMPTY_REPEAT) {
-      EMPTY_REPEAT = new RepeatImpl(value, 0);
-    }
-    return EMPTY_REPEAT;
-  }
   return new RepeatImpl(value, size);
 };
 
@@ -97,5 +91,3 @@ export class RepeatImpl extends IndexedSeqImpl {
       : deepEqual(this, other);
   }
 }
-
-let EMPTY_REPEAT;

--- a/src/Seq.js
+++ b/src/Seq.js
@@ -277,11 +277,8 @@ class CollectionSeq extends IndexedSeqImpl {
 }
 
 // # pragma Helper functions
-
-let EMPTY_SEQ;
-
 function emptySequence() {
-  return EMPTY_SEQ || (EMPTY_SEQ = new ArraySeq([]));
+  return new ArraySeq([]);
 }
 
 export function keyedSeqFromValue(value) {

--- a/src/Set.js
+++ b/src/Set.js
@@ -231,7 +231,6 @@ function makeSet(map, ownerID) {
   return set;
 }
 
-let EMPTY_SET;
 function emptySet() {
-  return EMPTY_SET || (EMPTY_SET = makeSet(emptyMap()));
+  return makeSet(emptyMap());
 }

--- a/src/Stack.js
+++ b/src/Stack.js
@@ -221,7 +221,6 @@ function makeStack(size, head, ownerID, hash) {
   return map;
 }
 
-let EMPTY_STACK;
 function emptyStack() {
-  return EMPTY_STACK || (EMPTY_STACK = makeStack(0));
+  return makeStack(0);
 }


### PR DESCRIPTION
Fixes #2140 

All empty collection singletons have been removed. Added tests for instance inequality on  immutable objects with value equality.