### PR TITLE
Preserve indexed methods after Seq concat

### DIFF
--- a/__tests__/concat.ts
+++ b/__tests__/concat.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { List, Seq, Set } from 'immutable';
+import { isIndexed, List, Seq, Set } from 'immutable';
 
 describe('concat', () => {
   it('concats two sequences', () => {
@@ -74,6 +74,17 @@ describe('concat', () => {
     const c = [7, 8, 9];
     expect(a.concat(b, c).size).toBe(9);
     expect(a.concat(b, c).toArray()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('preserves indexed methods when concatenating multiple sequences', () => {
+    const indexed = Seq.Indexed([1]).concat([2], [3]);
+
+    expect(isIndexed(indexed)).toBe(true);
+    expect(indexed.zip(Seq(['a', 'b', 'c'])).toArray()).toEqual([
+      [1, 'a'],
+      [2, 'b'],
+      [3, 'c'],
+    ]);
   });
 
   it('can concat itself!', () => {

--- a/src/Operations.js
+++ b/src/Operations.js
@@ -591,27 +591,7 @@ export function skipWhileFactory(collection, predicate, context, useKeys) {
   return skipSequence;
 }
 
-class ConcatSeq extends Seq {
-  constructor(iterables) {
-    this._wrappedIterables = iterables.flatMap((iterable) => {
-      if (iterable._wrappedIterables) {
-        return iterable._wrappedIterables;
-      }
-      return [iterable];
-    });
-    this.size = this._wrappedIterables.reduce((sum, iterable) => {
-      if (sum !== undefined) {
-        const size = iterable.size;
-        if (size !== undefined) {
-          return sum + size;
-        }
-      }
-    }, 0);
-    this[IS_KEYED_SYMBOL] = this._wrappedIterables[0][IS_KEYED_SYMBOL];
-    this[IS_INDEXED_SYMBOL] = this._wrappedIterables[0][IS_INDEXED_SYMBOL];
-    this[IS_ORDERED_SYMBOL] = this._wrappedIterables[0][IS_ORDERED_SYMBOL];
-  }
-
+const ConcatSeqPrototype = {
   __iterateUncached(fn, reverse) {
     if (this._wrappedIterables.length === 0) {
       return;
@@ -651,7 +631,7 @@ class ConcatSeq extends Seq {
       index++;
     }
     return index;
-  }
+  },
 
   __iteratorUncached(type, reverse) {
     if (this._wrappedIterables.length === 0) {
@@ -682,8 +662,30 @@ class ConcatSeq extends Seq {
       }
       return next;
     });
+  },
+};
+
+class KeyedConcatSeq extends KeyedSeq {
+  constructor(iterables) {
+    initConcatSeq(this, iterables);
   }
 }
+
+class IndexedConcatSeq extends IndexedSeq {
+  constructor(iterables) {
+    initConcatSeq(this, iterables);
+  }
+}
+
+class SetConcatSeq extends SetSeq {
+  constructor(iterables) {
+    initConcatSeq(this, iterables);
+  }
+}
+
+Object.assign(KeyedConcatSeq.prototype, ConcatSeqPrototype);
+Object.assign(IndexedConcatSeq.prototype, ConcatSeqPrototype);
+Object.assign(SetConcatSeq.prototype, ConcatSeqPrototype);
 
 export function concatFactory(collection, values) {
   const isKeyedCollection = isKeyed(collection);
@@ -716,7 +718,33 @@ export function concatFactory(collection, values) {
     }
   }
 
-  return new ConcatSeq(iters);
+  const concatSeqClass = isKeyedCollection
+    ? KeyedConcatSeq
+    : isIndexed(collection)
+      ? IndexedConcatSeq
+      : SetConcatSeq;
+
+  return new concatSeqClass(iters);
+}
+
+function initConcatSeq(seq, iterables) {
+  seq._wrappedIterables = iterables.flatMap((iterable) => {
+    if (iterable._wrappedIterables) {
+      return iterable._wrappedIterables;
+    }
+    return [iterable];
+  });
+  seq.size = seq._wrappedIterables.reduce((sum, iterable) => {
+    if (sum !== undefined) {
+      const size = iterable.size;
+      if (size !== undefined) {
+        return sum + size;
+      }
+    }
+  }, 0);
+  seq[IS_KEYED_SYMBOL] = seq._wrappedIterables[0][IS_KEYED_SYMBOL];
+  seq[IS_INDEXED_SYMBOL] = seq._wrappedIterables[0][IS_INDEXED_SYMBOL];
+  seq[IS_ORDERED_SYMBOL] = seq._wrappedIterables[0][IS_ORDERED_SYMBOL];
 }
 
 export function flattenFactory(collection, depth, useKeys) {


### PR DESCRIPTION
Summary:
- preserve keyed/indexed/set sequence prototypes when concat creates a multi-collection concat sequence
- keep the existing flattened concat iteration behavior shared across concat sequence variants
- add a regression test that `Seq.Indexed(...).concat(...).zip(...)` remains available

Tests:
- `npm_config_cache=/tmp/immutable-npm-cache npx jest __tests__/concat.ts __tests__/zip.ts --runInBand`
- `npm_config_cache=/tmp/immutable-npm-cache npm run test:unit -- --runInBand`
- `npm_config_cache=/tmp/immutable-npm-cache npm run lint`
- `npm_config_cache=/tmp/immutable-npm-cache npm run type-check`
- `npm_config_cache=/tmp/immutable-npm-cache npm run build`
- `git diff --check`

Fixes #2161