### PR TITLE
Move simple Group A methods from CollectionImpl mixin into Collection.ts classes

### DIFF
--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -1,6 +1,14 @@
-import { ITERATE_ENTRIES, type IteratorType } from './Iterator';
+import { reduce } from './CollectionHelperMethods';
+import {
+  ITERATE_ENTRIES,
+  ITERATE_KEYS,
+  ITERATE_VALUES,
+  type IteratorType,
+} from './Iterator';
 import { IndexedSeq, KeyedSeq, Seq, SetSeq } from './Seq';
+import { NOT_SET, returnTrue, wrapIndex } from './TrieUtils';
 import type ValueObject from './ValueObject';
+import { is } from './is';
 import { isAssociative } from './predicates/isAssociative';
 import { isCollection } from './predicates/isCollection';
 import { isIndexed } from './predicates/isIndexed';
@@ -53,33 +61,229 @@ export class CollectionImpl<K, V> implements ValueObject {
     return returnValue;
   }
 
-  entries() {
+  entries(): IterableIterator<[K, V]> {
     return this.__iterator(ITERATE_ENTRIES);
   }
 
+  keys(): IterableIterator<K> {
+    return this.__iterator(ITERATE_KEYS);
+  }
+
+  values(): IterableIterator<V> {
+    return this.__iterator(ITERATE_VALUES);
+  }
+
+  some(
+    predicate: (value: V, key: K, iter: this) => boolean,
+    context?: unknown
+  ): boolean {
+    assertNotInfinite(this.size);
+    let returnValue = false;
+
+    this.__iterate((v, k, c) => {
+      if (predicate.call(context, v, k, c)) {
+        returnValue = true;
+        return false;
+      }
+    });
+
+    return returnValue;
+  }
+
+  forEach(
+    sideEffect: (value: V, key: K, iter: this) => unknown,
+    context?: unknown
+  ): number {
+    assertNotInfinite(this.size);
+
+    return this.__iterate(context ? sideEffect.bind(context) : sideEffect);
+  }
+
+  findEntry(
+    predicate: (value: V, key: K, iter: this) => boolean,
+    context?: unknown,
+    notSetValue?: V
+  ): [K, V] | undefined {
+    let found = notSetValue as [K, V] | undefined;
+
+    this.__iterate((v, k, c) => {
+      if (predicate.call(context, v, k, c)) {
+        found = [k, v];
+
+        return false;
+      }
+    });
+
+    return found;
+  }
+
+  find(
+    predicate: (value: V, key: K, iter: this) => boolean,
+    context?: unknown,
+    notSetValue?: V
+  ): V | undefined {
+    const entry = this.findEntry(predicate, context);
+
+    return entry ? entry[1] : notSetValue;
+  }
+
+  findKey(
+    predicate: (value: V, key: K, iter: this) => boolean,
+    context?: unknown
+  ): K | undefined {
+    const entry = this.findEntry(predicate, context);
+
+    return entry && entry[0];
+  }
+
+  keyOf(searchValue: V): K | undefined {
+    return this.findKey((value) => is(value, searchValue));
+  }
+
+  first<NSV>(notSetValue: NSV): V | NSV;
+  first(): V | undefined;
+  first(notSetValue?: unknown): unknown {
+    return this.find(returnTrue, null, notSetValue as V | undefined);
+  }
+
+  get<NSV>(searchKey: K, notSetValue: NSV): V | NSV;
+  get(searchKey: K): V | undefined;
+  get(searchKey: K, notSetValue?: unknown): unknown {
+    return this.find(
+      (_, key) => is(key, searchKey),
+      undefined,
+      notSetValue as V | undefined
+    );
+  }
+
+  has(searchKey: K): boolean {
+    return (
+      this.get(searchKey, NOT_SET as unknown as V) !== (NOT_SET as unknown as V)
+    );
+  }
+
+  includes(searchValue: V): boolean {
+    return this.some((value) => is(value, searchValue));
+  }
+
+  isEmpty(): boolean {
+    return this.size !== undefined ? this.size === 0 : !this.some(returnTrue);
+  }
+
+  isSubset(iter: Iterable<V>): boolean {
+    // TODO better types !
+    const c =
+      typeof (iter as unknown as { includes?: unknown })?.includes ===
+      'function'
+        ? (iter as unknown as CollectionImpl<unknown, V>)
+        : (Collection(iter as never) as unknown as CollectionImpl<unknown, V>);
+
+    return this.every((value) => c.includes(value));
+  }
+
+  isSuperset(iter: Iterable<V>): boolean {
+    // TODO better types !
+    const c =
+      typeof (iter as unknown as { isSubset?: unknown })?.isSubset ===
+      'function'
+        ? (iter as unknown as CollectionImpl<unknown, V>)
+        : (Collection(iter as never) as unknown as CollectionImpl<unknown, V>);
+
+    return c.isSubset(this as unknown as Iterable<V>);
+  }
+
+  join(separator?: string): string {
+    assertNotInfinite(this.size);
+    const sep = separator !== undefined ? '' + separator : ',';
+    let joined = '';
+    let isFirst = true;
+
+    this.__iterate((v) => {
+      if (isFirst) {
+        isFirst = false;
+      } else {
+        joined += sep;
+      }
+      joined += v !== null && v !== undefined ? v.toString() : '';
+    });
+
+    return joined;
+  }
+
+  reduce<R>(
+    reducer: (reduction: R, value: V, key: K, iter: this) => R,
+    initialReduction: R,
+    context?: unknown
+  ): R;
+  reduce<R>(reducer: (reduction: V | R, value: V, key: K, iter: this) => R): R;
+  reduce<R>(
+    reducer: (reduction: V | R, value: V, key: K, iter: this) => R,
+    initialReduction?: R,
+    context?: unknown
+  ): R {
+    return reduce(
+      this,
+      // @ts-expect-error reducer is (reduction: V | R, value: V, key: K, iter: this) => R, but CollectionImpl<unknown, unknown> is expected
+      reducer,
+      initialReduction,
+      context,
+      arguments.length < 2,
+      false
+    ) as R; // TODO need better types for `reduce`
+  }
+
+  reduceRight<R>(
+    reducer: (reduction: R, value: V, key: K, iter: this) => R,
+    initialReduction: R,
+    context?: unknown
+  ): R;
+  reduceRight<R>(
+    reducer: (reduction: V | R, value: V, key: K, iter: this) => R
+  ): R;
+  reduceRight<R>(
+    reducer: (reduction: V | R, value: V, key: K, iter: this) => R,
+    initialReduction?: R,
+    context?: unknown
+  ): R {
+    return reduce(
+      this,
+      // @ts-expect-error reducer is (reduction: V | R, value: V, key: K, iter: this) => R, but CollectionImpl<unknown, unknown> is expected
+      reducer,
+      initialReduction,
+      context,
+      arguments.length < 2,
+      true
+    ) as R; // TODO need better types for `reduceRight`
+  }
+
+  update<R>(updater: (value: this) => R): R {
+    return updater(this);
+  }
+
   __iterate(
-    fn: (value: V, index: K, iter: this) => boolean,
-    reverse?: boolean
-  ): number;
-  __iterate(
-    fn: (value: V, index: K, iter: this) => void,
-    reverse?: boolean
-  ): void;
-  __iterate(
-    fn: (value: V, index: K, iter: this) => boolean | void,
+    fn: (value: V, index: K, iter: this) => unknown,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     reverse: boolean = false
-  ): number | void {
+  ): number {
     throw new Error(
       'CollectionImpl does not implement __iterate. Use a subclass instead.'
     );
   }
 
   __iterator(
+    type: typeof ITERATE_ENTRIES,
+    reverse?: boolean
+  ): IterableIterator<[K, V]>;
+  __iterator(type: typeof ITERATE_KEYS, reverse?: boolean): IterableIterator<K>;
+  __iterator(
+    type: typeof ITERATE_VALUES,
+    reverse?: boolean
+  ): IterableIterator<V>;
+  __iterator(
     type: IteratorType,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     reverse: boolean = false
-  ): Iterator<K | V | [K, V]> {
+  ): IterableIterator<K | V | [K, V]> {
     throw new Error(
       'CollectionImpl does not implement __iterator. Use a subclass instead.'
     );
@@ -134,6 +338,56 @@ export class IndexedCollectionImpl<T>
   declare toArray: () => T[];
 
   declare [Symbol.iterator]: () => IterableIterator<T>;
+
+  findIndex(
+    predicate: (value: T, index: number, iter: this) => boolean,
+    context?: unknown
+  ): number {
+    const entry = this.findEntry(predicate, context);
+    return entry ? entry[0] : -1;
+  }
+
+  indexOf(searchValue: T): number {
+    const key = this.keyOf(searchValue);
+    return key === undefined ? -1 : key;
+  }
+
+  override first<NSV>(notSetValue: NSV): T | NSV;
+  override first(): T | undefined;
+  override first(notSetValue?: unknown): unknown {
+    return this.get(0, notSetValue as T | undefined);
+  }
+
+  last<NSV>(notSetValue: NSV): T | NSV;
+  last(): T | undefined;
+  last(notSetValue?: unknown): unknown {
+    return this.get(-1, notSetValue as T | undefined);
+  }
+
+  override get<NSV>(index: number, notSetValue: NSV): T | NSV;
+  override get(index: number): T | undefined;
+  override get(index: number, notSetValue?: unknown): unknown {
+    index = wrapIndex(this, index);
+    return index < 0 ||
+      this.size === Infinity ||
+      (this.size !== undefined && index > this.size)
+      ? notSetValue
+      : this.find(
+          (_, key) => key === index,
+          undefined,
+          notSetValue as T | undefined
+        );
+  }
+
+  override has(index: number): boolean {
+    index = wrapIndex(this, index);
+    return (
+      index >= 0 &&
+      (this.size !== undefined
+        ? this.size === Infinity || index < this.size
+        : this.indexOf(index as unknown as T) !== -1)
+    );
+  }
 }
 
 export function SetCollection<T>(

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -11,9 +11,8 @@ import {
   keyMapper,
   neg,
   not,
-  reduce,
 } from './CollectionHelperMethods';
-import { ITERATE_KEYS, ITERATE_VALUES, Iterator } from './Iterator';
+import { Iterator } from './Iterator';
 import { List } from './List';
 import { Map } from './Map';
 import {
@@ -52,14 +51,7 @@ import {
 } from './Seq';
 import { Set } from './Set';
 import { Stack } from './Stack';
-import {
-  ensureSize,
-  NOT_SET,
-  resolveBegin,
-  returnTrue,
-  wrapIndex,
-} from './TrieUtils';
-import { is } from './is';
+import { ensureSize, resolveBegin } from './TrieUtils';
 import { getIn } from './methods/getIn';
 import { hasIn } from './methods/hasIn';
 import { toObject } from './methods/toObject';
@@ -172,10 +164,6 @@ mixin(CollectionImpl, {
     return reify(this, concatFactory(this, values));
   },
 
-  includes(searchValue) {
-    return this.some((value) => is(value, searchValue));
-  },
-
   filter(predicate, context) {
     return reify(this, filterFactory(this, predicate, context, true));
   },
@@ -184,57 +172,8 @@ mixin(CollectionImpl, {
     return partitionFactory(this, predicate, context);
   },
 
-  find(predicate, context, notSetValue) {
-    const entry = this.findEntry(predicate, context);
-    return entry ? entry[1] : notSetValue;
-  },
-
-  forEach(sideEffect, context) {
-    assertNotInfinite(this.size);
-    return this.__iterate(context ? sideEffect.bind(context) : sideEffect);
-  },
-
-  join(separator) {
-    assertNotInfinite(this.size);
-    separator = separator !== undefined ? '' + separator : ',';
-    let joined = '';
-    let isFirst = true;
-    this.__iterate((v) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
-      isFirst ? (isFirst = false) : (joined += separator);
-      joined += v !== null && v !== undefined ? v.toString() : '';
-    });
-    return joined;
-  },
-
-  keys() {
-    return this.__iterator(ITERATE_KEYS);
-  },
-
   map(mapper, context) {
     return reify(this, mapFactory(this, mapper, context));
-  },
-
-  reduce(reducer, initialReduction, context) {
-    return reduce(
-      this,
-      reducer,
-      initialReduction,
-      context,
-      arguments.length < 2,
-      false
-    );
-  },
-
-  reduceRight(reducer, initialReduction, context) {
-    return reduce(
-      this,
-      reducer,
-      initialReduction,
-      context,
-      arguments.length < 2,
-      true
-    );
   },
 
   reverse() {
@@ -245,34 +184,14 @@ mixin(CollectionImpl, {
     return reify(this, sliceFactory(this, begin, end, true));
   },
 
-  some(predicate, context) {
-    assertNotInfinite(this.size);
-    let returnValue = false;
-    this.__iterate((v, k, c) => {
-      if (predicate.call(context, v, k, c)) {
-        returnValue = true;
-        return false;
-      }
-    });
-    return returnValue;
-  },
-
   sort(comparator) {
     return reify(this, sortFactory(this, comparator));
-  },
-
-  values() {
-    return this.__iterator(ITERATE_VALUES);
   },
 
   // ### More sequential methods
 
   butLast() {
     return this.slice(0, -1);
-  },
-
-  isEmpty() {
-    return this.size !== undefined ? this.size === 0 : !this.some(() => true);
   },
 
   count(predicate, context) {
@@ -305,22 +224,6 @@ mixin(CollectionImpl, {
     return this.filter(not(predicate), context);
   },
 
-  findEntry(predicate, context, notSetValue) {
-    let found = notSetValue;
-    this.__iterate((v, k, c) => {
-      if (predicate.call(context, v, k, c)) {
-        found = [k, v];
-        return false;
-      }
-    });
-    return found;
-  },
-
-  findKey(predicate, context) {
-    const entry = this.findEntry(predicate, context);
-    return entry && entry[0];
-  },
-
   findLast(predicate, context, notSetValue) {
     return this.toKeyedSeq().reverse().find(predicate, context, notSetValue);
   },
@@ -335,10 +238,6 @@ mixin(CollectionImpl, {
     return this.toKeyedSeq().reverse().findKey(predicate, context);
   },
 
-  first(notSetValue) {
-    return this.find(returnTrue, null, notSetValue);
-  },
-
   flatMap(mapper, context) {
     return reify(this, flatMapFactory(this, mapper, context));
   },
@@ -351,35 +250,13 @@ mixin(CollectionImpl, {
     return new FromEntriesSequence(this);
   },
 
-  get(searchKey, notSetValue) {
-    return this.find((_, key) => is(key, searchKey), undefined, notSetValue);
-  },
-
   getIn: getIn,
 
   groupBy(grouper, context) {
     return groupByFactory(this, grouper, context);
   },
 
-  has(searchKey) {
-    return this.get(searchKey, NOT_SET) !== NOT_SET;
-  },
-
   hasIn: hasIn,
-
-  isSubset(iter) {
-    iter = typeof iter.includes === 'function' ? iter : Collection(iter);
-    return this.every((value) => iter.includes(value));
-  },
-
-  isSuperset(iter) {
-    iter = typeof iter.isSubset === 'function' ? iter : Collection(iter);
-    return iter.isSubset(this);
-  },
-
-  keyOf(searchValue) {
-    return this.findKey((value) => is(value, searchValue));
-  },
 
   keySeq() {
     return this.toSeq().map(keyMapper).toIndexedSeq();
@@ -454,10 +331,6 @@ mixin(CollectionImpl, {
 
   takeUntil(predicate, context) {
     return this.takeWhile(not(predicate), context);
-  },
-
-  update(fn) {
-    return fn(this);
   },
 
   valueSeq() {
@@ -536,16 +409,6 @@ mixin(IndexedCollectionImpl, {
     return reify(this, filterFactory(this, predicate, context, false));
   },
 
-  findIndex(predicate, context) {
-    const entry = this.findEntry(predicate, context);
-    return entry ? entry[0] : -1;
-  },
-
-  indexOf(searchValue) {
-    const key = this.keyOf(searchValue);
-    return key === undefined ? -1 : key;
-  },
-
   lastIndexOf(searchValue) {
     const key = this.lastKeyOf(searchValue);
     return key === undefined ? -1 : key;
@@ -585,31 +448,8 @@ mixin(IndexedCollectionImpl, {
     return entry ? entry[0] : -1;
   },
 
-  first(notSetValue) {
-    return this.get(0, notSetValue);
-  },
-
   flatten(depth) {
     return reify(this, flattenFactory(this, depth, false));
-  },
-
-  get(index, notSetValue) {
-    index = wrapIndex(this, index);
-    return index < 0 ||
-      this.size === Infinity ||
-      (this.size !== undefined && index > this.size)
-      ? notSetValue
-      : this.find((_, key) => key === index, undefined, notSetValue);
-  },
-
-  has(index) {
-    index = wrapIndex(this, index);
-    return (
-      index >= 0 &&
-      (this.size !== undefined
-        ? this.size === Infinity || index < this.size
-        : this.indexOf(index) !== -1)
-    );
   },
 
   interpose(separator) {
@@ -632,10 +472,6 @@ mixin(IndexedCollectionImpl, {
 
   keySeq() {
     return Range(0, this.size);
-  },
-
-  last(notSetValue) {
-    return this.get(-1, notSetValue);
   },
 
   skipWhile(predicate, context) {

--- a/src/Iterator.ts
+++ b/src/Iterator.ts
@@ -7,7 +7,7 @@ export type IteratorType =
   | typeof ITERATE_VALUES
   | typeof ITERATE_ENTRIES;
 
-export class Iterator<V> implements globalThis.Iterator<V, undefined> {
+export class Iterator<V> implements IterableIterator<V, undefined> {
   static KEYS = ITERATE_KEYS;
   static VALUES = ITERATE_VALUES;
   static ENTRIES = ITERATE_ENTRIES;

--- a/src/Range.ts
+++ b/src/Range.ts
@@ -1,8 +1,11 @@
 import type { Seq } from '../type-definitions/immutable';
 import {
+  ITERATE_ENTRIES,
+  ITERATE_KEYS,
+  ITERATE_VALUES,
   Iterator,
-  iteratorValue,
   iteratorDone,
+  iteratorValue,
   type IteratorType,
 } from './Iterator';
 import { IndexedSeqImpl } from './Seq';
@@ -58,16 +61,18 @@ export class RangeImpl extends IndexedSeqImpl implements Seq.Indexed<number> {
       : `Range [ ${this._start}...${this._end}${this._step !== 1 ? ' by ' + this._step : ''} ]`;
   }
 
-  get<NSV>(index: number, notSetValue: NSV): number | NSV;
-  get(index: number): number | undefined;
-  get<NSV>(index: number, notSetValue?: NSV): number | NSV | undefined {
-    // @ts-expect-error Issue with the mixin not understood by TypeScript
+  override get<NSV>(index: number, notSetValue: NSV): number | NSV;
+  override get(index: number): number | undefined;
+  override get<NSV>(
+    index: number,
+    notSetValue?: NSV
+  ): number | NSV | undefined {
     return this.has(index)
       ? this._start + wrapIndex(this, index) * this._step
       : notSetValue;
   }
 
-  includes(searchValue: number): boolean {
+  override includes(searchValue: number): boolean {
     const possibleIndex = (searchValue - this._start) / this._step;
     return (
       possibleIndex >= 0 &&
@@ -126,14 +131,26 @@ export class RangeImpl extends IndexedSeqImpl implements Seq.Indexed<number> {
   }
 
   override __iterator(
+    type: typeof ITERATE_ENTRIES,
+    reverse?: boolean
+  ): IterableIterator<[number, number]>;
+  override __iterator(
+    type: typeof ITERATE_KEYS,
+    reverse?: boolean
+  ): IterableIterator<number>;
+  override __iterator(
+    type: typeof ITERATE_VALUES,
+    reverse?: boolean
+  ): IterableIterator<number>;
+  override __iterator(
     type: IteratorType,
     reverse: boolean = false
-  ): Iterator<number> {
+  ): IterableIterator<number | [number, number]> {
     const size = this.size;
     const step = this._step;
     let value = reverse ? this._start + (size - 1) * step : this._start;
     let i = 0;
-    return new Iterator<number>(() => {
+    return new Iterator<number | [number, number]>(() => {
       if (i === size) {
         return iteratorDone();
       }

--- a/src/functional/get.ts
+++ b/src/functional/get.ts
@@ -55,8 +55,7 @@ export function get<K, V, NSV>(
   notSetValue?: NSV
 ): V | NSV | undefined {
   return isImmutable(collection)
-    ? // @ts-expect-error "get" is still in the mixin for now
-      collection.get(key, notSetValue)
+    ? collection.get(key, notSetValue)
     : !has(collection, key)
       ? notSetValue
       : // @ts-expect-error weird "get" here,

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -72,8 +72,7 @@ export default function deepEqual(
     b.__iterate((v, k) => {
       if (
         notAssociative
-          ? // @ts-expect-error has exists on Collection
-            !a.has(v)
+          ? !a.has(v)
           : flipped
             ? // @ts-expect-error type of `get` does not "catch" the version with `notSetValue`
               !is(v, a.get(k, NOT_SET))

--- a/src/utils/mixin.ts
+++ b/src/utils/mixin.ts
@@ -9,10 +9,14 @@ export default function mixin<C extends Constructor>(
   methods: Record<string, Function>
 ): C {
   const keyCopier = (key: string | symbol): void => {
+    // `methods` may be a class prototype, whose methods are non-enumerable
+    // (hence getOwnPropertyNames below rather than Object.keys) and which
+    // owns a `constructor` property we must not copy over.
+    if (key === 'constructor') return;
     // @ts-expect-error how to handle symbol ?
     ctor.prototype[key] = methods[key];
   };
-  Object.keys(methods).forEach(keyCopier);
+  Object.getOwnPropertyNames(methods).forEach(keyCopier);
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
   Object.getOwnPropertySymbols &&
     Object.getOwnPropertySymbols(methods).forEach(keyCopier);


### PR DESCRIPTION
## Summary

First batch of methods migrated out of the `CollectionImpl.js` `mixin()` and into class declarations in `Collection.ts`. Targets the methods that have no dependency on `Operations`, `Map`, `List`, `Set`, `Stack`, `OrderedMap`, `OrderedSet` — i.e. the ones that don't trigger circular import problems.

Goal: reduce the surface area of the runtime `mixin()` step, which is the main obstacle to fully TS-ifying `CollectionImpl.js`. Subsequent PRs will tackle the Operations-dependent group and finally the 6 conversion methods (`toMap`/`toList`/…) via a late-binding registry.

## What moved

- `CollectionImpl`: `values`, `some`, `forEach`, `findEntry`, `find`, `findKey`, `keyOf`, `first`, `get`, `has`, `includes`, `isEmpty`, `isSubset`, `isSuperset`, `join`, `reduce`, `reduceRight`, `update`
- `IndexedCollectionImpl`: `findIndex`, `indexOf`, `first` (override), `last`, `get` (override), `has` (override)

Signatures aligned with `type-definitions/immutable.d.ts` (NSV overloads on `get`/`first`/`last`, two-overload form for `reduce`/`reduceRight`, `predicate: => boolean`, `iter: Iterable<V>` for `isSubset`/`isSuperset`).

## Side adjustments

- `src/utils/mixin.ts` — switched from `Object.keys` to `Object.getOwnPropertyNames` (skipping `constructor`). Class methods are non-enumerable on the prototype, so the previous `Object.keys` no longer copied them into `KeyedSeqImpl`/`IndexedSeqImpl`/`SetSeqImpl` once the methods moved into the class.
- `src/Iterator.ts` — `Iterator<V>` now declares `implements IterableIterator<V, undefined>`. It already returned `this` from `[Symbol.iterator]()` at runtime; the `implements` clause was just out of date and made subclasses unable to satisfy the new `__iterator` overloads.
- `src/Range.ts` — added matching `__iterator` overloads, marked `includes` as `override`, removed a now-useless `@ts-expect-error`.
- `src/functional/get.ts`, `src/utils/deepEqual.ts` — removed `@ts-expect-error` directives that became unused now that the class declares `get`/`has`.

## Test plan

- [x] `npx jest` — 746/746 passing
- [x] `npm run type-check:ts` — clean
- [x] 0 test files modified