### PR TITLE
Migrate mixin operations to real TypeScript class methods in Collection.ts

### DIFF
--- a/.agents/commands/migrate-to-ts.md
+++ b/.agents/commands/migrate-to-ts.md
@@ -65,7 +65,36 @@ conventions of the immutable-js 6.x branch.
    migrated file introduces or refines public types that are not yet covered,
    add the missing tests. Run `npm run test:types` to verify.
 
-8. **Verify**:
+8. **Un-skip the matching source-pass type tests** in
+   `type-definitions/ts-tests-src/`. These files are duplicates of the ones in
+   `type-definitions/ts-tests/`, but their `tsconfig.json` resolves `immutable`
+   against the **TS source** (`src/Immutable.js`) instead of the hand-written
+   `type-definitions/immutable.d.ts`. They validate the types actually emitted
+   by the migration, not the reference declarations.
+
+   Every test there starts as `test.skip(...)` because, mid-migration, the
+   public factories (`List`, `Map`, …) and public type names (`List<number>` as
+   a *type*) live only in `immutable.d.ts` — a test routed through a not-yet-
+   migrated factory cannot even type-check against the source (its errors are
+   suppressed only because the test is skipped).
+
+   **This is the skip-list to keep up to date.** When you migrate a file:
+
+   - In the corresponding `ts-tests-src/*.ts` file(s), change `test.skip(` back
+     to `test(` for the tests that now pass against the source, and run
+     `npm run test:types`. A test only goes green here once **everything it
+     touches** is migrated (the factory *and* the methods *and* the public type
+     name it asserts) — so a single collection migration may un-skip a whole
+     file, or only part of it.
+   - If a d.ts-only type was removed from a duplicate's imports (e.g. `MapOf`,
+     `RecordOf`, `DeepCopy` — see the header comment in each file), add it back
+     once it exists in the source.
+   - When the skip-list is empty and every source-pass test is green, the
+     migration is complete: flip the `immutable` path in
+     `type-definitions/ts-tests/tsconfig.json` to the source too (or delete the
+     duplicate directory) and remove `type-definitions/immutable.d.ts`.
+
+9. **Verify**:
    ```bash
    npm run type-check
    npm run test:unit

--- a/.agents/commands/migrate-to-ts.md
+++ b/.agents/commands/migrate-to-ts.md
@@ -24,6 +24,7 @@ conventions of the immutable-js 6.x branch.
    shot once the full migration is complete.
 
    When writing types for the migrated file:
+
    - Open `immutable.d.ts` and find the declarations that correspond to the
      symbols you are migrating.
    - **Copy the JSDoc description** from `immutable.d.ts` to the migrated
@@ -36,6 +37,21 @@ conventions of the immutable-js 6.x branch.
      naturally write (narrower union, branded type, stricter generic
      constraint…), **keep that stricter typing** in the new `.ts` source —
      do not relax it.
+   - **Preserve every overload signature.** Many methods are declared with
+     multiple signatures in `immutable.d.ts` (e.g. `filter` and `partition`
+     have a type-guard overload `=> value is F` plus a plain one; `flatMap`,
+     `flatten`, `zip`, `zipWith`, `count`, `first`/`last`/`get` all have
+     several). Do **not** collapse them into a single signature — copy each
+     overload, then write **one loose implementation signature** that is
+     compatible with all of them — use the widest parameter and return types
+     (e.g. a rest parameter of `Array<unknown>` returning `unknown`). The
+     implementation signature is not visible to callers; only the overloads
+     are. Adapt the
+     public collection types to the internal `*Impl` ones (e.g.
+     `Collection<K, F>` → `CollectionImpl<K, F>`). When overriding an
+     overloaded base method in a subclass, redeclare **all** the overloads
+     with the `override` modifier — otherwise the inherited overloads are
+     hidden.
    - If you are **unsure** whether your type matches the intent of the
      hand-written declaration, or if reconciling them feels complex, **stop
      and ask the user** before continuing.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -120,7 +120,7 @@ export default tseslintConfig(
   },
 
   {
-    files: ['type-definitions/ts-tests/*'],
+    files: ['type-definitions/ts-tests/*', 'type-definitions/ts-tests-src/*'],
 
     rules: {
       '@typescript-eslint/no-unused-vars': 'off',

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -1,4 +1,10 @@
-import { reduce } from './CollectionHelperMethods';
+import {
+  defaultNegComparator,
+  keyMapper,
+  neg,
+  not,
+  reduce,
+} from './CollectionHelperMethods';
 import {
   ITERATE_ENTRIES,
   ITERATE_KEYS,
@@ -6,10 +12,25 @@ import {
   type IteratorType,
 } from './Iterator';
 import { IndexedSeq, KeyedSeq, Seq, SetSeq } from './Seq';
-import { NOT_SET, returnTrue, wrapIndex } from './TrieUtils';
+import { ensureSize, NOT_SET, returnTrue, wrapIndex } from './TrieUtils';
 import type ValueObject from './ValueObject';
 import { is } from './is';
-import { mapFactory } from './operations/factories';
+import {
+  filterFactory,
+  flatMapFactory,
+  flattenFactory,
+  flipFactory,
+  interposeFactory,
+  mapFactory,
+  maxFactory,
+  partitionFactory,
+  reverseFactory,
+  skipWhileFactory,
+  sliceFactory,
+  sortFactory,
+  takeWhileFactory,
+  zipWithFactory,
+} from './operations/factories';
 import { reify } from './operations/helpers';
 import { isAssociative } from './predicates/isAssociative';
 import { isCollection, IS_COLLECTION_SYMBOL } from './predicates/isCollection';
@@ -423,6 +444,368 @@ export class CollectionImpl<K, V> implements ValueObject {
         : this.toSetSeq();
   }
 
+  /**
+   * Returns a new Collection of the same type with only the entries for which
+   * the `predicate` function returns true.
+   *
+   * Note: `filter()` always returns a new instance, even if it results in
+   * not filtering out any values.
+   */
+  filter<F extends V>(
+    predicate: (value: V, key: K, iter: this) => value is F,
+    context?: unknown
+  ): CollectionImpl<K, F>;
+  filter(
+    predicate: (value: V, key: K, iter: this) => unknown,
+    context?: unknown
+  ): this;
+  filter(
+    predicate: (value: V, key: K, iter: this) => unknown,
+    context?: unknown
+  ): unknown {
+    return reify(this, filterFactory(this, predicate, context, true));
+  }
+
+  /**
+   * Returns a new Collection of the same type with only the entries for which
+   * the `predicate` function returns false.
+   */
+  filterNot(
+    predicate: (value: V, key: K, iter: this) => boolean,
+    context?: unknown
+  ): this {
+    return this.filter(not(predicate), context);
+  }
+
+  /**
+   * Returns a new Collection with the values for which the `predicate`
+   * function returns false and another for which is returns true.
+   */
+  partition<F extends V, C>(
+    predicate: (this: C, value: V, key: K, iter: this) => value is F,
+    context?: C
+  ): [CollectionImpl<K, V>, CollectionImpl<K, F>];
+  partition<C>(
+    predicate: (this: C, value: V, key: K, iter: this) => unknown,
+    context?: C
+  ): [this, this];
+  partition(
+    predicate: (value: V, key: K, iter: this) => unknown,
+    context?: unknown
+  ): unknown {
+    return partitionFactory(this, predicate, context);
+  }
+
+  /**
+   * Returns a new Collection of the same type in reverse order.
+   */
+  reverse(): this {
+    return reify(this, reverseFactory(this, true));
+  }
+
+  /**
+   * Returns a new Collection of the same type representing a portion of this
+   * Collection from start up to but not including end.
+   */
+  slice(begin?: number, end?: number): this {
+    return reify(this, sliceFactory(this, begin, end, true));
+  }
+
+  /**
+   * Returns a new Collection of the same type which includes the same entries,
+   * stably sorted by using a `comparator`.
+   *
+   * If a `comparator` is not provided, a default comparator uses `<` and `>`.
+   *
+   * When sorting collections which have no defined order, their ordered
+   * equivalents will be returned. e.g. `map.sort()` returns OrderedMap.
+   *
+   * Note: This is always an eager operation.
+   */
+  sort(comparator?: (valueA: V, valueB: V) => number): this {
+    return reify(this, sortFactory(this, comparator));
+  }
+
+  /**
+   * Like `sort`, but also accepts a `comparatorValueMapper` which allows for
+   * sorting by more sophisticated means.
+   *
+   * Note: This is always an eager operation.
+   */
+  sortBy<C>(
+    comparatorValueMapper: (value: V, key: K, iter: this) => C,
+    comparator?: (valueA: C, valueB: C) => number
+  ): this {
+    return reify(this, sortFactory(this, comparator, comparatorValueMapper));
+  }
+
+  /**
+   * Flat-maps the Collection, returning a Collection of the same type.
+   *
+   * Similar to `collection.map(...).flatten(true)`.
+   */
+  flatMap<M>(
+    mapper: (value: V, key: K, iter: this) => Iterable<M>,
+    context?: unknown
+  ): CollectionImpl<K, M>;
+  flatMap<KM, VM>(
+    mapper: (value: V, key: K, iter: this) => Iterable<[KM, VM]>,
+    context?: unknown
+  ): CollectionImpl<KM, VM>;
+  flatMap(
+    mapper: (value: V, key: K, iter: this) => Iterable<unknown>,
+    context?: unknown
+  ): unknown {
+    return reify(this, flatMapFactory(this, mapper, context));
+  }
+
+  /**
+   * Flattens nested Collections.
+   *
+   * Will deeply flatten the Collection by default, returning a Collection of
+   * the same type, but a `depth` can be provided in the form of a number or
+   * boolean (where true means to shallowly flatten one level). A depth of 0
+   * (or shallow: false) will deeply flatten.
+   */
+  flatten(depth?: number): CollectionImpl<unknown, unknown>;
+  flatten(shallow?: boolean): CollectionImpl<unknown, unknown>;
+  flatten(depth?: number | boolean): CollectionImpl<unknown, unknown> {
+    return reify(this, flattenFactory(this, depth, true));
+  }
+
+  /**
+   * Returns the maximum value in this collection. If any values are
+   * comparatively equivalent, the first one found will be returned.
+   */
+  max(comparator?: (valueA: V, valueB: V) => number): V | undefined {
+    return maxFactory(this, comparator);
+  }
+
+  /**
+   * Like `max`, but also accepts a `comparatorValueMapper` which allows for
+   * comparing by more sophisticated means.
+   */
+  maxBy<C>(
+    comparatorValueMapper: (value: V, key: K, iter: this) => C,
+    comparator?: (valueA: C, valueB: C) => number
+  ): V | undefined {
+    return maxFactory(this, comparator, comparatorValueMapper);
+  }
+
+  /**
+   * Returns the minimum value in this collection. If any values are
+   * comparatively equivalent, the first one found will be returned.
+   */
+  min(comparator?: (valueA: V, valueB: V) => number): V | undefined {
+    return maxFactory(
+      this,
+      comparator ? neg(comparator) : defaultNegComparator
+    );
+  }
+
+  /**
+   * Like `min`, but also accepts a `comparatorValueMapper` which allows for
+   * comparing by more sophisticated means.
+   */
+  minBy<C>(
+    comparatorValueMapper: (value: V, key: K, iter: this) => C,
+    comparator?: (valueA: C, valueB: C) => number
+  ): V | undefined {
+    return maxFactory(
+      this,
+      comparator ? neg(comparator) : defaultNegComparator,
+      comparatorValueMapper
+    );
+  }
+
+  /**
+   * Returns a new Collection of the same type which excludes the first `amount`
+   * entries from this Collection.
+   */
+  skip(amount: number): this {
+    return amount === 0 ? this : this.slice(Math.max(0, amount));
+  }
+
+  /**
+   * Returns a new Collection of the same type which excludes the last `amount`
+   * entries from this Collection.
+   */
+  skipLast(amount: number): this {
+    return amount === 0 ? this : this.slice(0, -Math.max(0, amount));
+  }
+
+  /**
+   * Returns a new Collection of the same type which includes entries starting
+   * from when `predicate` first returns false.
+   */
+  skipWhile(
+    predicate: (value: V, key: K, iter: this) => boolean,
+    context?: unknown
+  ): this {
+    return reify(this, skipWhileFactory(this, predicate, context, true));
+  }
+
+  /**
+   * Returns a new Collection of the same type which includes entries starting
+   * from when `predicate` first returns true.
+   */
+  skipUntil(
+    predicate: (value: V, key: K, iter: this) => boolean,
+    context?: unknown
+  ): this {
+    return this.skipWhile(not(predicate), context);
+  }
+
+  /**
+   * Returns a new Collection of the same type which includes the first `amount`
+   * entries from this Collection.
+   */
+  take(amount: number): this {
+    return this.slice(0, Math.max(0, amount));
+  }
+
+  /**
+   * Returns a new Collection of the same type which includes the last `amount`
+   * entries from this Collection.
+   */
+  takeLast(amount: number): this {
+    return this.slice(-Math.max(0, amount));
+  }
+
+  /**
+   * Returns a new Collection of the same type which includes entries from this
+   * Collection as long as the `predicate` returns true.
+   */
+  takeWhile(
+    predicate: (value: V, key: K, iter: this) => boolean,
+    context?: unknown
+  ): this {
+    return reify(this, takeWhileFactory(this, predicate, context));
+  }
+
+  /**
+   * Returns a new Collection of the same type which includes entries from this
+   * Collection as long as the `predicate` returns false.
+   */
+  takeUntil(
+    predicate: (value: V, key: K, iter: this) => boolean,
+    context?: unknown
+  ): this {
+    return this.takeWhile(not(predicate), context);
+  }
+
+  /**
+   * Returns a new Collection of the same type containing all entries except
+   * the last.
+   */
+  butLast(): this {
+    return this.slice(0, -1);
+  }
+
+  /**
+   * Returns a new Collection of the same type containing all entries except
+   * the first.
+   */
+  rest(): this {
+    return this.slice(1);
+  }
+
+  /**
+   * Returns the size of this Collection.
+   *
+   * If `predicate` is provided, then this returns the count of entries in the
+   * Collection for which the `predicate` returns true.
+   */
+  count(): number;
+  count(
+    predicate: (value: V, key: K, iter: CollectionImpl<K, V>) => boolean,
+    context?: unknown
+  ): number;
+  count(
+    predicate?: (value: V, key: K, iter: CollectionImpl<K, V>) => boolean,
+    context?: unknown
+  ): number {
+    return ensureSize(
+      predicate ? this.toSeq().filter(predicate, context) : this
+    );
+  }
+
+  /**
+   * Returns the last value for which the `predicate` returns true.
+   *
+   * Note: `predicate` will be called for each entry in reverse.
+   */
+  findLast(
+    predicate: (value: V, key: K, iter: CollectionImpl<K, V>) => boolean,
+    context?: unknown,
+    notSetValue?: V
+  ): V | undefined {
+    return this.toKeyedSeq().reverse().find(predicate, context, notSetValue);
+  }
+
+  /**
+   * Returns the last [key, value] entry for which the `predicate`
+   * returns true.
+   *
+   * Note: `predicate` will be called for each entry in reverse.
+   */
+  findLastEntry(
+    predicate: (value: V, key: K, iter: CollectionImpl<K, V>) => boolean,
+    context?: unknown,
+    notSetValue?: V
+  ): [K, V] | undefined {
+    return this.toKeyedSeq()
+      .reverse()
+      .findEntry(predicate, context, notSetValue);
+  }
+
+  /**
+   * Returns the last key for which the `predicate` returns true.
+   *
+   * Note: `predicate` will be called for each entry in reverse.
+   */
+  findLastKey(
+    predicate: (value: V, key: K, iter: CollectionImpl<K, V>) => boolean,
+    context?: unknown
+  ): K | undefined {
+    return this.toKeyedSeq().reverse().findKey(predicate, context);
+  }
+
+  /**
+   * Returns the last key associated with the search value, or undefined.
+   */
+  lastKeyOf(searchValue: V): K | undefined {
+    return this.toKeyedSeq().reverse().keyOf(searchValue);
+  }
+
+  /**
+   * Returns the last value in this Collection.
+   */
+  last<NSV>(notSetValue: NSV): V | NSV;
+  last(): V | undefined;
+  last(notSetValue?: unknown): unknown {
+    return this.toSeq()
+      .reverse()
+      .first(notSetValue as V | undefined);
+  }
+
+  /**
+   * Returns a new Seq.Indexed of the keys of this Collection,
+   * discarding values.
+   */
+  keySeq(): IndexedCollectionImpl<K> {
+    return this.toSeq()
+      .map(keyMapper)
+      .toIndexedSeq() as unknown as IndexedCollectionImpl<K>;
+  }
+
+  /**
+   * Returns a Seq.Indexed of the values of this Collection, discarding keys.
+   */
+  valueSeq(): IndexedCollectionImpl<V> {
+    return this.toIndexedSeq() as unknown as IndexedCollectionImpl<V>;
+  }
+
   __iterate(
     fn: (value: V, index: K, iter: this) => unknown,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -479,6 +862,14 @@ export class KeyedCollectionImpl<K, V> extends CollectionImpl<K, V> {
   // `KeyedCollectionImpl` structurally distinct from the base `CollectionImpl`,
   // otherwise `isKeyed`'s negative narrowing collapses `this` to `never`.
   declare [IS_KEYED_SYMBOL]: true;
+
+  /**
+   * Returns a new Collection.Keyed of the same type where the keys and values
+   * have been flipped.
+   */
+  flip(): KeyedCollectionImpl<V, K> {
+    return reify(this, flipFactory(this));
+  }
 }
 
 KeyedCollectionImpl.prototype[IS_KEYED_SYMBOL] = true;
@@ -555,9 +946,9 @@ export class IndexedCollectionImpl<T>
    * In case the `Collection` is empty returns the optional default
    * value if provided, if no default value is provided returns undefined.
    */
-  last<NSV>(notSetValue: NSV): T | NSV;
-  last(): T | undefined;
-  last(notSetValue?: unknown): unknown {
+  override last<NSV>(notSetValue: NSV): T | NSV;
+  override last(): T | undefined;
+  override last(notSetValue?: unknown): unknown {
     return this.get(-1, notSetValue);
   }
 
@@ -592,6 +983,157 @@ export class IndexedCollectionImpl<T>
         : this.find((_, key) => key === index, undefined, NOT_SET) !== NOT_SET)
     );
   }
+
+  override filter<F extends T>(
+    predicate: (value: T, index: number, iter: this) => value is F,
+    context?: unknown
+  ): IndexedCollectionImpl<F>;
+  override filter(
+    predicate: (value: T, index: number, iter: this) => unknown,
+    context?: unknown
+  ): this;
+  override filter(
+    predicate: (value: T, index: number, iter: this) => unknown,
+    context?: unknown
+  ): unknown {
+    return reify(this, filterFactory(this, predicate, context, false));
+  }
+
+  override reverse(): this {
+    return reify(this, reverseFactory(this, false));
+  }
+
+  override slice(begin?: number, end?: number): this {
+    return reify(this, sliceFactory(this, begin, end, false));
+  }
+
+  override flatten(depth?: number): CollectionImpl<unknown, unknown>;
+  override flatten(shallow?: boolean): CollectionImpl<unknown, unknown>;
+  override flatten(depth?: number | boolean): CollectionImpl<unknown, unknown> {
+    return reify(this, flattenFactory(this, depth, false));
+  }
+
+  override skipWhile(
+    predicate: (value: T, index: number, iter: this) => boolean,
+    context?: unknown
+  ): this {
+    return reify(this, skipWhileFactory(this, predicate, context, false));
+  }
+
+  /**
+   * Returns the last index at which a given value can be found in the
+   * Collection, or -1 if it is not present.
+   */
+  lastIndexOf(searchValue: T): number {
+    const key = this.lastKeyOf(searchValue);
+    return key === undefined ? -1 : key;
+  }
+
+  /**
+   * Returns the last index in the Collection where a value satisfies the
+   * provided predicate function. Otherwise -1 is returned.
+   */
+  findLastIndex(
+    predicate: (
+      value: T,
+      index: number,
+      iter: CollectionImpl<number, T>
+    ) => boolean,
+    context?: unknown
+  ): number {
+    const entry = this.findLastEntry(predicate, context);
+    return entry ? entry[0] : -1;
+  }
+
+  /**
+   * Returns a Collection of the same type with `separator` between each item
+   * in this Collection.
+   */
+  interpose(separator: T): this {
+    return reify(this, interposeFactory(this, separator));
+  }
+
+  /**
+   * Returns a Collection of the same type with the provided `collections`
+   * interleaved into this collection.
+   */
+  interleave(...collections: Array<CollectionImpl<unknown, T>>): this {
+    const thisAndCollections = [this, ...collections];
+    const zipped = zipWithFactory(
+      this.toSeq(),
+      IndexedSeq.of,
+      thisAndCollections
+    );
+    const interleaved = zipped.flatten(true);
+    if (zipped.size) {
+      interleaved.size = zipped.size * thisAndCollections.length;
+    }
+    return reify(this, interleaved);
+  }
+
+  /**
+   * Returns a Collection of the same type "zipped" with the provided
+   * collections.
+   *
+   * Like `zipWith`, but using the default `zipper`: creating an `Array`.
+   */
+  zip<U>(other: CollectionImpl<unknown, U>): IndexedCollectionImpl<[T, U]>;
+  zip<U, W>(
+    other: CollectionImpl<unknown, U>,
+    other2: CollectionImpl<unknown, W>
+  ): IndexedCollectionImpl<[T, U, W]>;
+  zip(
+    ...collections: Array<CollectionImpl<unknown, unknown>>
+  ): IndexedCollectionImpl<unknown>;
+  zip(...collections: Array<unknown>): unknown {
+    const thisAndCollections = [this, ...collections];
+    return reify(this, zipWithFactory(this, defaultZipper, thisAndCollections));
+  }
+
+  /**
+   * Returns a Collection "zipped" with the provided collections.
+   *
+   * Unlike `zip`, `zipAll` continues zipping until the longest collection is
+   * exhausted. Missing values from shorter collections are filled with
+   * `undefined`.
+   */
+  zipAll<U>(other: CollectionImpl<unknown, U>): IndexedCollectionImpl<[T, U]>;
+  zipAll<U, W>(
+    other: CollectionImpl<unknown, U>,
+    other2: CollectionImpl<unknown, W>
+  ): IndexedCollectionImpl<[T, U, W]>;
+  zipAll(
+    ...collections: Array<CollectionImpl<unknown, unknown>>
+  ): IndexedCollectionImpl<unknown>;
+  zipAll(...collections: Array<unknown>): unknown {
+    const thisAndCollections = [this, ...collections];
+    return reify(
+      this,
+      zipWithFactory(this, defaultZipper, thisAndCollections, true)
+    );
+  }
+
+  /**
+   * Returns a Collection of the same type "zipped" with the provided
+   * collections by using a custom `zipper` function.
+   */
+  zipWith<U, Z>(
+    zipper: (value: T, otherValue: U) => Z,
+    otherCollection: CollectionImpl<unknown, U>
+  ): IndexedCollectionImpl<Z>;
+  zipWith<U, W, Z>(
+    zipper: (value: T, otherValue: U, thirdValue: W) => Z,
+    otherCollection: CollectionImpl<unknown, U>,
+    thirdCollection: CollectionImpl<unknown, W>
+  ): IndexedCollectionImpl<Z>;
+  zipWith<Z>(
+    zipper: (...values: Array<unknown>) => Z,
+    ...collections: Array<CollectionImpl<unknown, unknown>>
+  ): IndexedCollectionImpl<Z>;
+  zipWith(zipper: unknown, ...collections: Array<unknown>): unknown {
+    const thisAndCollections = [this, ...collections];
+    return reify(this, zipWithFactory(this, zipper, thisAndCollections));
+  }
 }
 
 IndexedCollectionImpl.prototype[IS_INDEXED_SYMBOL] = true;
@@ -610,3 +1152,7 @@ export class SetCollectionImpl<T> extends CollectionImpl<T, T> {}
 Collection.Keyed = KeyedCollection;
 Collection.Indexed = IndexedCollection;
 Collection.Set = SetCollection;
+
+function defaultZipper(...values: Array<unknown>): Array<unknown> {
+  return values;
+}

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -752,7 +752,7 @@ export class CollectionImpl<K, V> implements ValueObject {
   findLastEntry(
     predicate: (value: V, key: K, iter: CollectionImpl<K, V>) => boolean,
     context?: unknown,
-    notSetValue?: V
+    notSetValue?: [K, V]
   ): [K, V] | undefined {
     return this.toKeyedSeq()
       .reverse()

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -9,10 +9,13 @@ import { IndexedSeq, KeyedSeq, Seq, SetSeq } from './Seq';
 import { NOT_SET, returnTrue, wrapIndex } from './TrieUtils';
 import type ValueObject from './ValueObject';
 import { is } from './is';
+import { mapFactory } from './operations/factories';
+import { reify } from './operations/helpers';
 import { isAssociative } from './predicates/isAssociative';
-import { isCollection } from './predicates/isCollection';
-import { isIndexed } from './predicates/isIndexed';
-import { isKeyed } from './predicates/isKeyed';
+import { isCollection, IS_COLLECTION_SYMBOL } from './predicates/isCollection';
+import { isIndexed, IS_INDEXED_SYMBOL } from './predicates/isIndexed';
+import { isKeyed, IS_KEYED_SYMBOL } from './predicates/isKeyed';
+import { IS_ORDERED_SYMBOL } from './predicates/isOrdered';
 import assertNotInfinite from './utils/assertNotInfinite';
 import deepEqual from './utils/deepEqual';
 import { hashCollection } from './utils/hashCollection';
@@ -48,6 +51,16 @@ export class CollectionImpl<K, V> implements ValueObject {
   private __hash: number | undefined;
 
   size: number = 0;
+
+  // Brand tested by the `isCollection` predicate. Declared for the type here;
+  // the value is set on the prototype just below the class. It cannot be a
+  // class field: that would be an own enumerable instance property, missing on
+  // the many instances built via `Object.create(prototype)` (e.g. mapped Seqs).
+  declare [IS_COLLECTION_SYMBOL]: true;
+
+  declare toIndexedSeq: () => CollectionImpl<K, V>;
+  declare toKeyedSeq: () => CollectionImpl<K, V>;
+  declare toSetSeq: () => CollectionImpl<K, V>;
 
   /**
    * True if this and the other Collection have value equality, as defined
@@ -384,6 +397,32 @@ export class CollectionImpl<K, V> implements ValueObject {
     return updater(this);
   }
 
+  /**
+   * Returns a new Collection of the same type with values passed through a
+   * `mapper` function.
+   *
+   * Note: `map()` always returns a new instance, even if it produced the same
+   * value at every step.
+   */
+  map<M>(
+    mapper: (value: V, key: K, iter: this) => M,
+    context?: unknown
+  ): CollectionImpl<K, M> {
+    return reify(this, mapFactory(this, mapper, context));
+  }
+
+  /**
+   * Converts this Collection to a Seq of the same kind (indexed,
+   * keyed, or set).
+   */
+  toSeq(): CollectionImpl<K, V> {
+    return isIndexed(this)
+      ? this.toIndexedSeq()
+      : isKeyed(this)
+        ? this.toKeyedSeq()
+        : this.toSetSeq();
+  }
+
   __iterate(
     fn: (value: V, index: K, iter: this) => unknown,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -414,6 +453,8 @@ export class CollectionImpl<K, V> implements ValueObject {
   }
 }
 
+CollectionImpl.prototype[IS_COLLECTION_SYMBOL] = true;
+
 /**
  * Always returns a Seq.Keyed, if input is not keyed, expects an
  * collection of [K, V] tuples.
@@ -433,32 +474,14 @@ export function KeyedCollection(
   return isKeyed(value) ? value : KeyedSeq(value);
 }
 
-// Methods provided at runtime by the CollectionImpl.js mixin. Declared via
-// interface declaration merging so callers see the narrower Seq.Keyed return
-// type. Once the mixin is removed, these can move into the class body.
-export interface KeyedCollectionImpl<K, V> {
-  toSeq(): KeyedCollectionImpl<K, V>;
-
-  /**
-   * Returns a new Collection.Keyed with values passed through a
-   * `mapper` function.
-   *
-   * ```js
-   * import { Collection } from 'immutable'
-   * Collection.Keyed({ a: 1, b: 2 }).map(x => 10 * x)
-   * // Seq { "a": 10, "b": 20 }
-   * ```
-   *
-   * Note: `map()` always returns a new instance, even if it produced the
-   * same value at every step.
-   */
-  map<M>(
-    mapper: (value: V, key: K, iter: this) => M,
-    context?: unknown
-  ): KeyedCollectionImpl<K, M>;
+export class KeyedCollectionImpl<K, V> extends CollectionImpl<K, V> {
+  // Brand tested by the `isKeyed` predicate. Declaring it also makes
+  // `KeyedCollectionImpl` structurally distinct from the base `CollectionImpl`,
+  // otherwise `isKeyed`'s negative narrowing collapses `this` to `never`.
+  declare [IS_KEYED_SYMBOL]: true;
 }
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- implemented in mixin
-export class KeyedCollectionImpl<K, V> extends CollectionImpl<K, V> {}
+
+KeyedCollectionImpl.prototype[IS_KEYED_SYMBOL] = true;
 
 export function IndexedCollection<T>(
   value: Iterable<T> | ArrayLike<T>
@@ -480,30 +503,6 @@ interface OrderedCollection<T> {
   [Symbol.iterator](): IterableIterator<T>;
 }
 
-// Methods provided at runtime by the CollectionImpl.js mixin. Declared via
-// interface declaration merging so callers see the narrower Seq.Indexed return
-// type. Once the mixin is removed, these can move into the class body.
-export interface IndexedCollectionImpl<T> {
-  toSeq(): IndexedCollectionImpl<T>;
-  /**
-   * Returns a new Collection.Indexed with values passed through a
-   * `mapper` function.
-   *
-   * ```js
-   * import { Collection } from 'immutable'
-   * Collection.Indexed([1,2]).map(x => 10 * x)
-   * // Seq [ 1, 2 ]
-   * ```
-   *
-   * Note: `map()` always returns a new instance, even if it produced the
-   * same value at every step.
-   */
-  map<M>(
-    mapper: (value: T, index: number, iter: this) => M,
-    context?: unknown
-  ): IndexedCollectionImpl<M>;
-}
-// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- implemented in mixin
 export class IndexedCollectionImpl<T>
   extends CollectionImpl<number, T>
   implements OrderedCollection<T>
@@ -511,6 +510,11 @@ export class IndexedCollectionImpl<T>
   declare toArray: () => T[];
 
   declare [Symbol.iterator]: () => IterableIterator<T>;
+
+  // Brands tested by the `isIndexed` / `isOrdered` predicates. Declared for the
+  // type here; the values are set on the prototype just below the class.
+  declare [IS_INDEXED_SYMBOL]: true;
+  declare [IS_ORDERED_SYMBOL]: true;
 
   /**
    * Returns the first index in the Collection where a value satisfies the
@@ -589,6 +593,9 @@ export class IndexedCollectionImpl<T>
     );
   }
 }
+
+IndexedCollectionImpl.prototype[IS_INDEXED_SYMBOL] = true;
+IndexedCollectionImpl.prototype[IS_ORDERED_SYMBOL] = true;
 
 export function SetCollection<T>(
   value: Iterable<T> | ArrayLike<T>

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -433,6 +433,31 @@ export function KeyedCollection(
   return isKeyed(value) ? value : KeyedSeq(value);
 }
 
+// Methods provided at runtime by the CollectionImpl.js mixin. Declared via
+// interface declaration merging so callers see the narrower Seq.Keyed return
+// type. Once the mixin is removed, these can move into the class body.
+export interface KeyedCollectionImpl<K, V> {
+  toSeq(): KeyedCollectionImpl<K, V>;
+
+  /**
+   * Returns a new Collection.Keyed with values passed through a
+   * `mapper` function.
+   *
+   * ```js
+   * import { Collection } from 'immutable'
+   * Collection.Keyed({ a: 1, b: 2 }).map(x => 10 * x)
+   * // Seq { "a": 10, "b": 20 }
+   * ```
+   *
+   * Note: `map()` always returns a new instance, even if it produced the
+   * same value at every step.
+   */
+  map<M>(
+    mapper: (value: V, key: K, iter: this) => M,
+    context?: unknown
+  ): KeyedCollectionImpl<K, M>;
+}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- implemented in mixin
 export class KeyedCollectionImpl<K, V> extends CollectionImpl<K, V> {}
 
 export function IndexedCollection<T>(
@@ -455,6 +480,30 @@ interface OrderedCollection<T> {
   [Symbol.iterator](): IterableIterator<T>;
 }
 
+// Methods provided at runtime by the CollectionImpl.js mixin. Declared via
+// interface declaration merging so callers see the narrower Seq.Indexed return
+// type. Once the mixin is removed, these can move into the class body.
+export interface IndexedCollectionImpl<T> {
+  toSeq(): IndexedCollectionImpl<T>;
+  /**
+   * Returns a new Collection.Indexed with values passed through a
+   * `mapper` function.
+   *
+   * ```js
+   * import { Collection } from 'immutable'
+   * Collection.Indexed([1,2]).map(x => 10 * x)
+   * // Seq [ 1, 2 ]
+   * ```
+   *
+   * Note: `map()` always returns a new instance, even if it produced the
+   * same value at every step.
+   */
+  map<M>(
+    mapper: (value: T, index: number, iter: this) => M,
+    context?: unknown
+  ): IndexedCollectionImpl<M>;
+}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- implemented in mixin
 export class IndexedCollectionImpl<T>
   extends CollectionImpl<number, T>
   implements OrderedCollection<T>
@@ -544,7 +593,9 @@ export class IndexedCollectionImpl<T>
 export function SetCollection<T>(
   value: Iterable<T> | ArrayLike<T>
 ): SetCollectionImpl<T> {
-  return isCollection(value) && !isAssociative(value) ? value : SetSeq(value);
+  return isCollection<T, T>(value) && !isAssociative<T, T>(value)
+    ? value
+    : SetSeq(value);
 }
 
 export class SetCollectionImpl<T> extends CollectionImpl<T, T> {}

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -79,9 +79,9 @@ export class CollectionImpl<K, V> implements ValueObject {
   // the many instances built via `Object.create(prototype)` (e.g. mapped Seqs).
   declare [IS_COLLECTION_SYMBOL]: true;
 
-  declare toIndexedSeq: () => CollectionImpl<K, V>;
-  declare toKeyedSeq: () => CollectionImpl<K, V>;
-  declare toSetSeq: () => CollectionImpl<K, V>;
+  declare toIndexedSeq: () => IndexedCollectionImpl<V>;
+  declare toKeyedSeq: () => KeyedCollectionImpl<K, V>;
+  declare toSetSeq: () => SetCollectionImpl<V>;
 
   /**
    * True if this and the other Collection have value equality, as defined
@@ -437,11 +437,10 @@ export class CollectionImpl<K, V> implements ValueObject {
    * keyed, or set).
    */
   toSeq(): CollectionImpl<K, V> {
-    return isIndexed(this)
-      ? this.toIndexedSeq()
-      : isKeyed(this)
-        ? this.toKeyedSeq()
-        : this.toSetSeq();
+    // Indexed and set collections override `toSeq` with their concrete Seq
+    // kind, where the key type is fixed by the class. A keyed collection (and
+    // the abstract base) converts to a keyed Seq.
+    return this.toKeyedSeq();
   }
 
   /**
@@ -784,9 +783,7 @@ export class CollectionImpl<K, V> implements ValueObject {
   last<NSV>(notSetValue: NSV): V | NSV;
   last(): V | undefined;
   last(notSetValue?: unknown): unknown {
-    return this.toSeq()
-      .reverse()
-      .first(notSetValue as V | undefined);
+    return this.toSeq().reverse().first(notSetValue);
   }
 
   /**
@@ -794,16 +791,14 @@ export class CollectionImpl<K, V> implements ValueObject {
    * discarding values.
    */
   keySeq(): IndexedCollectionImpl<K> {
-    return this.toSeq()
-      .map(keyMapper)
-      .toIndexedSeq() as unknown as IndexedCollectionImpl<K>;
+    return this.toSeq().map(keyMapper).toIndexedSeq();
   }
 
   /**
    * Returns a Seq.Indexed of the values of this Collection, discarding keys.
    */
   valueSeq(): IndexedCollectionImpl<V> {
-    return this.toIndexedSeq() as unknown as IndexedCollectionImpl<V>;
+    return this.toIndexedSeq();
   }
 
   __iterate(
@@ -906,6 +901,10 @@ export class IndexedCollectionImpl<T>
   // type here; the values are set on the prototype just below the class.
   declare [IS_INDEXED_SYMBOL]: true;
   declare [IS_ORDERED_SYMBOL]: true;
+
+  override toSeq(): IndexedCollectionImpl<T> {
+    return this.toIndexedSeq();
+  }
 
   /**
    * Returns the first index in the Collection where a value satisfies the
@@ -1147,7 +1146,11 @@ export function SetCollection<T>(
     : SetSeq(value);
 }
 
-export class SetCollectionImpl<T> extends CollectionImpl<T, T> {}
+export class SetCollectionImpl<T> extends CollectionImpl<T, T> {
+  override toSeq(): SetCollectionImpl<T> {
+    return this.toSetSeq();
+  }
+}
 
 Collection.Keyed = KeyedCollection;
 Collection.Indexed = IndexedCollection;

--- a/src/CollectionHelperMethods.ts
+++ b/src/CollectionHelperMethods.ts
@@ -32,14 +32,18 @@ export function entryMapper<K, V>(v: V, k: K): [K, V] {
   return [k, v];
 }
 
-export function not(predicate: (...args: unknown[]) => boolean) {
-  return function (this: unknown, ...args: unknown[]): boolean {
+export function not<Args extends unknown[]>(
+  predicate: (...args: Args) => boolean
+): (...args: Args) => boolean {
+  return function (this: unknown, ...args: Args): boolean {
     return !predicate.apply(this, args);
   };
 }
 
-export function neg(predicate: (...args: unknown[]) => number) {
-  return function (this: unknown, ...args: unknown[]): number {
+export function neg<Args extends unknown[]>(
+  predicate: (...args: Args) => number
+): (...args: Args) => number {
+  return function (this: unknown, ...args: Args): number {
     return -predicate.apply(this, args);
   };
 }

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -38,7 +38,6 @@ import {
   flattenFactory,
   flipFactory,
   interposeFactory,
-  mapFactory,
   maxFactory,
   partitionFactory,
   reverseFactory,
@@ -56,10 +55,7 @@ import {
   ToKeyedSequence,
   ToSetSequence,
 } from './operations/sequences';
-import { IS_COLLECTION_SYMBOL } from './predicates/isCollection';
-import { isIndexed, IS_INDEXED_SYMBOL } from './predicates/isIndexed';
-import { isKeyed, IS_KEYED_SYMBOL } from './predicates/isKeyed';
-import { IS_ORDERED_SYMBOL } from './predicates/isOrdered';
+import { isKeyed } from './predicates/isKeyed';
 import { toJS } from './toJS';
 import assertNotInfinite from './utils/assertNotInfinite';
 import mixin from './utils/mixin';
@@ -122,14 +118,6 @@ mixin(CollectionImpl, {
     return new ToSetSequence(this);
   },
 
-  toSeq() {
-    return isIndexed(this)
-      ? this.toIndexedSeq()
-      : isKeyed(this)
-        ? this.toKeyedSeq()
-        : this.toSetSeq();
-  },
-
   toStack() {
     // Use Late Binding here to solve the circular dependency.
     return Stack(isKeyed(this) ? this.valueSeq() : this);
@@ -171,10 +159,6 @@ mixin(CollectionImpl, {
 
   partition(predicate, context) {
     return partitionFactory(this, predicate, context);
-  },
-
-  map(mapper, context) {
-    return reify(this, mapFactory(this, mapper, context));
   },
 
   reverse() {
@@ -352,7 +336,6 @@ mixin(CollectionImpl, {
 });
 
 const CollectionPrototype = CollectionImpl.prototype;
-CollectionPrototype[IS_COLLECTION_SYMBOL] = true;
 CollectionPrototype[Symbol.iterator] = CollectionPrototype.values;
 CollectionPrototype.toJSON = CollectionPrototype.toArray;
 CollectionPrototype.__toStringMapper = quoteString;
@@ -391,7 +374,6 @@ mixin(KeyedCollectionImpl, {
 });
 
 const KeyedCollectionPrototype = KeyedCollectionImpl.prototype;
-KeyedCollectionPrototype[IS_KEYED_SYMBOL] = true;
 KeyedCollectionPrototype[Symbol.iterator] = CollectionPrototype.entries;
 KeyedCollectionPrototype.toJSON = toObject;
 KeyedCollectionPrototype.__toStringMapper = (v, k) =>
@@ -502,8 +484,6 @@ mixin(IndexedCollectionImpl, {
 });
 
 const IndexedCollectionPrototype = IndexedCollectionImpl.prototype;
-IndexedCollectionPrototype[IS_INDEXED_SYMBOL] = true;
-IndexedCollectionPrototype[IS_ORDERED_SYMBOL] = true;
 
 mixin(SetCollectionImpl, {
   // ### ES6 Collection methods (ES6 Array and Map)

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -5,48 +5,21 @@ import {
   KeyedCollectionImpl,
   SetCollectionImpl,
 } from './Collection';
-import {
-  defaultNegComparator,
-  entryMapper,
-  keyMapper,
-  neg,
-  not,
-} from './CollectionHelperMethods';
+import { entryMapper } from './CollectionHelperMethods';
 import { Iterator } from './Iterator';
 import { List } from './List';
 import { Map } from './Map';
 import { OrderedMap } from './OrderedMap';
 import { OrderedSet } from './OrderedSet';
 import { Range } from './Range';
-import {
-  ArraySeq,
-  IndexedSeq,
-  IndexedSeqImpl,
-  KeyedSeqImpl,
-  SetSeqImpl,
-} from './Seq';
+import { ArraySeq, IndexedSeqImpl, KeyedSeqImpl, SetSeqImpl } from './Seq';
 import { Set } from './Set';
 import { Stack } from './Stack';
-import { ensureSize, resolveBegin } from './TrieUtils';
+import { resolveBegin } from './TrieUtils';
 import { getIn } from './methods/getIn';
 import { hasIn } from './methods/hasIn';
 import { toObject } from './methods/toObject';
 import { countByFactory, groupByFactory } from './operations/aggregations';
-import {
-  filterFactory,
-  flatMapFactory,
-  flattenFactory,
-  flipFactory,
-  interposeFactory,
-  maxFactory,
-  partitionFactory,
-  reverseFactory,
-  skipWhileFactory,
-  sliceFactory,
-  sortFactory,
-  takeWhileFactory,
-  zipWithFactory,
-} from './operations/factories';
 import { reify } from './operations/helpers';
 import {
   concatFactory,
@@ -153,37 +126,7 @@ mixin(CollectionImpl, {
     return reify(this, concatFactory(this, values));
   },
 
-  filter(predicate, context) {
-    return reify(this, filterFactory(this, predicate, context, true));
-  },
-
-  partition(predicate, context) {
-    return partitionFactory(this, predicate, context);
-  },
-
-  reverse() {
-    return reify(this, reverseFactory(this, true));
-  },
-
-  slice(begin, end) {
-    return reify(this, sliceFactory(this, begin, end, true));
-  },
-
-  sort(comparator) {
-    return reify(this, sortFactory(this, comparator));
-  },
-
   // ### More sequential methods
-
-  butLast() {
-    return this.slice(0, -1);
-  },
-
-  count(predicate, context) {
-    return ensureSize(
-      predicate ? this.toSeq().filter(predicate, context) : this
-    );
-  },
 
   countBy(grouper, context) {
     return countByFactory(this, grouper, context);
@@ -205,32 +148,6 @@ mixin(CollectionImpl, {
     return entriesSequence;
   },
 
-  filterNot(predicate, context) {
-    return this.filter(not(predicate), context);
-  },
-
-  findLast(predicate, context, notSetValue) {
-    return this.toKeyedSeq().reverse().find(predicate, context, notSetValue);
-  },
-
-  findLastEntry(predicate, context, notSetValue) {
-    return this.toKeyedSeq()
-      .reverse()
-      .findEntry(predicate, context, notSetValue);
-  },
-
-  findLastKey(predicate, context) {
-    return this.toKeyedSeq().reverse().findKey(predicate, context);
-  },
-
-  flatMap(mapper, context) {
-    return reify(this, flatMapFactory(this, mapper, context));
-  },
-
-  flatten(depth) {
-    return reify(this, flattenFactory(this, depth, true));
-  },
-
   fromEntrySeq() {
     return new FromEntriesSequence(this);
   },
@@ -242,85 +159,6 @@ mixin(CollectionImpl, {
   },
 
   hasIn: hasIn,
-
-  keySeq() {
-    return this.toSeq().map(keyMapper).toIndexedSeq();
-  },
-
-  last(notSetValue) {
-    return this.toSeq().reverse().first(notSetValue);
-  },
-
-  lastKeyOf(searchValue) {
-    return this.toKeyedSeq().reverse().keyOf(searchValue);
-  },
-
-  max(comparator) {
-    return maxFactory(this, comparator);
-  },
-
-  maxBy(mapper, comparator) {
-    return maxFactory(this, comparator, mapper);
-  },
-
-  min(comparator) {
-    return maxFactory(
-      this,
-      comparator ? neg(comparator) : defaultNegComparator
-    );
-  },
-
-  minBy(mapper, comparator) {
-    return maxFactory(
-      this,
-      comparator ? neg(comparator) : defaultNegComparator,
-      mapper
-    );
-  },
-
-  rest() {
-    return this.slice(1);
-  },
-
-  skip(amount) {
-    return amount === 0 ? this : this.slice(Math.max(0, amount));
-  },
-
-  skipLast(amount) {
-    return amount === 0 ? this : this.slice(0, -Math.max(0, amount));
-  },
-
-  skipWhile(predicate, context) {
-    return reify(this, skipWhileFactory(this, predicate, context, true));
-  },
-
-  skipUntil(predicate, context) {
-    return this.skipWhile(not(predicate), context);
-  },
-
-  sortBy(mapper, comparator) {
-    return reify(this, sortFactory(this, comparator, mapper));
-  },
-
-  take(amount) {
-    return this.slice(0, Math.max(0, amount));
-  },
-
-  takeLast(amount) {
-    return this.slice(-Math.max(0, amount));
-  },
-
-  takeWhile(predicate, context) {
-    return reify(this, takeWhileFactory(this, predicate, context));
-  },
-
-  takeUntil(predicate, context) {
-    return this.takeWhile(not(predicate), context);
-  },
-
-  valueSeq() {
-    return this.toIndexedSeq();
-  },
 
   // ### Hashable Object
 
@@ -347,10 +185,6 @@ CollectionPrototype.contains = CollectionPrototype.includes;
 
 mixin(KeyedCollectionImpl, {
   // ### More sequential methods
-
-  flip() {
-    return reify(this, flipFactory(this));
-  },
 
   mapEntries(mapper, context) {
     let iterations = 0;
@@ -386,25 +220,6 @@ mixin(IndexedCollectionImpl, {
     return new ToKeyedSequence(this, false);
   },
 
-  // ### ES6 Collection methods (ES6 Array and Map)
-
-  filter(predicate, context) {
-    return reify(this, filterFactory(this, predicate, context, false));
-  },
-
-  lastIndexOf(searchValue) {
-    const key = this.lastKeyOf(searchValue);
-    return key === undefined ? -1 : key;
-  },
-
-  reverse() {
-    return reify(this, reverseFactory(this, false));
-  },
-
-  slice(begin, end) {
-    return reify(this, sliceFactory(this, begin, end, false));
-  },
-
   splice(index, removeNum, ...values) {
     const numArgs = arguments.length;
     removeNum = Math.max(removeNum || 0, 0);
@@ -424,62 +239,8 @@ mixin(IndexedCollectionImpl, {
     );
   },
 
-  // ### More collection methods
-
-  findLastIndex(predicate, context) {
-    const entry = this.findLastEntry(predicate, context);
-    return entry ? entry[0] : -1;
-  },
-
-  flatten(depth) {
-    return reify(this, flattenFactory(this, depth, false));
-  },
-
-  interpose(separator) {
-    return reify(this, interposeFactory(this, separator));
-  },
-
-  interleave(...collections) {
-    const thisAndCollections = [this].concat(collections);
-    const zipped = zipWithFactory(
-      this.toSeq(),
-      IndexedSeq.of,
-      thisAndCollections
-    );
-    const interleaved = zipped.flatten(true);
-    if (zipped.size) {
-      interleaved.size = zipped.size * thisAndCollections.length;
-    }
-    return reify(this, interleaved);
-  },
-
   keySeq() {
     return Range(0, this.size);
-  },
-
-  skipWhile(predicate, context) {
-    return reify(this, skipWhileFactory(this, predicate, context, false));
-  },
-
-  zip(...collections) {
-    const thisAndCollections = [this].concat(collections);
-
-    return reify(this, zipWithFactory(this, defaultZipper, thisAndCollections));
-  },
-
-  zipAll(...collections) {
-    const thisAndCollections = [this].concat(collections);
-
-    return reify(
-      this,
-      zipWithFactory(this, defaultZipper, thisAndCollections, true)
-    );
-  },
-
-  zipWith(zipper, ...collections) {
-    const thisAndCollections = [this].concat(collections);
-
-    return reify(this, zipWithFactory(this, zipper, thisAndCollections));
   },
 });
 
@@ -513,9 +274,3 @@ SetCollectionPrototype.keys = SetCollectionPrototype.values;
 mixin(KeyedSeqImpl, KeyedCollectionPrototype);
 mixin(IndexedSeqImpl, IndexedCollectionPrototype);
 mixin(SetSeqImpl, SetCollectionPrototype);
-
-// #pragma Helper functions
-
-function defaultZipper(...values) {
-  return values;
-}

--- a/src/Seq.js
+++ b/src/Seq.js
@@ -91,6 +91,7 @@ export const KeyedSeq = (value) =>
         ? value.toSeq()
         : keyedSeqFromValue(value);
 export class KeyedSeqImpl extends SeqImpl {
+  /** @returns {import('./Collection').KeyedCollectionImpl<unknown, unknown>} */
   toKeyedSeq() {
     return this;
   }
@@ -111,6 +112,7 @@ IndexedSeq.of = function (...values) {
   return IndexedSeq(values);
 };
 export class IndexedSeqImpl extends SeqImpl {
+  /** @returns {import('./Collection').IndexedCollectionImpl<unknown>} */
   toIndexedSeq() {
     return this;
   }
@@ -130,6 +132,7 @@ SetSeq.of = function (...values) {
 };
 
 export class SetSeqImpl extends SeqImpl {
+  /** @returns {import('./Collection').SetCollectionImpl<unknown>} */
   toSetSeq() {
     return this;
   }

--- a/src/operations/factories.js
+++ b/src/operations/factories.js
@@ -576,7 +576,6 @@ export function zipWithFactory(keyIter, zipper, iters, zipAll) {
   };
   zipSequence.__iteratorUncached = function (type, reverse) {
     const iterators = iters.map(
-      // eslint-disable-next-line no-sequences
       (i) => ((i = Collection(i)), getIterator(reverse ? i.reverse() : i))
     );
     let iterations = 0;

--- a/src/predicates/isAssociative.ts
+++ b/src/predicates/isAssociative.ts
@@ -16,10 +16,8 @@ import { isKeyed } from './isKeyed';
  * isAssociative(Set()); // false
  * ```
  */
-export function isAssociative(
+export function isAssociative<K, V>(
   maybeAssociative: unknown
-): maybeAssociative is
-  | KeyedCollectionImpl<unknown, unknown>
-  | IndexedCollectionImpl<unknown> {
-  return isKeyed(maybeAssociative) || isIndexed(maybeAssociative);
+): maybeAssociative is KeyedCollectionImpl<K, V> | IndexedCollectionImpl<V> {
+  return isKeyed<K, V>(maybeAssociative) || isIndexed<V>(maybeAssociative);
 }

--- a/src/predicates/isCollection.ts
+++ b/src/predicates/isCollection.ts
@@ -16,9 +16,9 @@ export const IS_COLLECTION_SYMBOL = '@@__IMMUTABLE_ITERABLE__@@';
  * isCollection(Stack()); // true
  * ```
  */
-export function isCollection(
+export function isCollection<K, V>(
   maybeCollection: unknown
-): maybeCollection is CollectionImpl<unknown, unknown> {
+): maybeCollection is CollectionImpl<K, V> {
   return Boolean(
     maybeCollection &&
       // @ts-expect-error: maybeCollection is typed as `{}`, need to change in 6.0 to `maybeCollection && typeof maybeCollection === 'object' && IS_COLLECTION_SYMBOL in maybeCollection`

--- a/src/predicates/isKeyed.ts
+++ b/src/predicates/isKeyed.ts
@@ -15,9 +15,9 @@ export const IS_KEYED_SYMBOL = '@@__IMMUTABLE_KEYED__@@';
  * isKeyed(Stack()); // false
  * ```
  */
-export function isKeyed(
+export function isKeyed<K, V>(
   maybeKeyed: unknown
-): maybeKeyed is KeyedCollectionImpl<unknown, unknown> {
+): maybeKeyed is KeyedCollectionImpl<K, V> {
   return Boolean(
     maybeKeyed &&
       // @ts-expect-error: maybeKeyed is typed as `{}`, need to change in 6.0 to `maybeKeyed && typeof maybeKeyed === 'object' && IS_KEYED_SYMBOL in maybeKeyed`

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://tstyche.org/schemas/config.json",
   "testFileMatch": [
-    "type-definitions/ts-tests/*.ts"
+    "type-definitions/ts-tests/*.ts",
+    "type-definitions/ts-tests-src/*.ts"
   ]
 }

--- a/type-definitions/ts-tests-src/collection.ts
+++ b/type-definitions/ts-tests-src/collection.ts
@@ -1,0 +1,164 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { Collection, List, Map, OrderedMap, Seq, Set } from 'immutable';
+import { expect, test } from 'tstyche';
+
+// Type-level coverage for shared Collection methods (defined on the
+// Collection.ts classes), exercised through the concrete public types.
+
+test.skip('subset methods keep the collection type (indexed / keyed / set / seq)', () => {
+  expect(List<number>().skipWhile((x) => x < 3)).type.toBe<List<number>>();
+  expect(List<number>().skipUntil((x) => x < 3)).type.toBe<List<number>>();
+  expect(List<number>().takeWhile((x) => x < 3)).type.toBe<List<number>>();
+  expect(List<number>().takeUntil((x) => x < 3)).type.toBe<List<number>>();
+  expect(List<number>().skip(2)).type.toBe<List<number>>();
+  expect(List<number>().skipLast(2)).type.toBe<List<number>>();
+  expect(List<number>().take(2)).type.toBe<List<number>>();
+  expect(List<number>().takeLast(2)).type.toBe<List<number>>();
+  expect(List<number>().butLast()).type.toBe<List<number>>();
+  expect(List<number>().rest()).type.toBe<List<number>>();
+  expect(List<number>().reverse()).type.toBe<List<number>>();
+  expect(List<number>().sort()).type.toBe<List<number>>();
+  expect(List<number>().sortBy((x) => -x)).type.toBe<List<number>>();
+  expect(List<number>().filterNot((x) => x > 1)).type.toBe<List<number>>();
+
+  expect(Map<string, number>().skipWhile((v) => v > 1)).type.toBe<
+    Map<string, number>
+  >();
+  expect(Map<string, number>().filterNot((v) => v > 1)).type.toBe<
+    Map<string, number>
+  >();
+  // Sorting an unordered Map yields its ordered equivalent.
+  expect(Map<string, number>().sortBy((v) => v)).type.toBe<
+    Map<string, number> & OrderedMap<string, number>
+  >();
+
+  expect(Set<number>().filterNot((v) => v > 1)).type.toBe<Set<number>>();
+
+  expect(Seq.Indexed<number>().skipWhile((x) => x < 1)).type.toBe<
+    Seq.Indexed<number>
+  >();
+  expect(Seq.Keyed<string, number>().filterNot((v) => v > 1)).type.toBe<
+    Seq.Keyed<string, number>
+  >();
+});
+
+test.skip('filter narrows with a type guard, across collection types', () => {
+  expect(
+    List<number | string>().filter((x): x is number => typeof x === 'number')
+  ).type.toBe<List<number>>();
+  expect(
+    Map<string, number | string>().filter(
+      (v): v is number => typeof v === 'number'
+    )
+  ).type.toBe<Map<string, number>>();
+  expect(
+    Set<number | string>().filter((v): v is number => typeof v === 'number')
+  ).type.toBe<Set<number>>();
+
+  // Without a guard, filter returns the same type.
+  expect(List<number>().filter((x) => x > 1)).type.toBe<List<number>>();
+});
+
+test.skip('partition splits and narrows', () => {
+  expect(List<number>().partition((x) => x > 1)).type.toBe<
+    [List<number>, List<number>]
+  >();
+  expect(
+    List<number | string>().partition((x): x is string => typeof x === 'string')
+  ).type.toBe<[List<number | string>, List<string>]>();
+});
+
+test.skip('flatMap returns the mapped collection type (indexed and keyed)', () => {
+  expect(List([1, 2]).flatMap((x) => [x, x * 10])).type.toBe<List<number>>();
+  expect(
+    Map<string, number>().flatMap((v, k): Array<[string, number]> => [[k, v]])
+  ).type.toBe<Map<string, number>>();
+});
+
+test.skip('flatten returns a collection', () => {
+  expect(List([1, 2]).flatten()).type.toBe<Collection<unknown, unknown>>();
+  expect(List([1, 2]).flatten(1)).type.toBe<Collection<unknown, unknown>>();
+  expect(List([1, 2]).flatten(true)).type.toBe<Collection<unknown, unknown>>();
+});
+
+test.skip('reducing-to-a-single-value methods', () => {
+  expect(List<number>().max()).type.toBe<number | undefined>();
+  expect(List<number>().min((a, b) => a - b)).type.toBe<number | undefined>();
+  expect(List<number>().maxBy((x) => x)).type.toBe<number | undefined>();
+  expect(
+    List<number>().minBy(
+      (x) => x,
+      (a, b) => a - b
+    )
+  ).type.toBe<number | undefined>();
+});
+
+test.skip('find / last family', () => {
+  expect(List<number>().findLast((x) => x > 1)).type.toBe<number | undefined>();
+  expect(List<number>().findLastEntry((x) => x > 1)).type.toBe<
+    [number, number] | undefined
+  >();
+  expect(Map<string, number>().findLastKey((v) => v > 1)).type.toBe<
+    string | undefined
+  >();
+  expect(OrderedMap<string, number>().lastKeyOf(1)).type.toBe<
+    string | undefined
+  >();
+});
+
+test.skip('indexed search returns number indices', () => {
+  expect(List<number>().findLastIndex((x) => x > 1)).type.toBe<number>();
+  expect(List<number>().lastIndexOf(1)).type.toBe<number>();
+});
+
+test.skip('indexed combination keeps the indexed type', () => {
+  expect(List<number>().interpose(0)).type.toBe<List<number>>();
+  expect(List<number>().interleave(List<number>())).type.toBe<List<number>>();
+  expect(Seq.Indexed<number>().interpose(0)).type.toBe<Seq.Indexed<number>>();
+});
+
+test.skip('zip family produces tuples and respects arity', () => {
+  expect(List<number>().zip(List<string>())).type.toBe<
+    List<[number, string]>
+  >();
+  expect(List<number>().zip(List<string>(), List<boolean>())).type.toBe<
+    List<[number, string, boolean]>
+  >();
+  expect(List<number>().zipAll(List<string>())).type.toBe<
+    List<[number, string]>
+  >();
+  expect(List<number>().zipWith((a, b) => a + b, List<number>())).type.toBe<
+    List<number>
+  >();
+  expect(
+    List<number>().zipWith(
+      (a, b: string, c: boolean) => `${a}${b}${c}`,
+      List<string>(),
+      List<boolean>()
+    )
+  ).type.toBe<List<string>>();
+});
+
+test.skip('flip swaps key and value types', () => {
+  expect(Map<string, number>().flip()).type.toBe<Map<number, string>>();
+  expect(Seq.Keyed<string, number>().flip()).type.toBe<
+    Seq.Keyed<number, string>
+  >();
+});
+
+test.skip('indexed-only methods are not available on keyed collections', () => {
+  expect(Map<string, number>().findLastIndex((v) => v > 1)).type.toRaiseError();
+  expect(Map<string, number>().lastIndexOf(1)).type.toRaiseError();
+  expect(Map<string, number>().zip(List<number>())).type.toRaiseError();
+  expect(Map<string, number>().interpose(0)).type.toRaiseError();
+});
+
+test.skip('flip is keyed-only', () => {
+  expect(List<number>().flip()).type.toRaiseError();
+});

--- a/type-definitions/ts-tests-src/covariance.ts
+++ b/type-definitions/ts-tests-src/covariance.ts
@@ -1,0 +1,86 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { List, Map, OrderedMap, OrderedSet, Set, Stack } from 'immutable';
+import { expect, test } from 'tstyche';
+
+class A {
+  x: number;
+
+  constructor() {
+    this.x = 1;
+  }
+}
+
+class B extends A {
+  y: string;
+
+  constructor() {
+    super();
+    this.y = 'B';
+  }
+}
+
+class C {
+  z: string;
+
+  constructor() {
+    this.z = 'C';
+  }
+}
+
+test.skip('List covariance', () => {
+  expect<List<B>>().type.toBeAssignableTo(List<A>());
+
+  expect(List([new B()])).type.toBe<List<B>>();
+
+  expect<List<B>>().type.not.toBeAssignableTo(List<C>());
+});
+
+test.skip('Map covariance', () => {
+  expect<Map<string, B>>().type.toBeAssignableTo<Map<string, A>>();
+
+  expect(Map({ b: new B() })).type.toBe<MapOf<{ b: B }>>();
+
+  expect<Map<string, B>>().type.not.toBeAssignableTo<Map<string, C>>();
+});
+
+test.skip('Set covariance', () => {
+  expect<Set<B>>().type.toBeAssignableTo<Set<A>>();
+
+  expect(Set([new B()])).type.toBe<Set<B>>();
+
+  expect<Set<B>>().type.not.toBeAssignableTo<Set<C>>();
+});
+
+test.skip('Stack covariance', () => {
+  expect<Stack<B>>().type.toBeAssignableTo<Stack<A>>();
+
+  expect(Stack([new B()])).type.toBe<Stack<B>>();
+
+  expect<Stack<B>>().type.not.toBeAssignableTo<Stack<C>>();
+});
+
+test.skip('OrderedMap covariance', () => {
+  expect<OrderedMap<string, B>>().type.toBeAssignableTo<
+    OrderedMap<string, A>
+  >();
+
+  expect(OrderedMap({ b: new B() })).type.toBe<OrderedMap<string, B>>();
+
+  expect<OrderedMap<string, B>>().type.not.toBeAssignableTo<
+    OrderedMap<string, C>
+  >();
+});
+
+test.skip('OrderedSet covariance', () => {
+  expect<OrderedSet<B>>().type.toBeAssignableTo<OrderedSet<A>>();
+
+  expect(OrderedSet([new B()])).type.toBe<OrderedSet<B>>();
+
+  expect<OrderedSet<B>>().type.not.toBeAssignableTo<OrderedSet<C>>();
+});

--- a/type-definitions/ts-tests-src/deepCopy.ts
+++ b/type-definitions/ts-tests-src/deepCopy.ts
@@ -1,0 +1,119 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { Collection, List, Map, Record, Seq, Set } from 'immutable';
+import { describe, expect, test } from 'tstyche';
+
+describe.skip('DeepCopy', () => {
+  test.skip('basic types', () => {
+    expect<
+      DeepCopy<{
+        a: number;
+        b: number;
+      }>
+    >().type.toBe<{
+      a: number;
+      b: number;
+    }>();
+  });
+
+  test.skip('iterables', () => {
+    expect<DeepCopy<string[]>>().type.toBe<string[]>();
+
+    expect<DeepCopy<Collection.Indexed<number>>>().type.toBe<number[]>();
+  });
+
+  test.skip('immutable first-level types', () => {
+    expect<DeepCopy<Map<string, string>>>().type.toBe<{
+      [x: string]: string;
+    }>();
+
+    // should be `{ [x: string]: object }`, but there is an issue with circular references
+    expect<DeepCopy<Map<object, object>>>().type.toBe<{
+      [x: string]: unknown;
+    }>();
+
+    // should be `{ [x: string]: object; [x: number]: object }`, but there is an issue with circular references
+    expect<DeepCopy<Map<object | number, object>>>().type.toBe<{
+      [x: string]: unknown;
+      [x: number]: unknown;
+    }>();
+
+    expect<DeepCopy<List<string>>>().type.toBe<string[]>();
+
+    expect<DeepCopy<Set<string>>>().type.toBe<string[]>();
+  });
+
+  test.skip('keyed', () => {
+    expect<DeepCopy<Collection.Keyed<string, number>>>().type.toBe<{
+      [x: string]: number;
+    }>();
+
+    expect<DeepCopy<Collection.Keyed<string | number, number>>>().type.toBe<{
+      [x: string]: number;
+      [x: number]: number;
+    }>();
+
+    expect<DeepCopy<Seq.Keyed<string | number, number>>>().type.toBe<{
+      [x: string]: number;
+      [x: number]: number;
+    }>();
+
+    expect<DeepCopy<Map<string | number, number>>>().type.toBe<{
+      [x: string]: number;
+      [x: number]: number;
+    }>();
+  });
+
+  test.skip('nested', () => {
+    // should be `{ map: { [x: string]: string }; list: string[]; set: string[] }`, but there is an issue with circular references
+    expect<
+      DeepCopy<{
+        map: Map<string, string>;
+        list: List<string>;
+        set: Set<string>;
+      }>
+    >().type.toBe<{ map: unknown; list: unknown; set: unknown }>();
+
+    // should be `{ map: { [x: string]: string } }`, but there is an issue with circular references
+    expect<DeepCopy<Map<'map', Map<string, string>>>>().type.toBe<{
+      map: unknown;
+    }>();
+  });
+
+  test.skip('circular references', () => {
+    type Article = Record<{ title: string; tag: Tag }>;
+    type Tag = Record<{ name: string; article: Article }>;
+
+    // should handle circular references here somehow
+    expect<DeepCopy<Article>>().type.toBe<{ title: string; tag: unknown }>();
+  });
+
+  test.skip('circular references #1957', () => {
+    class Foo1 extends Record<{ foo: undefined | Foo1 }>({
+      foo: undefined,
+    }) {}
+
+    class Foo2 extends Record<{ foo?: Foo2 }>({
+      foo: undefined,
+    }) {}
+
+    class Foo3 extends Record<{ foo: null | Foo3 }>({
+      foo: null,
+    }) {}
+
+    expect<DeepCopy<Foo1>>().type.toBe<{ foo: unknown }>();
+    expect<DeepCopy<Foo2>>().type.toBe<{ foo?: unknown }>();
+    expect<DeepCopy<Foo3>>().type.toBe<{ foo: unknown }>();
+
+    class FooWithList extends Record<{ foo: undefined | List<FooWithList> }>({
+      foo: undefined,
+    }) {}
+
+    expect<DeepCopy<FooWithList>>().type.toBe<{ foo: unknown }>();
+  });
+});

--- a/type-definitions/ts-tests-src/empty.ts
+++ b/type-definitions/ts-tests-src/empty.ts
@@ -1,0 +1,47 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { Collection, Seq } from 'immutable';
+import { expect, test } from 'tstyche';
+
+test.skip('typed empty Seq', () => {
+  expect(Seq()).type.toBe<Seq<unknown, unknown>>();
+
+  expect(Seq<number, string>()).type.toBe<Seq<number, string>>();
+
+  expect(Seq.Indexed()).type.toBe<Seq.Indexed<unknown>>();
+
+  expect(Seq.Indexed<string>()).type.toBe<Seq.Indexed<string>>();
+
+  expect(Seq.Keyed()).type.toBe<Seq.Keyed<unknown, unknown>>();
+
+  expect(Seq.Keyed<number, string>()).type.toBe<Seq.Keyed<number, string>>();
+
+  expect(Seq.Set()).type.toBe<Seq.Set<unknown>>();
+
+  expect(Seq.Set<string>()).type.toBe<Seq.Set<string>>();
+});
+
+test.skip('typed empty Collection', () => {
+  expect(Collection()).type.toBe<Collection<unknown, unknown>>();
+
+  expect(Collection<number, string>()).type.toBe<Collection<number, string>>();
+
+  expect(Collection.Indexed()).type.toBe<Collection.Indexed<unknown>>();
+
+  expect(Collection.Indexed<string>()).type.toBe<Collection.Indexed<string>>();
+
+  expect(Collection.Keyed()).type.toBe<Collection.Keyed<unknown, unknown>>();
+
+  expect(Collection.Keyed<number, string>()).type.toBe<
+    Collection.Keyed<number, string>
+  >();
+
+  expect(Collection.Set()).type.toBe<Collection.Set<unknown>>();
+
+  expect(Collection.Set<string>()).type.toBe<Collection.Set<string>>();
+});

--- a/type-definitions/ts-tests-src/es6-collections.ts
+++ b/type-definitions/ts-tests-src/es6-collections.ts
@@ -1,0 +1,28 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { Map as ImmutableMap, Set as ImmutableSet } from 'immutable';
+import { expect, test } from 'tstyche';
+
+test.skip('immutable.js collections', () => {
+  const mapImmutable: ImmutableMap<string, number> = ImmutableMap<
+    string,
+    number
+  >();
+  const setImmutable: ImmutableSet<string> = ImmutableSet<string>();
+
+  expect(mapImmutable.delete('foo')).type.toBe<ImmutableMap<string, number>>();
+  expect(setImmutable.delete('bar')).type.toBe<ImmutableSet<string>>();
+});
+
+test.skip('ES6 collections', () => {
+  const mapES6: Map<string, number> = new Map<string, number>();
+  const setES6: Set<string> = new Set<string>();
+
+  expect(mapES6.delete('foo')).type.toBe<boolean>();
+  expect(setES6.delete('bar')).type.toBe<boolean>();
+});

--- a/type-definitions/ts-tests-src/exports.ts
+++ b/type-definitions/ts-tests-src/exports.ts
@@ -1,0 +1,119 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+// Some tests look like they are repeated in order to avoid false positives.
+
+import * as Immutable from 'immutable';
+import {
+  Collection,
+  List,
+  Map,
+  OrderedMap,
+  OrderedSet,
+  Range,
+  Repeat,
+  Seq,
+  Set,
+  Stack,
+} from 'immutable';
+import { expect, test } from 'tstyche';
+
+test.skip('named imports', () => {
+  expect(List).type.toBe<typeof List>();
+
+  expect(Map).type.toBe<typeof Map>();
+
+  expect(OrderedMap).type.toBe<typeof OrderedMap>();
+
+  expect(OrderedSet).type.toBe<typeof OrderedSet>();
+
+  expect(Range).type.toBe<
+    (
+      start: number,
+      end: number,
+      step?: number | undefined
+    ) => Seq.Indexed<number>
+  >();
+
+  expect(Repeat).type.toBe<
+    <T>(value: T, times?: number | undefined) => Seq.Indexed<T>
+  >();
+
+  expect(Seq).type.toBe<typeof Seq>();
+
+  expect(Set).type.toBe<typeof Set>();
+
+  expect(Stack).type.toBe<typeof Stack>();
+
+  expect(Collection).type.toBe<typeof Collection>();
+
+  expect(Collection.Set).type.toBe<
+    <T>(
+      collection?: Iterable<T> | ArrayLike<T> | undefined
+    ) => Collection.Set<T>
+  >();
+
+  expect(Collection.Keyed).type.toBe<{
+    <K, V>(collection?: Iterable<[K, V]> | undefined): Collection.Keyed<K, V>;
+    <V>(obj: { [key: string]: V }): Collection.Keyed<string, V>;
+  }>();
+
+  expect(Collection.Indexed).type.toBe<
+    <T>(
+      collection?: Iterable<T> | ArrayLike<T> | undefined
+    ) => Collection.Indexed<T>
+  >();
+});
+
+test.skip('namespace import', () => {
+  expect(Immutable.List).type.toBe<typeof Immutable.List>();
+
+  expect(Immutable.Map).type.toBe<typeof Immutable.Map>();
+
+  expect(Immutable.OrderedMap).type.toBe<typeof Immutable.OrderedMap>();
+
+  expect(Immutable.OrderedSet).type.toBe<typeof Immutable.OrderedSet>();
+
+  expect(Immutable.Range).type.toBe<
+    (
+      start: number,
+      end: number,
+      step?: number | undefined
+    ) => Immutable.Seq.Indexed<number>
+  >();
+
+  expect(Immutable.Repeat).type.toBe<
+    <T>(value: T, times?: number | undefined) => Immutable.Seq.Indexed<T>
+  >();
+
+  expect(Immutable.Seq).type.toBe<typeof Immutable.Seq>();
+
+  expect(Immutable.Set).type.toBe<typeof Immutable.Set>();
+
+  expect(Immutable.Stack).type.toBe<typeof Immutable.Stack>();
+
+  expect(Immutable.Collection).type.toBe<typeof Immutable.Collection>();
+
+  expect(Immutable.Collection.Set).type.toBe<
+    <T>(
+      collection?: Iterable<T> | ArrayLike<T> | undefined
+    ) => Immutable.Collection.Set<T>
+  >();
+
+  expect(Immutable.Collection.Keyed).type.toBe<{
+    <K, V>(
+      collection?: Iterable<[K, V]> | undefined
+    ): Immutable.Collection.Keyed<K, V>;
+    <V>(obj: { [key: string]: V }): Immutable.Collection.Keyed<string, V>;
+  }>();
+
+  expect(Immutable.Collection.Indexed).type.toBe<
+    <T>(
+      collection?: Iterable<T> | ArrayLike<T> | undefined
+    ) => Immutable.Collection.Indexed<T>
+  >();
+});

--- a/type-definitions/ts-tests-src/from-js.ts
+++ b/type-definitions/ts-tests-src/from-js.ts
@@ -1,0 +1,53 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { Collection, List, Map, fromJS } from 'immutable';
+import { expect, test } from 'tstyche';
+
+test.skip('fromJS', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  expect(fromJS({}, (a: any, b: any) => b)).type.toBe<
+    Collection<unknown, unknown>
+  >();
+
+  expect(fromJS('abc')).type.toBe<string>();
+
+  expect(fromJS([0, 1, 2])).type.toBe<List<number>>();
+
+  expect(fromJS(List([0, 1, 2]))).type.toBe<List<number>>();
+
+  expect(fromJS({ a: 0, b: 1, c: 2 })).type.toBe<
+    Map<'b' | 'a' | 'c', number>
+  >();
+
+  expect(fromJS(Map({ a: 0, b: 1, c: 2 }))).type.toBe<
+    MapOf<{ a: number; b: number; c: number }>
+  >();
+
+  expect(fromJS([{ a: 0 }])).type.toBe<List<Map<'a', number>>>();
+
+  expect(fromJS({ a: [0] })).type.toBe<Map<'a', List<number>>>();
+
+  expect(fromJS([[[0]]])).type.toBe<List<List<List<number>>>>();
+
+  expect(fromJS({ a: { b: { c: 0 } } })).type.toBe<
+    Map<'a', Map<'b', Map<'c', number>>>
+  >();
+});
+
+test.skip('fromJS in an array of function', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const create = [(data: any) => data, fromJS][1];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  expect(create({ a: 'A' })).type.toBe<any>();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const createConst = ([(data: any) => data, fromJS] as const)[1];
+
+  expect(createConst({ a: 'A' })).type.toBe<Map<'a', string>>();
+});

--- a/type-definitions/ts-tests-src/functional.ts
+++ b/type-definitions/ts-tests-src/functional.ts
@@ -1,0 +1,170 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import {
+  List,
+  Map,
+  get,
+  getIn,
+  has,
+  hasIn,
+  remove,
+  set,
+  update,
+} from 'immutable';
+import { expect, test } from 'tstyche';
+
+test.skip('get', () => {
+  expect(get([1, 2, 3], 0)).type.toBe<number | undefined>();
+
+  expect(get([1, 2, 3], 0, 'a')).type.toBe<number | 'a'>();
+
+  expect(get({ x: 10, y: 20 }, 'x')).type.toBe<number | undefined>();
+
+  expect(get({ x: 10, y: 20 }, 'z', 'missing')).type.toBe<number | 'missing'>();
+});
+
+test.skip('getIn', () => {
+  expect(getIn('a', ['length'])).type.toBe<never>();
+
+  expect(getIn([1, 2, 3], [0])).type.toBe<number>();
+
+  // first parameter type is Array<number> so we can not detect that the number will be invalid
+  expect(getIn([1, 2, 3], [99])).type.toBe<number>();
+
+  // We do not handle List in getIn TS type yet (hard to convert to a tuple)
+  expect(getIn([1, 2, 3], List([0]))).type.toBe<unknown>();
+
+  expect(getIn([1, 2, 3], [0], 'a')).type.toBe<number>();
+
+  expect(getIn(List([1, 2, 3]), [0])).type.toBe<number>();
+
+  // first parameter type is Array<number> so we can not detect that the number will be invalid
+  expect(getIn(List([1, 2, 3]), [99])).type.toBe<number>();
+
+  expect(getIn(List([1, 2, 3]), ['a'])).type.toBe<never>();
+
+  expect(getIn(List([1, 2, 3]), ['a'], 'missing')).type.toBe<'missing'>();
+
+  expect(getIn({ x: 10, y: 20 }, ['x'])).type.toBe<number>();
+
+  expect(getIn({ x: 10, y: 20 }, ['z'], 'missing')).type.toBe<'missing'>();
+
+  expect(getIn({ x: { y: 20 } }, ['x'])).type.toBe<{ y: number }>();
+
+  expect(getIn({ x: { y: 20 } }, ['z'])).type.toBe<never>();
+
+  expect(getIn({ x: { y: 20 } }, ['x', 'y'])).type.toBe<number>();
+
+  expect(getIn({ x: Map({ y: 20 }) }, ['x', 'y'])).type.toBe<number>();
+
+  expect(getIn(Map({ x: Map({ y: 20 }) }), ['x', 'y'])).type.toBe<number>();
+
+  const o = Map({ x: List([Map({ y: 20 })]) });
+
+  expect(getIn(o, ['x', 'y'])).type.toBe<never>();
+
+  expect(getIn(o, ['x'])).type.toBe<List<MapOf<{ y: number }>>>();
+
+  expect(getIn(o, ['x', 0])).type.toBe<MapOf<{ y: number }>>();
+
+  expect(getIn(o, ['x', 0, 'y'])).type.toBe<number>();
+});
+
+test.skip('has', () => {
+  expect(has([1, 2, 3], 0)).type.toBe<boolean>();
+
+  expect(has({ x: 10, y: 20 }, 'x')).type.toBe<boolean>();
+});
+
+test.skip('hasIn', () => {
+  expect(hasIn('a', ['length' as const])).type.toBe<never>();
+
+  expect(hasIn(123, [])).type.toBe<never>();
+
+  expect(hasIn(true, [])).type.toBe<never>();
+
+  expect(hasIn([1, 2, 3], [0])).type.toBe<boolean>();
+
+  // first parameter type is Array<number> so we can not detect that the number will be invalid
+  expect(hasIn([1, 2, 3], [99])).type.toBe<boolean>();
+
+  // We do not handle List in hasIn TS type yet (hard to convert to a tuple)
+  expect(hasIn([1, 2, 3], List([0]))).type.toBe<boolean>();
+
+  expect(hasIn(List([1, 2, 3]), [0])).type.toBe<boolean>();
+
+  // first parameter type is Array<number> so we can not detect that the number will be invalid
+  expect(hasIn(List([1, 2, 3]), [99])).type.toBe<boolean>();
+
+  expect(hasIn(List([1, 2, 3]), ['a' as const])).type.toBe<boolean>();
+
+  expect(hasIn({ x: 10, y: 20 }, ['x' as const])).type.toBe<boolean>();
+
+  expect(hasIn({ x: { y: 20 } }, ['z' as const])).type.toBe<boolean>();
+
+  expect(
+    hasIn({ x: { y: 20 } }, ['x' as const, 'y' as const])
+  ).type.toBe<boolean>();
+
+  expect(
+    hasIn({ x: Map({ y: 20 }) }, ['x' as const, 'y' as const])
+  ).type.toBe<boolean>();
+
+  expect(
+    hasIn(Map({ x: Map({ y: 20 }) }), ['x' as const, 'y' as const])
+  ).type.toBe<boolean>();
+
+  const o = Map({ x: List([Map({ y: 20 })]) });
+
+  expect(hasIn(o, ['x' as const, 'y' as const])).type.toBe<boolean>();
+
+  expect(hasIn(o, ['x' as const, 0, 'y' as const])).type.toBe<boolean>();
+});
+
+test.skip('set', () => {
+  expect(set([1, 2, 3], 0, 10)).type.toBe<number[]>();
+
+  expect(set([1, 2, 3], 0, 'a')).type.toRaiseError();
+
+  expect(set([1, 2, 3], 'a', 0)).type.toRaiseError();
+
+  expect(set({ x: 10, y: 20 }, 'x', 100)).type.toBe<{
+    x: number;
+    y: number;
+  }>();
+
+  expect(set({ x: 10, y: 20 }, 'x', 'a')).type.toRaiseError();
+});
+
+test.skip('remove', () => {
+  expect(remove([1, 2, 3], 0)).type.toBe<number[]>();
+
+  expect(remove({ x: 10, y: 20 }, 'x')).type.toBe<{
+    x: number;
+    y: number;
+  }>();
+});
+
+test.skip('update', () => {
+  expect(update([1, 2, 3], 0, (v: number) => v + 1)).type.toBe<number[]>();
+
+  expect(update([1, 2, 3], 0, 1)).type.toRaiseError();
+
+  expect(update([1, 2, 3], 0, (v: string) => v + 'a')).type.toRaiseError();
+
+  expect(update([1, 2, 3], 'a', (v: number) => v + 1)).type.toRaiseError();
+
+  expect(update({ x: 10, y: 20 }, 'x', (v: number) => v + 1)).type.toBe<{
+    x: number;
+    y: number;
+  }>();
+
+  expect(
+    update({ x: 10, y: 20 }, 'x', (v: string) => v + 'a')
+  ).type.toRaiseError();
+});

--- a/type-definitions/ts-tests-src/groupBy.ts
+++ b/type-definitions/ts-tests-src/groupBy.ts
@@ -1,0 +1,65 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import {
+  Collection,
+  List,
+  Map,
+  OrderedMap,
+  OrderedSet,
+  Seq,
+  Set,
+  Stack,
+} from 'immutable';
+import { expect, test } from 'tstyche';
+
+test.skip('groupBy', () => {
+  expect(Collection(['a', 'b', 'c', 'a']).groupBy((v) => v)).type.toBe<
+    Map<string, Collection.Indexed<string>>
+  >();
+
+  expect(
+    Collection({ a: 1, b: 2, c: 3, d: 1 }).groupBy((v) => `key-${v}`)
+  ).type.toBe<Map<string, Collection.Keyed<string, number>>>();
+
+  expect(List(['a', 'b', 'c', 'a']).groupBy((v) => v)).type.toBe<
+    Map<string, List<string>>
+  >();
+
+  expect(Seq(['a', 'b', 'c', 'a']).groupBy((v) => v)).type.toBe<
+    Map<string, Seq.Indexed<string>>
+  >();
+
+  expect(Seq({ a: 1, b: 2, c: 3, d: 1 }).groupBy((v) => `key-${v}`)).type.toBe<
+    Map<string, Seq.Keyed<string, number>>
+  >();
+
+  expect(Set(['a', 'b', 'c', 'a']).groupBy((v) => v)).type.toBe<
+    Map<string, Set<string>>
+  >();
+
+  expect(Stack(['a', 'b', 'c', 'a']).groupBy((v) => v)).type.toBe<
+    Map<string, Stack<string>>
+  >();
+
+  expect(OrderedSet(['a', 'b', 'c', 'a']).groupBy((v) => v)).type.toBe<
+    Map<string, OrderedSet<string>>
+  >();
+
+  expect(
+    Map<string, number>({ a: 1, b: 2, c: 3, d: 1 }).groupBy((v) => `key-${v}`)
+  ).type.toBe<Map<string, Map<string, number>>>();
+
+  // type should be something like Map<string, MapOf<Partial{ a: number, b: number, c: number, d: number }>>> but groupBy returns a wrong type with `this`
+  expect(Map({ a: 1, b: 2, c: 3, d: 1 }).groupBy((v) => `key-${v}`)).type.toBe<
+    Map<string, MapOf<{ a: number; b: number; c: number; d: number }>>
+  >();
+
+  expect(
+    OrderedMap({ a: 1, b: 2, c: 3, d: 1 }).groupBy((v) => `key-${v}`)
+  ).type.toBe<Map<string, OrderedMap<string, number>>>();
+});

--- a/type-definitions/ts-tests-src/list.ts
+++ b/type-definitions/ts-tests-src/list.ts
@@ -1,0 +1,410 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import {
+  List,
+  get,
+  merge,
+  remove,
+  removeIn,
+  set,
+  setIn,
+  update,
+  updateIn,
+} from 'immutable';
+import { expect, pick, test } from 'tstyche';
+
+test.skip('#constructor', () => {
+  expect(List()).type.toBe<List<unknown>>();
+
+  expect(List<number>()).type.toBeAssignableTo<List<number>>();
+
+  expect(List([1, 'a'])).type.toBeAssignableTo<List<number | string>>();
+  expect(List([1, 'a'])).type.not.toBeAssignableTo<List<number>>();
+});
+
+test.skip('#size', () => {
+  expect(pick(List(), 'size')).type.toBe<{ readonly size: number }>();
+});
+
+test.skip('#setSize', () => {
+  expect(List<number>().setSize(10)).type.toBe<List<number>>();
+
+  expect(List<number>().setSize('foo')).type.toRaiseError();
+});
+
+test.skip('.of', () => {
+  expect(List.of(1, 2, 3)).type.toBe<List<number>>();
+
+  expect(List.of<number>('a', 1)).type.toRaiseError();
+
+  expect(List.of<number | string>('a', 1)).type.toBe<List<string | number>>();
+});
+
+test.skip('#get', () => {
+  expect(List<number>().get(4)).type.toBe<number | undefined>();
+
+  expect(List<number>().get(4, 'a')).type.toBe<number | 'a'>();
+
+  expect(List<number>().get<number>(4, 'a')).type.toRaiseError();
+
+  expect(get(List<number>(), 4)).type.toBe<number | undefined>();
+
+  expect(get(List<number>(), 4, 'a')).type.toBe<number | 'a'>();
+});
+
+test.skip('#set', () => {
+  expect(List<number>().set(0, 0)).type.toBe<List<number>>();
+
+  expect(List<number>().set(1, 'a')).type.toRaiseError();
+
+  expect(List<number>().set('a', 1)).type.toRaiseError();
+
+  expect(List<number | string>().set(0, 1)).type.toBe<List<string | number>>();
+
+  expect(List<number | string>().set(0, 'a')).type.toBe<
+    List<string | number>
+  >();
+
+  expect(set(List<number>(), 0, 0)).type.toBe<List<number>>();
+});
+
+test.skip('#first', () => {
+  const a = List<number>().first();
+  //    ^?
+  expect(List<number>().first()).type.toBe<number | undefined>();
+  expect(List<number>().first('first')).type.toBe<number | 'first'>();
+});
+
+test.skip('#last', () => {
+  expect(List<number>().last()).type.toBe<number | undefined>();
+  expect(List<number>().last('last')).type.toBe<number | 'last'>();
+});
+
+test.skip('#set', () => {
+  expect(set(List<number>(), 1, 'a')).type.toRaiseError();
+
+  expect(set(List<number>(), 'a', 1)).type.toRaiseError();
+});
+
+test.skip('#setIn', () => {
+  expect(List<number>().setIn([], 0)).type.toBe<List<number>>();
+
+  expect(setIn(List<number>(), [], 0)).type.toBe<List<number>>();
+});
+
+test.skip('#insert', () => {
+  expect(List<number>().insert(0, 0)).type.toBe<List<number>>();
+
+  expect(List<number>().insert(1, 'a')).type.toRaiseError();
+
+  expect(List<number>().insert('a', 1)).type.toRaiseError();
+
+  expect(List<number | string>().insert(0, 1)).type.toBe<
+    List<string | number>
+  >();
+
+  expect(List<number | string>().insert(0, 'a')).type.toBe<
+    List<string | number>
+  >();
+});
+
+test.skip('#push', () => {
+  expect(List<number>().push(0, 0)).type.toBe<List<number>>();
+
+  expect(List<number>().push(1, 'a')).type.toRaiseError();
+
+  expect(List<number>().push('a', 1)).type.toRaiseError();
+
+  expect(List<number | string>().push(0, 1)).type.toBe<List<string | number>>();
+
+  expect(List<number | string>().push(0, 'a')).type.toBe<
+    List<string | number>
+  >();
+});
+
+test.skip('#unshift', () => {
+  expect(List<number>().unshift(0, 0)).type.toBe<List<number>>();
+
+  expect(List<number>().unshift(1, 'a')).type.toRaiseError();
+
+  expect(List<number>().unshift('a', 1)).type.toRaiseError();
+
+  expect(List<number | string>().unshift(0, 1)).type.toBe<
+    List<string | number>
+  >();
+
+  expect(List<number | string>().unshift(0, 'a')).type.toBe<
+    List<string | number>
+  >();
+});
+
+test.skip('#delete', () => {
+  expect(List<number>().delete(0)).type.toBe<List<number>>();
+
+  expect(List().delete('a')).type.toRaiseError();
+});
+
+test.skip('#deleteIn', () => {
+  expect(List<number>().deleteIn([])).type.toBe<List<number>>();
+});
+
+test.skip('#remove', () => {
+  expect(List<number>().remove(0)).type.toBe<List<number>>();
+
+  expect(List().remove('a')).type.toRaiseError();
+
+  expect(remove(List<number>(), 0)).type.toBe<List<number>>();
+});
+
+test.skip('#removeIn', () => {
+  expect(List<number>().removeIn([])).type.toBe<List<number>>();
+
+  expect(removeIn(List<number>(), [])).type.toBe<List<number>>();
+});
+
+test.skip('#clear', () => {
+  expect(List<number>().clear()).type.toBe<List<number>>();
+
+  expect(List().clear(10)).type.toRaiseError();
+});
+
+test.skip('#pop', () => {
+  expect(List<number>().pop()).type.toBe<List<number>>();
+
+  expect(List().pop(10)).type.toRaiseError();
+});
+
+test.skip('#shift', () => {
+  expect(List<number>().shift()).type.toBe<List<number>>();
+
+  expect(List().shift(10)).type.toRaiseError();
+});
+
+test.skip('#update', () => {
+  expect(List().update((v) => 1)).type.toBe<number>();
+
+  expect(
+    List<number>().update((v: List<string> | undefined) => v)
+  ).type.toRaiseError();
+
+  expect(List<number>().update(0, (v: number | undefined) => 0)).type.toBe<
+    List<number>
+  >();
+
+  expect(
+    List<number>().update(0, (v: number | undefined) => v + 'a')
+  ).type.toRaiseError();
+
+  expect(List<number>().update(1, 10, (v: number | undefined) => 0)).type.toBe<
+    List<number>
+  >();
+
+  expect(
+    List<number>().update(1, 'a', (v: number | undefined) => 0)
+  ).type.toRaiseError();
+
+  expect(
+    List<number>().update(1, 10, (v: number | undefined) => v + 'a')
+  ).type.toRaiseError();
+
+  expect(List<string>().update(1, (v) => v?.toUpperCase())).type.toBe<
+    List<string>
+  >();
+
+  expect(update(List<number>(), 0, (v: number | undefined) => 0)).type.toBe<
+    List<number>
+  >();
+
+  expect(
+    update(List<number>(), 1, 10, (v: number) => v + 'a')
+  ).type.toRaiseError();
+});
+
+test.skip('#updateIn', () => {
+  expect(List<number>().updateIn([], (v) => v)).type.toBe<List<number>>();
+
+  expect(List<number>().updateIn([], 10)).type.toRaiseError();
+
+  expect(updateIn(List<number>(), [], (v) => v)).type.toBe<List<number>>();
+});
+
+test.skip('#map', () => {
+  expect(
+    List<number>().map((value: number, key: number, iter: List<number>) => 1)
+  ).type.toBe<List<number>>();
+
+  expect(
+    List<number>().map((value: number, key: number, iter: List<number>) => 'a')
+  ).type.toBe<List<string>>();
+
+  expect(
+    List<number>().map<number>(
+      (value: number, key: number, iter: List<number>) => 1
+    )
+  ).type.toBe<List<number>>();
+
+  expect(
+    List<number>().map<string>(
+      (value: number, key: number, iter: List<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    List<number>().map<number>(
+      (value: string, key: number, iter: List<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    List<number>().map<number>(
+      (value: number, key: string, iter: List<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    List<number>().map<number>(
+      (value: number, key: number, iter: List<string>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    List<number>().map<number>(
+      (value: number, key: number, iter: List<number>) => 'a'
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#flatMap', () => {
+  expect(
+    List<number>().flatMap((value: number, key: number, iter: List<number>) => [
+      1,
+    ])
+  ).type.toBe<List<number>>();
+
+  expect(
+    List<number>().flatMap((value: number, key: number, iter: List<number>) => [
+      'a',
+    ])
+  ).type.toBe<List<string>>();
+
+  expect(List<List<string>>().flatMap((list) => list)).type.toBe<
+    List<string>
+  >();
+
+  expect(
+    List<number>().flatMap<number>(
+      (value: number, key: number, iter: List<number>) => [1]
+    )
+  ).type.toBe<List<number>>();
+
+  expect(
+    List<number>().flatMap<string>(
+      (value: number, key: number, iter: List<number>) => [1]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    List<number>().flatMap<number>(
+      (value: string, key: number, iter: List<number>) => [1]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    List<number>().flatMap<number>(
+      (value: number, key: string, iter: List<number>) => [1]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    List<number>().flatMap<number>(
+      (value: number, key: number, iter: List<string>) => [1]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    List<number>().flatMap<number>(
+      (value: number, key: number, iter: List<number>) => ['a']
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#merge', () => {
+  expect(List<number>().merge(List<number>())).type.toBe<List<number>>();
+
+  expect(List<number>().merge(List<string>())).type.toBe<
+    List<string | number>
+  >();
+
+  expect(List<number | string>().merge(List<string>())).type.toBe<
+    List<string | number>
+  >();
+
+  expect(List<number | string>().merge(List<number>())).type.toBe<
+    List<string | number>
+  >();
+
+  expect(merge(List<number>(), List<number>())).type.toBe<List<number>>();
+});
+
+test.skip('#mergeIn', () => {
+  expect(List<number>().mergeIn([], [])).type.toBe<List<number>>();
+});
+
+test.skip('#mergeDeepIn', () => {
+  expect(List<number>().mergeDeepIn([], [])).type.toBe<List<number>>();
+});
+
+test.skip('#flatten', () => {
+  expect(List<number>().flatten()).type.toBe<
+    Immutable.Collection<unknown, unknown>
+  >();
+
+  expect(List<number>().flatten(10)).type.toBe<
+    Immutable.Collection<unknown, unknown>
+  >();
+
+  expect(List<number>().flatten(false)).type.toBe<
+    Immutable.Collection<unknown, unknown>
+  >();
+
+  expect(List<number>().flatten('a')).type.toRaiseError();
+});
+
+test.skip('#withMutations', () => {
+  expect(List<number>().withMutations((mutable) => mutable)).type.toBe<
+    List<number>
+  >();
+
+  expect(
+    List<number>().withMutations((mutable: List<string>) => mutable)
+  ).type.toRaiseError();
+});
+
+test.skip('#asMutable', () => {
+  expect(List<number>().asMutable()).type.toBe<List<number>>();
+});
+
+test.skip('#asImmutable', () => {
+  expect(List<number>().asImmutable()).type.toBe<List<number>>();
+});
+
+test.skip('#toJS', () => {
+  expect(List<List<number>>().toJS()).type.toBe<number[][]>();
+});
+
+test.skip('#toJSON', () => {
+  expect(List<List<number>>().toJSON()).type.toBe<List<number>[]>();
+});
+
+test.skip('for of loops', () => {
+  const list = List([1, 2, 3, 4]);
+
+  for (const val of list) {
+    expect(val).type.toBe<number>();
+  }
+});

--- a/type-definitions/ts-tests-src/map.ts
+++ b/type-definitions/ts-tests-src/map.ts
@@ -1,0 +1,679 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { List, Map, OrderedMap } from 'immutable';
+import { expect, pick, test } from 'tstyche';
+
+test.skip('#constructor', () => {
+  expect(Map()).type.toBe<Map<unknown, unknown>>();
+
+  expect(Map<number, number>()).type.toBe<Map<number, number>>();
+
+  expect(Map([[1, 'a']])).type.toBe<Map<number, string>>();
+
+  expect(Map([['a', 'a']])).type.toBe<Map<string, string>>();
+
+  expect(Map([] as ReadonlyArray<readonly [number, string]>)).type.toBe<
+    Map<number, string>
+  >();
+
+  expect(Map(List<[number, string]>([[1, 'a']]))).type.toBe<
+    Map<number, string>
+  >();
+
+  expect(Map({ a: 1 })).type.toBe<MapOf<{ a: number }>>();
+
+  expect(Map({ a: 1, b: 'b' })).type.toBe<MapOf<{ a: number; b: string }>>();
+
+  expect(Map({ a: Map({ b: Map({ c: 3 }) }) })).type.toBe<
+    MapOf<{ a: MapOf<{ b: MapOf<{ c: number }> }> }>
+  >();
+
+  expect(Map<{ a: string }>({ a: 1 })).type.toRaiseError();
+
+  expect(Map<{ a: string }>({ a: 'a', b: 'b' })).type.toRaiseError();
+
+  // TODO this type is really weird, it should be `Map<string, string>` or MapOf<{ a: string }> See https://github.com/immutable-js/immutable-js/pull/1991#discussion_r1510863932
+  expect(Map(List([List(['a', 'b'])]))).type.toBe<MapOf<List<List<string>>>>();
+
+  expect(Map([[1, 'a']])).type.not.toBeAssignableTo<Map<number, number>>();
+
+  expect(Map<'status', string>({ status: 'paid' })).type.toBe<
+    Map<'status', string>
+  >();
+
+  expect(Map<'status' | 'amount', string>({ status: 'paid' })).type.toBe<
+    Map<'status' | 'amount', string>
+  >();
+
+  expect(
+    Map<'status', string>({ status: 'paid', amount: 10 })
+  ).type.toRaiseError();
+});
+
+test.skip('#size', () => {
+  expect(pick(Map(), 'size')).type.toBe<{ readonly size: number }>();
+});
+
+test.skip('#get', () => {
+  expect(Map<number, number>().get(4)).type.toBe<number | undefined>();
+
+  expect(Map<number, number>().get(4, 'a')).type.toBe<number | 'a'>();
+
+  expect(Map<number, number>().get<number>(4, 'a')).type.toRaiseError();
+
+  expect(Map({ a: 4, b: true }).get('a')).type.toBe<number>();
+
+  expect(Map({ a: 4, b: true }).get('b')).type.toBe<boolean>();
+
+  expect(
+    Map({ a: Map({ b: true }) })
+      .get('a')
+      .get('b')
+  ).type.toBe<boolean>();
+
+  expect(Map({ a: 4 }).get('b')).type.toRaiseError();
+
+  expect(Map({ a: 4 }).get('b', undefined)).type.toBe<undefined>();
+
+  expect(Map({ 1: 4 }).get(1)).type.toBe<number>();
+
+  expect(Map({ 1: 4 }).get(2)).type.toRaiseError();
+
+  expect(Map({ 1: 4 }).get(2, 3)).type.toBe<3>();
+
+  const s1 = Symbol('s1');
+
+  expect(Map({ [s1]: 4 }).get(s1)).type.toBe<number>();
+
+  const s2 = Symbol('s2');
+
+  expect(Map({ [s2]: 4 }).get(s1)).type.toRaiseError();
+});
+
+test.skip('#getIn', () => {
+  const result = Map({ a: 4, b: true }).getIn(['a']);
+
+  expect(result).type.toBe<number>();
+
+  expect(Map({ a: 4, b: true }).getIn(['a'])).type.toBe<number>();
+
+  expect(
+    Map({ a: Map({ b: Map({ c: Map({ d: 4 }) }) }) }).getIn([
+      'a',
+      'b',
+      'c',
+      'd',
+    ])
+  ).type.toBe<number>();
+
+  expect(Map({ a: [1] }).getIn(['a', 0])).type.toBe<number>();
+
+  expect(Map({ a: List([1]) }).getIn(['a', 0])).type.toBe<number>();
+});
+
+test.skip('#set', () => {
+  expect(Map<number, number>().set(0, 0)).type.toBe<Map<number, number>>();
+
+  expect(Map<number, number>().set(1, 'a')).type.toRaiseError();
+
+  expect(Map<number, number>().set('a', 1)).type.toRaiseError();
+
+  expect(Map<number, number | string>().set(0, 1)).type.toBe<
+    Map<number, string | number>
+  >();
+
+  expect(Map<number, number | string>().set(0, 'a')).type.toBe<
+    Map<number, string | number>
+  >();
+
+  expect(Map({ a: 1 }).set('b', 'b')).type.toRaiseError();
+
+  expect(Map<{ a: number; b?: string }>({ a: 1 }).set('b', 'b')).type.toBe<
+    MapOf<{ a: number; b?: string | undefined }>
+  >();
+
+  expect(
+    Map<{ a: number; b?: string }>({ a: 1 }).set('b', undefined)
+  ).type.toBe<MapOf<{ a: number; b?: string | undefined }>>();
+
+  expect(
+    Map<{ a: number; b?: string }>({ a: 1 }).set('b', 'b').get('a')
+  ).type.toBe<number>();
+
+  expect(
+    Map<{ a: number; b?: string }>({ a: 1 }).set('b', 'b').get('b')
+  ).type.toBe<string | undefined>();
+
+  const customer = Map<{ phone: string | number }>({
+    phone: 'bar',
+  });
+
+  expect(customer.set('phone', 8)).type.toBeAssignableTo(customer);
+});
+
+test.skip('#setIn', () => {
+  expect(Map<number, number>().setIn([], 0)).type.toBe<Map<number, number>>();
+});
+
+test.skip('#delete', () => {
+  expect(Map<number, number>().delete(0)).type.toBe<Map<number, number>>();
+
+  expect(Map<number, number>().delete('a')).type.toRaiseError();
+
+  expect(Map({ a: 1, b: 'b' }).delete('b')).type.toBe<never>();
+
+  expect(
+    Map<{ a: number; b?: string }>({ a: 1, b: 'b' }).delete('b')
+  ).type.toBe<MapOf<{ a: number; b?: string | undefined }>>();
+
+  expect(
+    Map<{ a?: number; b?: string }>({ a: 1, b: 'b' }).remove('b').delete('a')
+  ).type.toBe<MapOf<{ a?: number | undefined; b?: string | undefined }>>();
+
+  expect(
+    Map<{ a: number; b?: string }>({ a: 1, b: 'b' }).remove('b').get('a')
+  ).type.toBe<number>();
+
+  expect(
+    Map<{ a: number; b?: string }>({ a: 1, b: 'b' }).remove('b').get('b')
+  ).type.toBe<string | undefined>();
+});
+
+test.skip('#deleteAll', () => {
+  expect(Map<number, number>().deleteAll([0])).type.toBe<Map<number, number>>();
+
+  expect(Map<number, number>().deleteAll([0, 'a'])).type.toRaiseError();
+});
+
+test.skip('#deleteIn', () => {
+  expect(Map<number, number>().deleteIn([])).type.toBe<Map<number, number>>();
+});
+
+test.skip('#remove', () => {
+  expect(Map<number, number>().remove(0)).type.toBe<Map<number, number>>();
+
+  expect(Map<number, number>().remove('a')).type.toRaiseError();
+});
+
+test.skip('#removeAll', () => {
+  expect(Map<number, number>().removeAll([0])).type.toBe<Map<number, number>>();
+
+  expect(Map<number, number>().removeAll([0, 'a'])).type.toRaiseError();
+});
+
+test.skip('#removeIn', () => {
+  expect(Map<number, number>().removeIn([])).type.toBe<Map<number, number>>();
+});
+
+test.skip('#clear', () => {
+  expect(Map<number, number>().clear()).type.toBe<Map<number, number>>();
+
+  expect(Map().clear(10)).type.toRaiseError();
+});
+
+test.skip('#update', () => {
+  expect(Map().update((v) => 1)).type.toBe<number>();
+
+  expect(
+    Map<number, number>().update((v: Map<string> | undefined) => v)
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().update(0, (v: number | undefined) => 0)
+  ).type.toBe<Map<number, number>>();
+
+  expect(
+    Map<number, number>().update(0, (v: number | undefined) => v + 'a')
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().update(1, 10, (v: number | undefined) => 0)
+  ).type.toBe<Map<number, number>>();
+
+  expect(
+    Map<number, number>().update(1, 'a', (v: number | undefined) => 0)
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().update(1, 10, (v: number | undefined) => v + 'a')
+  ).type.toRaiseError();
+
+  expect(Map({ a: 1, b: 'b' }).update('c', (v) => v)).type.toRaiseError();
+
+  expect(Map({ a: 1, b: 'b' }).update('b', (v) => v.toUpperCase())).type.toBe<
+    MapOf<{ a: number; b: string }>
+  >();
+
+  expect(
+    Map({ a: 1, b: 'b' }).update('b', 'NSV', (v) => v.toUpperCase())
+  ).type.toBe<MapOf<{ a: number; b: string }>>();
+
+  expect(Map({ a: 1, b: 'b' }).update((v) => ({ a: 'a' }))).type.toRaiseError();
+
+  expect(
+    Map({ a: 1, b: 'b' }).update((v) => v.set('a', 2).set('b', 'B'))
+  ).type.toBe<MapOf<{ a: number; b: string }>>();
+
+  expect(
+    Map({ a: 1, b: 'b' }).update((v) => v.set('c', 'c'))
+  ).type.toRaiseError();
+
+  expect(
+    Map<string, string>().update('noKey', (ls) => ls?.toUpperCase())
+  ).type.toBe<Map<string, string>>();
+});
+
+test.skip('#updateIn', () => {
+  expect(Map<number, number>().updateIn([], (v) => v)).type.toBe<
+    Map<number, number>
+  >();
+
+  expect(Map<number, number>().updateIn([], 10)).type.toRaiseError();
+});
+
+test.skip('#map', () => {
+  expect(
+    Map<number, number>().map(
+      (value: number, key: number, iter: Map<number, number>) => 1
+    )
+  ).type.toBe<Map<number, number>>();
+
+  expect(
+    Map<number, number>().map(
+      (value: number, key: number, iter: Map<number, number>) => 'a'
+    )
+  ).type.toBe<Map<number, string>>();
+
+  expect(
+    Map<number, number>().map<number>(
+      (value: number, key: number, iter: Map<number, number>) => 1
+    )
+  ).type.toBe<Map<number, number>>();
+
+  expect(
+    Map<number, number>().map<string>(
+      (value: number, key: number, iter: Map<number, number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().map<number>(
+      (value: string, key: number, iter: Map<number, number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().map<number>(
+      (value: number, key: string, iter: Map<number, number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().map<number>(
+      (value: number, key: number, iter: Map<number, string>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().map<number>(
+      (value: number, key: number, iter: Map<number, number>) => 'a'
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#mapKeys', () => {
+  expect(
+    Map<number, number>().mapKeys(
+      (value: number, key: number, iter: Map<number, number>) => 1
+    )
+  ).type.toBe<Map<number, number>>();
+
+  expect(
+    Map<number, number>().mapKeys(
+      (value: number, key: number, iter: Map<number, number>) => 'a'
+    )
+  ).type.toBe<Map<string, number>>();
+
+  expect(
+    Map<number, number>().mapKeys<number>(
+      (value: number, key: number, iter: Map<number, number>) => 1
+    )
+  ).type.toBe<Map<number, number>>();
+
+  expect(
+    Map<number, number>().mapKeys<string>(
+      (value: number, key: number, iter: Map<number, number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().mapKeys<number>(
+      (value: string, key: number, iter: Map<number, number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().mapKeys<number>(
+      (value: number, key: string, iter: Map<number, number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().mapKeys<number>(
+      (value: number, key: number, iter: Map<number, string>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().mapKeys<number>(
+      (value: number, key: number, iter: Map<number, number>) => 'a'
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#flatMap', () => {
+  expect(
+    Map<number, number>().flatMap(
+      (value: number, key: number, iter: Map<number, number>) => [[0, 1]]
+    )
+  ).type.toBe<Map<number, number>>();
+
+  expect(
+    Map<number, number>().flatMap(
+      (value: number, key: number, iter: Map<number, number>) => [['a', 'b']]
+    )
+  ).type.toBe<Map<string, string>>();
+
+  expect(
+    Map<number, number>().flatMap<number, number>(
+      (value: number, key: number, iter: Map<number, number>) => [[0, 1]]
+    )
+  ).type.toBe<Map<number, number>>();
+
+  expect(
+    Map<number, number>().flatMap<number, string>(
+      (value: number, key: number, iter: Map<number, number>) => [[0, 1]]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().flatMap<number, number>(
+      (value: string, key: number, iter: Map<number, number>) => [[0, 1]]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().flatMap<number, number>(
+      (value: number, key: string, iter: Map<number, number>) => [[0, 1]]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().flatMap<number, number>(
+      (value: number, key: number, iter: Map<number, string>) => [[0, 1]]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().flatMap<number, number>(
+      (value: number, key: number, iter: Map<number, number>) => [[0, 'a']]
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#merge', () => {
+  expect(Map<string, number>().merge({ a: 1 })).type.toBe<
+    Map<string, number>
+  >();
+
+  expect(Map<string, number>().merge({ a: { b: 1 } })).type.toBe<
+    Map<string, number | { b: number }>
+  >();
+
+  expect(Map<number, number>().merge(Map<number, number>())).type.toBe<
+    Map<number, number>
+  >();
+
+  expect(Map<number, number>().merge(Map<number, string>())).type.toBe<
+    Map<number, string | number>
+  >();
+
+  expect(Map<number, number | string>().merge(Map<number, string>())).type.toBe<
+    Map<number, string | number>
+  >();
+
+  expect(Map<number, number | string>().merge(Map<number, number>())).type.toBe<
+    Map<number, string | number>
+  >();
+
+  expect(Map({ a: 1 }).merge(Map({ b: 2 }))).type.toBe<
+    Map<'b' | 'a', number>
+  >();
+});
+
+test.skip('#mergeIn', () => {
+  expect(Map<number, number>().mergeIn([], [])).type.toBe<
+    Map<number, number>
+  >();
+});
+
+test.skip('#mergeWith', () => {
+  expect(
+    Map<number, number>().mergeWith(
+      (prev: number, next: number, key: number) => 1,
+      Map<number, number>()
+    )
+  ).type.toBe<Map<number, number>>();
+
+  expect(
+    Map<number, number>().mergeWith(
+      (prev: string, next: number, key: number) => 1,
+      Map<number, number>()
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().mergeWith(
+      (prev: number, next: string, key: number) => 1,
+      Map<number, number>()
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().mergeWith(
+      (prev: number, next: number, key: string) => 1,
+      Map<number, number>()
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number>().mergeWith(
+      (prev: number, next: number, key: number) => 'a',
+      Map<number, number>()
+    )
+  ).type.toBe<Map<number, string | number>>();
+
+  expect(
+    Map<number, number>().mergeWith(
+      (prev: number, next: number, key: number) => 1,
+      Map<number, string>()
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<string, number>().mergeWith(
+      (prev: number, next: number, key: string) => 1,
+      { a: 1 }
+    )
+  ).type.toBe<Map<string, number>>();
+
+  expect(
+    Map<string, number>().mergeWith(
+      (prev: number, next: number, key: string) => 1,
+      { a: 'a' }
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<string, number>().mergeWith(
+      (prev: number, next: number | string, key: string) => 1,
+      { a: 'a' }
+    )
+  ).type.toBe<Map<string, string | number>>();
+
+  expect(
+    Map<number, number | string>().mergeWith(
+      (prev: number | string, next: number | string, key: number) => 1,
+      Map<number, string>()
+    )
+  ).type.toBe<Map<number, string | number>>();
+});
+
+test.skip('#mergeDeep', () => {
+  expect(Map<string, number>().mergeDeep({ a: 1 })).type.toBe<
+    Map<string, number>
+  >();
+
+  expect(Map<string, number>().mergeDeep({ a: { b: 1 } })).type.toBe<
+    Map<string, number | { b: number }>
+  >();
+
+  expect(Map<string, number>().mergeDeep(Map({ a: { b: 1 } }))).type.toBe<
+    Map<string, number | { b: number }>
+  >();
+
+  expect(Map<number, number>().mergeDeep(Map<number, number>())).type.toBe<
+    Map<number, number>
+  >();
+
+  expect(Map<number, number>().mergeDeep(Map<number, string>())).type.toBe<
+    Map<number, string | number>
+  >();
+
+  expect(
+    Map<number, number | string>().mergeDeep(Map<number, string>())
+  ).type.toBe<Map<number, string | number>>();
+
+  expect(
+    Map<number, number | string>().mergeDeep(Map<number, number>())
+  ).type.toBe<Map<number, string | number>>();
+});
+
+test.skip('#mergeDeepIn', () => {
+  expect(Map<number, number>().mergeDeepIn([], [])).type.toBe<
+    Map<number, number>
+  >();
+});
+
+test.skip('#mergeDeepWith', () => {
+  expect(
+    Map<number, number>().mergeDeepWith(
+      (prev: unknown, next: unknown, key: unknown) => 1,
+      Map<number, number>()
+    )
+  ).type.toBe<Map<number, number>>();
+
+  expect(
+    Map<number, number>().mergeDeepWith(
+      (prev: unknown, next: unknown, key: unknown) => 1,
+      Map<number, string>()
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<string, number>().mergeDeepWith(
+      (prev: unknown, next: unknown, key: unknown) => 1,
+      { a: 1 }
+    )
+  ).type.toBe<Map<string, number>>();
+
+  expect(
+    Map<string, number>().mergeDeepWith(
+      (prev: unknown, next: unknown, key: unknown) => 1,
+      { a: 'a' }
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Map<number, number | string>().mergeDeepWith(
+      (prev: unknown, next: unknown, key: unknown) => 1,
+      Map<number, string>()
+    )
+  ).type.toBe<Map<number, string | number>>();
+});
+
+test.skip('#flip', () => {
+  expect(Map<number, string>().flip()).type.toBe<Map<string, number>>();
+});
+
+test.skip('#sort', () => {
+  expect(Map<string, string>().sort()).type.toBe<
+    Map<string, string> & OrderedMap<string, string>
+  >();
+  expect(Map<string, string>().sort((a, b) => 1)).type.toBe<
+    Map<string, string> & OrderedMap<string, string>
+  >();
+
+  expect(Map({ a: 'a' }).sort()).type.toBe<
+    MapOf<{ a: string }> & OrderedMap<'a', string>
+  >();
+});
+
+test.skip('#sortBy', () => {
+  expect(Map<string, string>().sortBy((v) => v)).type.toBe<
+    Map<string, string> & OrderedMap<string, string>
+  >();
+
+  expect(
+    Map<string, string>().sortBy(
+      (v) => v,
+      (a, b) => 1
+    )
+  ).type.toBe<Map<string, string> & OrderedMap<string, string>>();
+  expect(Map({ a: 'a' }).sortBy((v) => v)).type.toBe<
+    MapOf<{ a: string }> & OrderedMap<'a', string>
+  >();
+});
+
+test.skip('#withMutations', () => {
+  expect(Map<number, number>().withMutations((mutable) => mutable)).type.toBe<
+    Map<number, number>
+  >();
+
+  expect(
+    Map<number, number>().withMutations((mutable: Map<string>) => mutable)
+  ).type.toRaiseError();
+});
+
+test.skip('#asMutable', () => {
+  expect(Map<number, number>().asMutable()).type.toBe<Map<number, number>>();
+});
+
+test.skip('#asImmutable', () => {
+  expect(Map<number, number>().asImmutable()).type.toBe<Map<number, number>>();
+});
+
+test.skip('#toJS', () => {
+  expect(Map<number, number>().toJS()).type.toBe<{
+    [x: string]: number;
+    [x: number]: number;
+    [x: symbol]: number;
+  }>();
+
+  expect(Map({ a: 'A' }).toJS()).type.toBe<{ a: string }>();
+
+  expect(Map({ a: Map({ b: 'b' }) }).toJS()).type.toBe<{
+    a: { b: string };
+  }>();
+});
+
+test.skip('#toJSON', () => {
+  expect(Map({ a: Map({ b: 'b' }) }).toJSON()).type.toBe<{
+    a: MapOf<{ b: string }>;
+  }>();
+});

--- a/type-definitions/ts-tests-src/ordered-map.ts
+++ b/type-definitions/ts-tests-src/ordered-map.ts
@@ -1,0 +1,511 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { List, OrderedMap } from 'immutable';
+import { expect, pick, test } from 'tstyche';
+
+test.skip('#constructor', () => {
+  expect(OrderedMap()).type.toBe<OrderedMap<unknown, unknown>>();
+
+  expect(OrderedMap<number, number>()).type.toBe<OrderedMap<number, number>>();
+
+  expect(OrderedMap([[1, 'a']])).type.toBe<OrderedMap<number, string>>();
+
+  expect(OrderedMap(List<[number, string]>([[1, 'a']]))).type.toBe<
+    OrderedMap<number, string>
+  >();
+
+  expect(OrderedMap({ a: 1 })).type.toBe<OrderedMap<string, number>>();
+
+  // No longer works in typescript@>=3.9
+  // // $ExpectError - TypeScript does not support Lists as tuples
+  // OrderedMap(List([List(['a', 'b'])]));
+});
+
+test.skip('#size', () => {
+  expect(pick(OrderedMap(), 'size')).type.toBe<{ readonly size: number }>();
+});
+
+test.skip('#get', () => {
+  expect(OrderedMap<number, number>().get(4)).type.toBe<number | undefined>();
+
+  expect(OrderedMap<number, number>().get(4, 'a')).type.toBe<number | 'a'>();
+
+  expect(OrderedMap<number, number>().get<number>(4, 'a')).type.toRaiseError();
+});
+
+test.skip('#set', () => {
+  expect(OrderedMap<number, number>().set(0, 0)).type.toBe<
+    OrderedMap<number, number>
+  >();
+
+  expect(OrderedMap<number, number>().set(1, 'a')).type.toRaiseError();
+
+  expect(OrderedMap<number, number>().set('a', 1)).type.toRaiseError();
+
+  expect(OrderedMap<number, number | string>().set(0, 1)).type.toBe<
+    OrderedMap<number, string | number>
+  >();
+
+  expect(OrderedMap<number, number | string>().set(0, 'a')).type.toBe<
+    OrderedMap<number, string | number>
+  >();
+});
+
+test.skip('#setIn', () => {
+  expect(OrderedMap<number, number>().setIn([], 0)).type.toBe<
+    OrderedMap<number, number>
+  >();
+});
+
+test.skip('#delete', () => {
+  expect(OrderedMap<number, number>().delete(0)).type.toBe<
+    OrderedMap<number, number>
+  >();
+
+  expect(OrderedMap<number, number>().delete('a')).type.toRaiseError();
+});
+
+test.skip('#deleteAll', () => {
+  expect(OrderedMap<number, number>().deleteAll([0])).type.toBe<
+    OrderedMap<number, number>
+  >();
+
+  expect(OrderedMap<number, number>().deleteAll([0, 'a'])).type.toRaiseError();
+});
+
+test.skip('#deleteIn', () => {
+  expect(OrderedMap<number, number>().deleteIn([])).type.toBe<
+    OrderedMap<number, number>
+  >();
+});
+
+test.skip('#remove', () => {
+  expect(OrderedMap<number, number>().remove(0)).type.toBe<
+    OrderedMap<number, number>
+  >();
+
+  expect(OrderedMap<number, number>().remove('a')).type.toRaiseError();
+});
+
+test.skip('#removeAll', () => {
+  expect(OrderedMap<number, number>().removeAll([0])).type.toBe<
+    OrderedMap<number, number>
+  >();
+
+  expect(OrderedMap<number, number>().removeAll([0, 'a'])).type.toRaiseError();
+});
+
+test.skip('#removeIn', () => {
+  expect(OrderedMap<number, number>().removeIn([])).type.toBe<
+    OrderedMap<number, number>
+  >();
+});
+
+test.skip('#clear', () => {
+  expect(OrderedMap<number, number>().clear()).type.toBe<
+    OrderedMap<number, number>
+  >();
+
+  expect(OrderedMap().clear(10)).type.toRaiseError();
+});
+
+test.skip('#update', () => {
+  expect(OrderedMap().update((v) => 1)).type.toBe<number>();
+
+  expect(
+    OrderedMap<number, number>().update(
+      (v: OrderedMap<string> | undefined) => v
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().update(0, (v: number | undefined) => 0)
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().update(0, (v: number | undefined) => v + 'a')
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().update(1, 10, (v: number | undefined) => 0)
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().update(1, 'a', (v: number | undefined) => 0)
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().update(
+      1,
+      10,
+      (v: number | undefined) => v + 'a'
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#updateIn', () => {
+  expect(OrderedMap<number, number>().updateIn([], (v) => v)).type.toBe<
+    OrderedMap<number, number>
+  >();
+
+  expect(OrderedMap<number, number>().updateIn([], 10)).type.toRaiseError();
+});
+
+test.skip('#map', () => {
+  expect(
+    OrderedMap<number, number>().map(
+      (value: number, key: number, iter: OrderedMap<number, number>) => 1
+    )
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().map(
+      (value: number, key: number, iter: OrderedMap<number, number>) => 'a'
+    )
+  ).type.toBe<OrderedMap<number, string>>();
+
+  expect(
+    OrderedMap<number, number>().map<number>(
+      (value: number, key: number, iter: OrderedMap<number, number>) => 1
+    )
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().map<string>(
+      (value: number, key: number, iter: OrderedMap<number, number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().map<number>(
+      (value: string, key: number, iter: OrderedMap<number, number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().map<number>(
+      (value: number, key: string, iter: OrderedMap<number, number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().map<number>(
+      (value: number, key: number, iter: OrderedMap<number, string>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().map<number>(
+      (value: number, key: number, iter: OrderedMap<number, number>) => 'a'
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#mapKeys', () => {
+  expect(
+    OrderedMap<number, number>().mapKeys(
+      (value: number, key: number, iter: OrderedMap<number, number>) => 1
+    )
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().mapKeys(
+      (value: number, key: number, iter: OrderedMap<number, number>) => 'a'
+    )
+  ).type.toBe<OrderedMap<string, number>>();
+
+  expect(
+    OrderedMap<number, number>().mapKeys<number>(
+      (value: number, key: number, iter: OrderedMap<number, number>) => 1
+    )
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().mapKeys<string>(
+      (value: number, key: number, iter: OrderedMap<number, number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().mapKeys<number>(
+      (value: string, key: number, iter: OrderedMap<number, number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().mapKeys<number>(
+      (value: number, key: string, iter: OrderedMap<number, number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().mapKeys<number>(
+      (value: number, key: number, iter: OrderedMap<number, string>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().mapKeys<number>(
+      (value: number, key: number, iter: OrderedMap<number, number>) => 'a'
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#flatMap', () => {
+  expect(
+    OrderedMap<number, number>().flatMap(
+      (value: number, key: number, iter: OrderedMap<number, number>) => [[0, 1]]
+    )
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().flatMap(
+      (value: number, key: number, iter: OrderedMap<number, number>) => [
+        ['a', 'b'],
+      ]
+    )
+  ).type.toBe<OrderedMap<string, string>>();
+
+  expect(
+    OrderedMap<number, number>().flatMap<number, number>(
+      (value: number, key: number, iter: OrderedMap<number, number>) => [[0, 1]]
+    )
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().flatMap<number, string>(
+      (value: number, key: number, iter: OrderedMap<number, number>) => [[0, 1]]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().flatMap<number, number>(
+      (value: string, key: number, iter: OrderedMap<number, number>) => [[0, 1]]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().flatMap<number, number>(
+      (value: number, key: string, iter: OrderedMap<number, number>) => [[0, 1]]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().flatMap<number, number>(
+      (value: number, key: number, iter: OrderedMap<number, string>) => [[0, 1]]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().flatMap<number, number>(
+      (value: number, key: number, iter: OrderedMap<number, number>) => [
+        [0, 'a'],
+      ]
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#merge', () => {
+  expect(OrderedMap<string, number>().merge({ a: 1 })).type.toBe<
+    OrderedMap<string, number>
+  >();
+
+  expect(OrderedMap<string, number>().merge({ a: { b: 1 } })).type.toBe<
+    OrderedMap<string, number | { b: number }>
+  >();
+
+  expect(
+    OrderedMap<number, number>().merge(OrderedMap<number, number>())
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().merge(OrderedMap<number, string>())
+  ).type.toBe<OrderedMap<number, string | number>>();
+
+  expect(
+    OrderedMap<number, number | string>().merge(OrderedMap<number, string>())
+  ).type.toBe<OrderedMap<number, string | number>>();
+
+  expect(
+    OrderedMap<number, number | string>().merge(OrderedMap<number, number>())
+  ).type.toBe<OrderedMap<number, string | number>>();
+});
+
+test.skip('#mergeIn', () => {
+  expect(OrderedMap<number, number>().mergeIn([], [])).type.toBe<
+    OrderedMap<number, number>
+  >();
+});
+
+test.skip('#mergeWith', () => {
+  expect(
+    OrderedMap<number, number>().mergeWith(
+      (prev: number, next: number, key: number) => 1,
+      OrderedMap<number, number>()
+    )
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().mergeWith(
+      (prev: string, next: number, key: number) => 1,
+      OrderedMap<number, number>()
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().mergeWith(
+      (prev: number, next: string, key: number) => 1,
+      OrderedMap<number, number>()
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().mergeWith(
+      (prev: number, next: number, key: string) => 1,
+      OrderedMap<number, number>()
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number>().mergeWith(
+      (prev: number, next: number, key: number) => 'a',
+      OrderedMap<number, number>()
+    )
+  ).type.toBe<OrderedMap<number, string | number>>();
+
+  expect(
+    OrderedMap<number, number>().mergeWith(
+      (prev: number, next: number, key: number) => 1,
+      OrderedMap<number, string>()
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<string, number>().mergeWith(
+      (prev: number, next: number, key: string) => 1,
+      { a: 1 }
+    )
+  ).type.toBe<OrderedMap<string, number>>();
+
+  expect(
+    OrderedMap<string, number>().mergeWith(
+      (prev: number, next: number, key: string) => 1,
+      { a: 'a' }
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number | string>().mergeWith(
+      (prev: number | string, next: number | string, key: number) => 1,
+      OrderedMap<number, string>()
+    )
+  ).type.toBe<OrderedMap<number, string | number>>();
+});
+
+test.skip('#mergeDeep', () => {
+  expect(OrderedMap<string, number>().mergeDeep({ a: 1 })).type.toBe<
+    OrderedMap<string, number>
+  >();
+
+  expect(OrderedMap<string, number>().mergeDeep({ a: { b: 1 } })).type.toBe<
+    OrderedMap<string, number | { b: number }>
+  >();
+
+  expect(
+    OrderedMap<number, number>().mergeDeep(OrderedMap<number, number>())
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().mergeDeep(OrderedMap<number, string>())
+  ).type.toBe<OrderedMap<number, string | number>>();
+
+  expect(
+    OrderedMap<number, number | string>().mergeDeep(
+      OrderedMap<number, string>()
+    )
+  ).type.toBe<OrderedMap<number, string | number>>();
+
+  expect(
+    OrderedMap<number, number | string>().mergeDeep(
+      OrderedMap<number, number>()
+    )
+  ).type.toBe<OrderedMap<number, string | number>>();
+});
+
+test.skip('#mergeDeepIn', () => {
+  expect(OrderedMap<number, number>().mergeDeepIn([], [])).type.toBe<
+    OrderedMap<number, number>
+  >();
+});
+
+test.skip('#mergeDeepWith', () => {
+  expect(
+    OrderedMap<number, number>().mergeDeepWith(
+      (prev: unknown, next: unknown, key: unknown) => 1,
+      OrderedMap<number, number>()
+    )
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().mergeDeepWith(
+      (prev: unknown, next: unknown, key: unknown) => 1,
+      OrderedMap<number, string>()
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<string, number>().mergeDeepWith(
+      (prev: unknown, next: unknown, key: unknown) => 1,
+      { a: 1 }
+    )
+  ).type.toBe<OrderedMap<string, number>>();
+
+  expect(
+    OrderedMap<string, number>().mergeDeepWith(
+      (prev: unknown, next: unknown, key: unknown) => 1,
+      { a: 'a' }
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedMap<number, number | string>().mergeDeepWith(
+      (prev: unknown, next: unknown, key: unknown) => 1,
+      OrderedMap<number, string>()
+    )
+  ).type.toBe<OrderedMap<number, string | number>>();
+});
+
+test.skip('#flip', () => {
+  expect(OrderedMap<number, string>().flip()).type.toBe<
+    OrderedMap<string, number>
+  >();
+});
+
+test.skip('#withMutations', () => {
+  expect(
+    OrderedMap<number, number>().withMutations((mutable) => mutable)
+  ).type.toBe<OrderedMap<number, number>>();
+
+  expect(
+    OrderedMap<number, number>().withMutations(
+      (mutable: OrderedMap<string>) => mutable
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#asMutable', () => {
+  expect(OrderedMap<number, number>().asMutable()).type.toBe<
+    OrderedMap<number, number>
+  >();
+});
+
+test.skip('#asImmutable', () => {
+  expect(OrderedMap<number, number>().asImmutable()).type.toBe<
+    OrderedMap<number, number>
+  >();
+});

--- a/type-definitions/ts-tests-src/ordered-set.ts
+++ b/type-definitions/ts-tests-src/ordered-set.ts
@@ -1,0 +1,285 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { Collection, Map, OrderedSet } from 'immutable';
+import { expect, pick, test } from 'tstyche';
+
+test.skip('#constructor', () => {
+  expect(OrderedSet()).type.toBe<OrderedSet<unknown>>();
+
+  expect(OrderedSet<number>()).type.toBe<OrderedSet<number>>();
+
+  expect(OrderedSet([1, 'a'])).type.toBe<OrderedSet<number | string>>();
+
+  expect(OrderedSet([1, 'a'])).type.not.toBeAssignableTo(OrderedSet<number>());
+});
+
+test.skip('#size', () => {
+  expect(pick(OrderedSet(), 'size')).type.toBe<{ readonly size: number }>();
+});
+
+test.skip('.of', () => {
+  expect(OrderedSet.of(1, 2, 3)).type.toBe<OrderedSet<number>>();
+
+  expect(OrderedSet.of<number>('a', 1)).type.toRaiseError();
+
+  expect(OrderedSet.of<number | string>('a', 1)).type.toBe<
+    OrderedSet<string | number>
+  >();
+});
+
+test.skip('.fromKeys', () => {
+  expect(OrderedSet.fromKeys(Map<number, string>())).type.toBe<
+    OrderedSet<number>
+  >();
+
+  expect(OrderedSet.fromKeys<number>(Map<number, string>())).type.toBe<
+    OrderedSet<number>
+  >();
+
+  expect(OrderedSet.fromKeys({ a: 1 })).type.toBe<OrderedSet<string>>();
+
+  expect(
+    OrderedSet.fromKeys<number>(Map<string, string>())
+  ).type.toRaiseError();
+
+  expect(
+    OrderedSet.fromKeys<number | string>(Map<number | string, string>())
+  ).type.toBe<OrderedSet<string | number>>();
+});
+
+test.skip('#get', () => {
+  expect(OrderedSet<number>().get(4)).type.toBe<number | undefined>();
+
+  expect(OrderedSet<number>().get(4, 'a')).type.toBe<number | 'a'>();
+
+  expect(OrderedSet<number>().get<number>(4, 'a')).type.toRaiseError();
+});
+
+test.skip('#delete', () => {
+  expect(OrderedSet<number>().delete(0)).type.toBe<OrderedSet<number>>();
+
+  expect(OrderedSet<number>().delete('a')).type.toRaiseError();
+});
+
+test.skip('#remove', () => {
+  expect(OrderedSet<number>().remove(0)).type.toBe<OrderedSet<number>>();
+
+  expect(OrderedSet<number>().remove('a')).type.toRaiseError();
+});
+
+test.skip('#clear', () => {
+  expect(OrderedSet<number>().clear()).type.toBe<OrderedSet<number>>();
+
+  expect(OrderedSet().clear(10)).type.toRaiseError();
+});
+
+test.skip('#map', () => {
+  expect(
+    OrderedSet<number>().map(
+      (value: number, key: number, iter: OrderedSet<number>) => 1
+    )
+  ).type.toBe<OrderedSet<number>>();
+
+  expect(
+    OrderedSet<number>().map(
+      (value: number, key: number, iter: OrderedSet<number>) => 'a'
+    )
+  ).type.toBe<OrderedSet<string>>();
+
+  expect(
+    OrderedSet<number>().map<number>(
+      (value: number, key: number, iter: OrderedSet<number>) => 1
+    )
+  ).type.toBe<OrderedSet<number>>();
+
+  expect(
+    OrderedSet<number>().map<string>(
+      (value: number, key: number, iter: OrderedSet<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedSet<number>().map<number>(
+      (value: string, key: number, iter: OrderedSet<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedSet<number>().map<number>(
+      (value: number, key: string, iter: OrderedSet<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedSet<number>().map<number>(
+      (value: number, key: number, iter: OrderedSet<string>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedSet<number>().map<number>(
+      (value: number, key: number, iter: OrderedSet<number>) => 'a'
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#flatMap', () => {
+  expect(
+    OrderedSet<number>().flatMap(
+      (value: number, key: number, iter: OrderedSet<number>) => [1]
+    )
+  ).type.toBe<OrderedSet<number>>();
+
+  expect(
+    OrderedSet<number>().flatMap(
+      (value: number, key: number, iter: OrderedSet<number>) => ['a']
+    )
+  ).type.toBe<OrderedSet<string>>();
+
+  expect(
+    OrderedSet<number>().flatMap<number>(
+      (value: number, key: number, iter: OrderedSet<number>) => [1]
+    )
+  ).type.toBe<OrderedSet<number>>();
+
+  expect(
+    OrderedSet<number>().flatMap<string>(
+      (value: number, key: number, iter: OrderedSet<number>) => [1]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedSet<number>().flatMap<number>(
+      (value: string, key: number, iter: OrderedSet<number>) => [1]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedSet<number>().flatMap<number>(
+      (value: number, key: string, iter: OrderedSet<number>) => [1]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedSet<number>().flatMap<number>(
+      (value: number, key: number, iter: OrderedSet<string>) => [1]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    OrderedSet<number>().flatMap<number>(
+      (value: number, key: number, iter: OrderedSet<number>) => ['a']
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#union', () => {
+  expect(OrderedSet<number>().union(OrderedSet<number>())).type.toBe<
+    OrderedSet<number>
+  >();
+
+  expect(OrderedSet<number>().union(OrderedSet<string>())).type.toBe<
+    OrderedSet<string | number>
+  >();
+
+  expect(OrderedSet<number | string>().union(OrderedSet<string>())).type.toBe<
+    OrderedSet<string | number>
+  >();
+
+  expect(OrderedSet<number | string>().union(OrderedSet<number>())).type.toBe<
+    OrderedSet<string | number>
+  >();
+});
+
+test.skip('#merge', () => {
+  expect(OrderedSet<number>().merge(OrderedSet<number>())).type.toBe<
+    OrderedSet<number>
+  >();
+
+  expect(OrderedSet<number>().merge(OrderedSet<string>())).type.toBe<
+    OrderedSet<string | number>
+  >();
+
+  expect(OrderedSet<number | string>().merge(OrderedSet<string>())).type.toBe<
+    OrderedSet<string | number>
+  >();
+
+  expect(OrderedSet<number | string>().merge(OrderedSet<number>())).type.toBe<
+    OrderedSet<string | number>
+  >();
+});
+
+test.skip('#intersect', () => {
+  expect(OrderedSet<number>().intersect(OrderedSet<number>())).type.toBe<
+    OrderedSet<number>
+  >();
+
+  expect(
+    OrderedSet<number>().intersect(OrderedSet<string>())
+  ).type.toRaiseError();
+
+  expect(
+    OrderedSet<number | string>().intersect(OrderedSet<string>())
+  ).type.toBe<OrderedSet<string | number>>();
+
+  expect(
+    OrderedSet<number | string>().intersect(OrderedSet<number>())
+  ).type.toBe<OrderedSet<string | number>>();
+});
+
+test.skip('#subtract', () => {
+  expect(OrderedSet<number>().subtract(OrderedSet<number>())).type.toBe<
+    OrderedSet<number>
+  >();
+
+  expect(
+    OrderedSet<number>().subtract(OrderedSet<string>())
+  ).type.toRaiseError();
+
+  expect(
+    OrderedSet<number | string>().subtract(OrderedSet<string>())
+  ).type.toBe<OrderedSet<string | number>>();
+
+  expect(
+    OrderedSet<number | string>().subtract(OrderedSet<number>())
+  ).type.toBe<OrderedSet<string | number>>();
+});
+
+test.skip('#flatten', () => {
+  expect(OrderedSet<number>().flatten()).type.toBe<
+    Collection<unknown, unknown>
+  >();
+
+  expect(OrderedSet<number>().flatten(10)).type.toBe<
+    Collection<unknown, unknown>
+  >();
+
+  expect(OrderedSet<number>().flatten(false)).type.toBe<
+    Collection<unknown, unknown>
+  >();
+
+  expect(OrderedSet<number>().flatten('a')).type.toRaiseError();
+});
+
+test.skip('#withMutations', () => {
+  expect(OrderedSet<number>().withMutations((mutable) => mutable)).type.toBe<
+    OrderedSet<number>
+  >();
+
+  expect(
+    OrderedSet<number>().withMutations((mutable: OrderedSet<string>) => mutable)
+  ).type.toRaiseError();
+});
+
+test.skip('#asMutable', () => {
+  expect(OrderedSet<number>().asMutable()).type.toBe<OrderedSet<number>>();
+});
+
+test.skip('#asImmutable', () => {
+  expect(OrderedSet<number>().asImmutable()).type.toBe<OrderedSet<number>>();
+});

--- a/type-definitions/ts-tests-src/partition.ts
+++ b/type-definitions/ts-tests-src/partition.ts
@@ -1,0 +1,191 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import {
+  Collection,
+  List,
+  Map,
+  OrderedMap,
+  OrderedSet,
+  Seq,
+  Set,
+} from 'immutable';
+import { expect, test } from 'tstyche';
+
+abstract class A {}
+class B extends A {}
+
+test.skip('Collection', () => {
+  type Indexed<T> = Collection.Indexed<T>;
+  type Keyed<K, V> = Collection.Keyed<K, V>;
+  type Set<T> = Collection.Set<T>;
+
+  (c: Collection<string, number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<
+      [Collection<string, number>, Collection<string, number>]
+    >();
+  };
+
+  (c: Collection<string, A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [Collection<string, A>, Collection<string, B>]
+    >();
+  };
+
+  (c: Keyed<string, number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<
+      [Keyed<string, number>, Keyed<string, number>]
+    >();
+  };
+
+  (c: Keyed<string, A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [Keyed<string, A>, Keyed<string, B>]
+    >();
+  };
+
+  (c: Indexed<number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<
+      [Indexed<number>, Indexed<number>]
+    >();
+  };
+
+  (c: Indexed<A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [Indexed<A>, Indexed<B>]
+    >();
+  };
+
+  (c: Set<number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<[Set<number>, Set<number>]>();
+  };
+
+  (c: Set<A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [Set<A>, Set<B>]
+    >();
+  };
+});
+
+test.skip('Seq', () => {
+  type Indexed<T> = Seq.Indexed<T>;
+  type Keyed<K, V> = Seq.Keyed<K, V>;
+  type Set<T> = Seq.Set<T>;
+
+  (c: Seq<string, number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<
+      [Seq<string, number>, Seq<string, number>]
+    >();
+  };
+
+  (c: Seq<string, A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [Seq<string, A>, Seq<string, B>]
+    >();
+  };
+
+  (c: Keyed<string, number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<
+      [Keyed<string, number>, Keyed<string, number>]
+    >();
+  };
+
+  (c: Keyed<string, A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [Keyed<string, A>, Keyed<string, B>]
+    >();
+  };
+
+  (c: Indexed<number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<
+      [Indexed<number>, Indexed<number>]
+    >();
+  };
+
+  (c: Indexed<A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [Indexed<A>, Indexed<B>]
+    >();
+  };
+
+  (c: Set<number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<[Set<number>, Set<number>]>();
+  };
+
+  (c: Set<A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [Set<A>, Set<B>]
+    >();
+  };
+});
+
+test.skip('Map', () => {
+  (c: Map<string, number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<
+      [Map<string, number>, Map<string, number>]
+    >();
+  };
+
+  (c: Map<string, A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [Map<string, A>, Map<string, B>]
+    >();
+  };
+});
+
+test.skip('OrderedMap', () => {
+  (c: OrderedMap<string, number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<
+      [OrderedMap<string, number>, OrderedMap<string, number>]
+    >();
+  };
+
+  (c: OrderedMap<string, A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [OrderedMap<string, A>, OrderedMap<string, B>]
+    >();
+  };
+});
+
+test.skip('List', () => {
+  (c: List<number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<[List<number>, List<number>]>();
+  };
+
+  (c: List<A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [List<A>, List<B>]
+    >();
+  };
+});
+
+test.skip('Set', () => {
+  (c: Set<number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<[Set<number>, Set<number>]>();
+  };
+
+  (c: Set<A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [Set<A>, Set<B>]
+    >();
+  };
+});
+
+test.skip('OrderedSet', () => {
+  (c: OrderedSet<number>) => {
+    expect(c.partition((x) => x % 2)).type.toBe<
+      [OrderedSet<number>, OrderedSet<number>]
+    >();
+  };
+
+  (c: OrderedSet<A>) => {
+    expect(c.partition((x): x is B => x instanceof B)).type.toBe<
+      [OrderedSet<A>, OrderedSet<B>]
+    >();
+  };
+});

--- a/type-definitions/ts-tests-src/range.ts
+++ b/type-definitions/ts-tests-src/range.ts
@@ -1,0 +1,19 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { Range, Seq } from 'immutable';
+import { expect, test } from 'tstyche';
+
+test.skip('#constructor', () => {
+  expect(Range(0, 0, 1)).type.toBe<Seq.Indexed<number>>();
+
+  expect(Range('a', 0, 0)).type.toRaiseError();
+
+  expect(Range()).type.toRaiseError();
+
+  expect(Range(1)).type.toRaiseError();
+});

--- a/type-definitions/ts-tests-src/record.ts
+++ b/type-definitions/ts-tests-src/record.ts
@@ -1,0 +1,115 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { List, Map, Record, Set } from 'immutable';
+import { expect, pick, test } from 'tstyche';
+
+test.skip('Factory', () => {
+  const PointXY = Record({ x: 0, y: 0 });
+
+  expect(PointXY).type.toBe<Record.Factory<{ x: number; y: number }>>();
+
+  expect(PointXY({ x: 'a' })).type.toRaiseError();
+
+  const pointXY = PointXY();
+
+  expect(pointXY).type.toBe<
+    Record<{ x: number; y: number }> & Readonly<{ x: number; y: number }>
+  >();
+
+  expect(pick(pointXY, 'x')).type.toBe<{ readonly x: number }>();
+
+  expect(pick(pointXY, 'y')).type.toBe<{ readonly y: number }>();
+
+  expect(pointXY.toJS()).type.toBe<{ x: number; y: number }>();
+
+  class PointClass extends PointXY {
+    setX(x: number) {
+      return this.set('x', x);
+    }
+
+    setY(y: number) {
+      return this.set('y', y);
+    }
+  }
+
+  const point = new PointClass();
+
+  expect(point).type.toBe<PointClass>();
+
+  expect(point.x).type.toBe<number>();
+
+  expect(point.y).type.toBe<number>();
+
+  expect(point.setX(10)).type.toBe<PointClass>();
+
+  expect(point.setY(10)).type.toBe<PointClass>();
+
+  expect(point.toJSON()).type.toBe<{ x: number; y: number }>();
+
+  expect(point.toJS()).type.toBe<{ x: number; y: number }>();
+});
+
+test.skip('.getDescriptiveName', () => {
+  const PointXY = Record({ x: 0, y: 0 });
+
+  expect(Record.getDescriptiveName(PointXY())).type.toBe<string>();
+
+  expect(Record.getDescriptiveName({})).type.toRaiseError();
+});
+
+test.skip('Factory', () => {
+  const WithMap = Record({
+    map: Map({ a: 'A' }),
+    list: List(['a']),
+    set: Set(['a']),
+  });
+
+  const withMap = WithMap();
+
+  expect(withMap.toJSON()).type.toBe<{
+    map: MapOf<{ a: string }>;
+    list: List<string>;
+    set: Set<string>;
+  }>();
+
+  // should be `{ map: { a: string; }; list: string[]; set: string[]; }` but there is an issue with circular references
+  expect(withMap.toJS()).type.toBe<{
+    map: unknown;
+    list: unknown;
+    set: unknown;
+  }>();
+});
+
+test.skip('optional properties', () => {
+  interface Size {
+    distance: string;
+  }
+
+  const Line = Record<{ size?: Size; color?: string }>({
+    size: undefined,
+    color: 'red',
+  });
+
+  const line = Line({});
+
+  // should be  { size?: { distance: string; } | undefined; color?: string | undefined; } but there is an issue with circular references
+  expect(line.toJS()).type.toBe<{
+    size?: unknown;
+    color?: string | undefined;
+  }>();
+});
+
+test.skip('similar properties, but one is optional', () => {
+  // see https://github.com/immutable-js/immutable-js/issues/1930
+
+  interface Id {
+    value: string;
+  }
+
+  expect<RecordOf<{ id: Id }>>().type.toBeAssignableTo<RecordOf<{ id?: Id }>>();
+});

--- a/type-definitions/ts-tests-src/repeat.ts
+++ b/type-definitions/ts-tests-src/repeat.ts
@@ -1,0 +1,17 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { Repeat, Seq } from 'immutable';
+import { expect, test } from 'tstyche';
+
+test.skip('#constructor', () => {
+  expect(Repeat(0, 0)).type.toBe<Seq.Indexed<number>>();
+
+  expect(Repeat('a', 0)).type.toBe<Seq.Indexed<string>>();
+
+  expect(Repeat('a', 'b')).type.toRaiseError();
+});

--- a/type-definitions/ts-tests-src/seq.ts
+++ b/type-definitions/ts-tests-src/seq.ts
@@ -1,0 +1,33 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { Seq } from 'immutable';
+import { expect, pick, test } from 'tstyche';
+
+test.skip('#constructor', () => {
+  expect(Seq([1, 2, 3])).type.toBe<Seq.Indexed<number>>();
+});
+
+test.skip('#size', () => {
+  expect(pick(Seq(), 'size')).type.toBe<{
+    readonly size: number | undefined;
+  }>();
+});
+
+test.skip('Set.Indexed concat', () => {
+  const s: Seq.Indexed<number> = Seq([1]);
+  expect(s).type.toBe<Seq.Indexed<number>>();
+  expect(s.concat([4, 5, 6])).type.toBe<Seq.Indexed<number>>();
+  expect(s.concat(Seq([4, 5, 6]))).type.toBe<Seq.Indexed<number>>();
+});
+
+test.skip('Set concat', () => {
+  const s: Seq<unknown, unknown> = Seq([1]);
+  expect(s).type.toBe<Seq<unknown, unknown>>();
+  expect(s.concat([4, 5, 6])).type.toBe<Seq<unknown, unknown>>();
+  expect(s.concat(Seq([4, 5, 6]))).type.toBe<Seq<unknown, unknown>>();
+});

--- a/type-definitions/ts-tests-src/set.ts
+++ b/type-definitions/ts-tests-src/set.ts
@@ -1,0 +1,281 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { Collection, Map, OrderedSet, Set } from 'immutable';
+import { expect, pick, test } from 'tstyche';
+
+test.skip('#constructor', () => {
+  expect(Set()).type.toBe<Set<unknown>>();
+
+  expect(Set<number>()).type.toBe<Set<number>>();
+
+  expect(Set([1, 'a'])).type.toBe<Set<number | string>>();
+
+  expect(Set([1, 'a'])).type.not.toBeAssignableTo<Set<number>>();
+});
+
+test.skip('#size', () => {
+  expect(pick(Set(), 'size')).type.toBe<{ readonly size: number }>();
+});
+
+test.skip('.of', () => {
+  expect(Set.of(1, 2, 3)).type.toBe<Set<number>>();
+
+  expect(Set.of<number>('a', 1)).type.toRaiseError();
+
+  expect(Set.of<number | string>('a', 1)).type.toBe<Set<string | number>>();
+});
+
+test.skip('.fromKeys', () => {
+  expect(Set.fromKeys(Map<number, string>())).type.toBe<Set<number>>();
+
+  expect(Set.fromKeys<number>(Map<number, string>())).type.toBe<Set<number>>();
+
+  expect(Set.fromKeys({ a: 1 })).type.toBe<Set<string>>();
+
+  expect(Set.fromKeys<number>(Map<string, string>())).type.toRaiseError();
+
+  expect(
+    Set.fromKeys<number | string>(Map<number | string, string>())
+  ).type.toBe<Set<string | number>>();
+});
+
+test.skip('#get', () => {
+  expect(Set<number>().get(4)).type.toBe<number | undefined>();
+
+  expect(Set<number>().get(4, 'a')).type.toBe<number | 'a'>();
+
+  expect(Set<number>().get<number>(4, 'a')).type.toRaiseError();
+});
+
+test.skip('#delete', () => {
+  expect(Set<number>().delete(0)).type.toBe<Set<number>>();
+
+  expect(Set<number>().delete('a')).type.toRaiseError();
+});
+
+test.skip('#remove', () => {
+  expect(Set<number>().remove(0)).type.toBe<Set<number>>();
+
+  expect(Set<number>().remove('a')).type.toRaiseError();
+});
+
+test.skip('#clear', () => {
+  expect(Set<number>().clear()).type.toBe<Set<number>>();
+
+  expect(Set().clear(10)).type.toRaiseError();
+});
+
+test.skip('#map', () => {
+  expect(
+    Set<number>().map((value: number, key: number, iter: Set<number>) => 1)
+  ).type.toBe<Set<number>>();
+
+  expect(
+    Set<number>().map((value: number, key: number, iter: Set<number>) => 'a')
+  ).type.toBe<Set<string>>();
+
+  expect(
+    Set<number>().map<number>(
+      (value: number, key: number, iter: Set<number>) => 1
+    )
+  ).type.toBe<Set<number>>();
+
+  expect(
+    Set<number>().map<string>(
+      (value: number, key: number, iter: Set<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Set<number>().map<number>(
+      (value: string, key: number, iter: Set<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Set<number>().map<number>(
+      (value: number, key: string, iter: Set<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Set<number>().map<number>(
+      (value: number, key: number, iter: Set<string>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Set<number>().map<number>(
+      (value: number, key: number, iter: Set<number>) => 'a'
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#flatMap', () => {
+  expect(
+    Set<number>().flatMap((value: number, key: number, iter: Set<number>) => [
+      1,
+    ])
+  ).type.toBe<Set<number>>();
+
+  expect(
+    Set<number>().flatMap((value: number, key: number, iter: Set<number>) => [
+      'a',
+    ])
+  ).type.toBe<Set<string>>();
+
+  expect(
+    Set<number>().flatMap<number>(
+      (value: number, key: number, iter: Set<number>) => [1]
+    )
+  ).type.toBe<Set<number>>();
+
+  expect(
+    Set<number>().flatMap<string>(
+      (value: number, key: number, iter: Set<number>) => [1]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Set<number>().flatMap<number>(
+      (value: string, key: number, iter: Set<number>) => [1]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Set<number>().flatMap<number>(
+      (value: number, key: string, iter: Set<number>) => [1]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Set<number>().flatMap<number>(
+      (value: number, key: number, iter: Set<string>) => [1]
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Set<number>().flatMap<number>(
+      (value: number, key: number, iter: Set<number>) => ['a']
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#union', () => {
+  expect(Set<number>().union(Set<number>())).type.toBe<Set<number>>();
+
+  expect(Set<number>().union(Set<string>())).type.toBe<Set<string | number>>();
+
+  expect(Set<number | string>().union(Set<string>())).type.toBe<
+    Set<string | number>
+  >();
+
+  expect(Set<number | string>().union(Set<number>())).type.toBe<
+    Set<string | number>
+  >();
+});
+
+test.skip('#merge', () => {
+  expect(Set<number>().merge(Set<number>())).type.toBe<Set<number>>();
+
+  expect(Set<number>().merge(Set<string>())).type.toBe<Set<string | number>>();
+
+  expect(Set<number | string>().merge(Set<string>())).type.toBe<
+    Set<string | number>
+  >();
+
+  expect(Set<number | string>().merge(Set<number>())).type.toBe<
+    Set<string | number>
+  >();
+});
+
+test.skip('#intersect', () => {
+  expect(Set<number>().intersect(Set<number>())).type.toBe<Set<number>>();
+
+  expect(Set<number>().intersect(Set<string>())).type.toRaiseError();
+
+  expect(Set<number | string>().intersect(Set<string>())).type.toBe<
+    Set<string | number>
+  >();
+
+  expect(Set<number | string>().intersect(Set<number>())).type.toBe<
+    Set<string | number>
+  >();
+});
+
+test.skip('#subtract', () => {
+  expect(Set<number>().subtract(Set<number>())).type.toBe<Set<number>>();
+
+  expect(Set<number>().subtract(Set<string>())).type.toRaiseError();
+
+  expect(Set<number | string>().subtract(Set<string>())).type.toBe<
+    Set<string | number>
+  >();
+
+  expect(Set<number | string>().subtract(Set<number>())).type.toBe<
+    Set<string | number>
+  >();
+});
+
+test.skip('#flatten', () => {
+  expect(Set<number>().flatten()).type.toBe<Collection<unknown, unknown>>();
+
+  expect(Set<number>().flatten(10)).type.toBe<Collection<unknown, unknown>>();
+
+  expect(Set<number>().flatten(false)).type.toBe<
+    Collection<unknown, unknown>
+  >();
+
+  expect(Set<number>().flatten('a')).type.toRaiseError();
+});
+
+test.skip('#sort', () => {
+  expect(Set<string>().sort()).type.toBe<Set<string> & OrderedSet<string>>();
+  expect(Set<string>().sort((a, b) => 1)).type.toBe<
+    Set<string> & OrderedSet<string>
+  >();
+});
+
+test.skip('#sortBy', () => {
+  expect(Set<string>().sortBy((v) => v)).type.toBe<
+    Set<string> & OrderedSet<string>
+  >();
+
+  expect(
+    Set<string>().sortBy(
+      (v) => v,
+      (a, b) => 1
+    )
+  ).type.toBe<Set<string> & OrderedSet<string>>();
+});
+
+test.skip('#withMutations', () => {
+  expect(Set<number>().withMutations((mutable) => mutable)).type.toBe<
+    Set<number>
+  >();
+
+  expect(
+    Set<number>().withMutations((mutable: Set<string>) => mutable)
+  ).type.toRaiseError();
+});
+
+test.skip('#asMutable', () => {
+  expect(Set<number>().asMutable()).type.toBe<Set<number>>();
+});
+
+test.skip('#asImmutable', () => {
+  expect(Set<number>().asImmutable()).type.toBe<Set<number>>();
+});
+
+test.skip('#toJS', () => {
+  expect(Set<Set<number>>().toJS()).type.toBe<number[][]>();
+});
+
+test.skip('#toJSON', () => {
+  expect(Set<Set<number>>().toJSON()).type.toBe<Set<number>[]>();
+});

--- a/type-definitions/ts-tests-src/stack.ts
+++ b/type-definitions/ts-tests-src/stack.ts
@@ -1,0 +1,233 @@
+// AUTO/SOURCE-PASS DUPLICATE of ../ts-tests/<same name>.
+// Resolves `immutable` against the TS SOURCE (src/Immutable.js), to validate the
+// types emitted by the migration. Tests are `.skip` until the underlying
+// collection/method is migrated to TS; un-skip them as migration progresses.
+// Some d.ts-only types (MapOf, RecordOf, DeepCopy) are omitted from imports
+// until they exist in the source. See .agents/commands/migrate-to-ts.md.
+
+import { Collection, Stack } from 'immutable';
+import { expect, pick, test } from 'tstyche';
+
+test.skip('#constructor', () => {
+  expect(Stack()).type.toBe<Stack<unknown>>();
+
+  expect(Stack<number>()).type.toBe<Stack<number>>();
+
+  expect(Stack([1, 'a'])).type.toBe<Stack<number | string>>();
+});
+
+test.skip('#size', () => {
+  expect(pick(Stack(), 'size')).type.toBe<{ readonly size: number }>();
+});
+
+test.skip('.of', () => {
+  expect(Stack.of(1, 2, 3)).type.toBe<Stack<number>>();
+
+  expect(Stack.of<number>('a', 1)).type.toRaiseError();
+
+  expect(Stack.of<number | string>('a', 1)).type.toBe<Stack<string | number>>();
+});
+
+test.skip('#peek', () => {
+  expect(Stack<number>().peek()).type.toBe<number | undefined>();
+});
+
+test.skip('#push', () => {
+  expect(Stack<number>().push(0)).type.toBe<Stack<number>>();
+
+  expect(Stack<number>().push('a')).type.toRaiseError();
+
+  expect(Stack<number | string>().push(0)).type.toBe<Stack<string | number>>();
+
+  expect(Stack<number | string>().push('a')).type.toBe<
+    Stack<string | number>
+  >();
+});
+
+test.skip('#pushAll', () => {
+  expect(Stack<number>().pushAll([0])).type.toBe<Stack<number>>();
+
+  expect(Stack<number>().pushAll(['a'])).type.toRaiseError();
+
+  expect(Stack<number | string>().pushAll([0])).type.toBe<
+    Stack<string | number>
+  >();
+
+  expect(Stack<number | string>().pushAll(['a'])).type.toBe<
+    Stack<string | number>
+  >();
+});
+
+test.skip('#unshift', () => {
+  expect(Stack<number>().unshift(0)).type.toBe<Stack<number>>();
+
+  expect(Stack<number>().unshift('a')).type.toRaiseError();
+
+  expect(Stack<number | string>().unshift(0)).type.toBe<
+    Stack<string | number>
+  >();
+
+  expect(Stack<number | string>().unshift('a')).type.toBe<
+    Stack<string | number>
+  >();
+});
+
+test.skip('#unshiftAll', () => {
+  expect(Stack<number>().unshiftAll([0])).type.toBe<Stack<number>>();
+
+  expect(Stack<number>().unshiftAll(['a'])).type.toRaiseError();
+
+  expect(Stack<number | string>().unshiftAll([1])).type.toBe<
+    Stack<string | number>
+  >();
+
+  expect(Stack<number | string>().unshiftAll(['a'])).type.toBe<
+    Stack<string | number>
+  >();
+});
+
+test.skip('#clear', () => {
+  expect(Stack<number>().clear()).type.toBe<Stack<number>>();
+
+  expect(Stack().clear(10)).type.toRaiseError();
+});
+
+test.skip('#pop', () => {
+  expect(Stack<number>().pop()).type.toBe<Stack<number>>();
+
+  expect(Stack().pop(10)).type.toRaiseError();
+});
+
+test.skip('#shift', () => {
+  expect(Stack<number>().shift()).type.toBe<Stack<number>>();
+
+  expect(Stack().shift(10)).type.toRaiseError();
+});
+
+test.skip('#map', () => {
+  expect(
+    Stack<number>().map((value: number, key: number, iter: Stack<number>) => 1)
+  ).type.toBe<Stack<number>>();
+
+  expect(
+    Stack<number>().map(
+      (value: number, key: number, iter: Stack<number>) => 'a'
+    )
+  ).type.toBe<Stack<string>>();
+
+  expect(
+    Stack<number>().map<number>(
+      (value: number, key: number, iter: Stack<number>) => 1
+    )
+  ).type.toBe<Stack<number>>();
+
+  expect(
+    Stack<number>().map<string>(
+      (value: number, key: number, iter: Stack<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Stack<number>().map<number>(
+      (value: string, key: number, iter: Stack<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Stack<number>().map<number>(
+      (value: number, key: string, iter: Stack<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Stack<number>().map<number>(
+      (value: number, key: number, iter: Stack<string>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Stack<number>().map<number>(
+      (value: number, key: number, iter: Stack<number>) => 'a'
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#flatMap', () => {
+  expect(
+    Stack<number>().flatMap(
+      (value: number, key: number, iter: Stack<number>) => [1]
+    )
+  ).type.toBe<Stack<number>>();
+
+  expect(
+    Stack<number>().flatMap(
+      (value: number, key: number, iter: Stack<number>) => 'a'
+    )
+  ).type.toBe<Stack<string>>();
+
+  expect(
+    Stack<number>().flatMap<number>(
+      (value: number, key: number, iter: Stack<number>) => [1]
+    )
+  ).type.toBe<Stack<number>>();
+
+  expect(
+    Stack<number>().flatMap<string>(
+      (value: number, key: number, iter: Stack<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Stack<number>().flatMap<number>(
+      (value: string, key: number, iter: Stack<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Stack<number>().flatMap<number>(
+      (value: number, key: string, iter: Stack<number>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Stack<number>().flatMap<number>(
+      (value: number, key: number, iter: Stack<string>) => 1
+    )
+  ).type.toRaiseError();
+
+  expect(
+    Stack<number>().flatMap<number>(
+      (value: number, key: number, iter: Stack<number>) => 'a'
+    )
+  ).type.toRaiseError();
+});
+
+test.skip('#flatten', () => {
+  expect(Stack<number>().flatten()).type.toBe<Collection<unknown, unknown>>();
+
+  expect(Stack<number>().flatten(10)).type.toBe<Collection<unknown, unknown>>();
+
+  expect(Stack<number>().flatten(false)).type.toBe<
+    Collection<unknown, unknown>
+  >();
+
+  expect(Stack<number>().flatten('a')).type.toRaiseError();
+});
+
+test.skip('#withMutations', () => {
+  expect(Stack<number>().withMutations((mutable) => mutable)).type.toBe<
+    Stack<number>
+  >();
+
+  expect(
+    Stack<number>().withMutations((mutable: Stack<string>) => mutable)
+  ).type.toRaiseError();
+});
+
+test.skip('#asMutable', () => {
+  expect(Stack<number>().asMutable()).type.toBe<Stack<number>>();
+});
+
+test.skip('#asImmutable', () => {
+  expect(Stack<number>().asImmutable()).type.toBe<Stack<number>>();
+});

--- a/type-definitions/ts-tests-src/tsconfig.json
+++ b/type-definitions/ts-tests-src/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": [],
+    "baseUrl": "./",
+    "paths": {
+      "immutable": ["../../src/Immutable.js"]
+    }
+  },
+  "include": ["./*.ts", "../../src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Follows #2192 and builds on the `Operations.js` split (#2194). Migrates a large
batch of mixin methods out of `CollectionImpl.js` into **real TypeScript class
methods** on the `Collection.ts` classes — a concrete step toward deleting
`src/utils/mixin.ts`.

### What changed

- **Real class methods** (no longer mixin entries) on `CollectionImpl` /
  `KeyedCollectionImpl` / `IndexedCollectionImpl`: `map`, `toSeq`, `filter`,
  `filterNot`, `partition`, `reverse`, `slice`, `sort`, `sortBy`, `flatMap`,
  `flatten`, `max`/`maxBy`/`min`/`minBy`, `skip`/`skipLast`/`skipWhile`/`skipUntil`,
  `take`/`takeLast`/`takeWhile`/`takeUntil`, `butLast`, `rest`, `count`,
  `findLast`/`findLastEntry`/`findLastKey`/`findLastIndex`, `lastKeyOf`/`lastIndexOf`,
  `last`, `keySeq`/`valueSeq`, `flip`, `findIndex`/`indexOf`, `interpose`/`interleave`,
  `zip`/`zipAll`/`zipWith`. Implementations delegate to the `operations/factories`
  + `operations/helpers` functions (import-safe — no eval-time `extends`, no `Map`
  import, so no load-order cycle).

- **Removed the temporary interface declaration merging** for `map`/`toSeq`: the
  real method bodies now carry the types directly.

- **`IS_*_SYMBOL` brands are real runtime props** assigned on the prototypes in
  `Collection.ts` (`IS_COLLECTION_SYMBOL`, `IS_KEYED_SYMBOL`, `IS_INDEXED_SYMBOL`,
  `IS_ORDERED_SYMBOL`). They make the otherwise structurally-identical empty
  subclasses distinct, which fixes `this` collapsing to `never` in `toSeq`'s
  `isIndexed`/`isKeyed` narrowing, and they are what `isKeyed`/`isIndexed`/… test
  at runtime. They must live on the prototype (not as class fields) because
  `makeSequence` uses `Object.create(prototype)` and bypasses the constructor.

- **Every overload is preserved** (e.g. `filter`/`partition` type-guard overloads,
  `flatMap` indexed-vs-keyed, `flatten` number-vs-boolean, the `zip` family arity
  overloads), with a single loose implementation signature — matching the
  hand-written `type-definitions/immutable.d.ts`.

- **Migration guide updated** (`.agents/commands/migrate-to-ts.md`): added a step
  documenting overload preservation.

`CollectionImpl.js` shrinks accordingly; the 3 `mixin(...SeqImpl, ...)` calls and
the conversion/aggregation methods that still depend on `operations/sequences.js`
(eval-time `extends`) and `operations/aggregations.js` (imports `Map`) are
**intentionally left for a later PR**.

## Tests

- **Unit** — behavioral tests live in the instance files where the shared methods
  are exercised through concrete types: `__tests__/List.ts` (indexed helpers +
  edge cases), `__tests__/Map.ts` (keyed variants), `__tests__/toSeq.ts`.
- **Type (TSTyche)** — `type-definitions/ts-tests/collection.ts` covers return
  types and overloads across List/Map/Set/Seq, including type-guard narrowing,
  the `zip` tuple arities, `flip`, and error cases (indexed-only methods on keyed
  collections).
- `src/Collection.ts` line coverage ~97% (remainder = abstract `__iterate`/
  `__iterator` stubs, unreachable from the public API).

## Test plan

- [x] `npm run type-check` — 0 errors
- [x] `npm run test:unit` — green
- [x] `npm run test:types` — green
- [x] `npm run lint` / `npm run format` — clean

