### PR TITLE
Split Operations.js into src/operations/{factories.ts, sequences.js, aggregations.js, helpers.js}

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15134,9 +15134,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -25587,9 +25587,9 @@
       }
     },
     "typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true
     },
     "typescript-eslint": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "website:dev": "cd website && next dev --turbopack",
     "check-build-output": "node ./resources/check-build-output.mjs",
     "check-git-clean": "./resources/check-git-clean.sh",
+    "check-circular-deps": "npx dpdm --no-warning --no-tree src/Immutable.js",
     "benchmark": "node ./resources/benchmark.js",
     "publish": "echo 'ONLY PUBLISH VIA CI'; exit 1;"
   },

--- a/src/CollectionImpl.js
+++ b/src/CollectionImpl.js
@@ -15,30 +15,6 @@ import {
 import { Iterator } from './Iterator';
 import { List } from './List';
 import { Map } from './Map';
-import {
-  concatFactory,
-  countByFactory,
-  filterFactory,
-  flatMapFactory,
-  flattenFactory,
-  flipFactory,
-  FromEntriesSequence,
-  groupByFactory,
-  interposeFactory,
-  mapFactory,
-  maxFactory,
-  partitionFactory,
-  reify,
-  reverseFactory,
-  skipWhileFactory,
-  sliceFactory,
-  sortFactory,
-  takeWhileFactory,
-  ToIndexedSequence,
-  ToKeyedSequence,
-  ToSetSequence,
-  zipWithFactory,
-} from './Operations';
 import { OrderedMap } from './OrderedMap';
 import { OrderedSet } from './OrderedSet';
 import { Range } from './Range';
@@ -55,6 +31,31 @@ import { ensureSize, resolveBegin } from './TrieUtils';
 import { getIn } from './methods/getIn';
 import { hasIn } from './methods/hasIn';
 import { toObject } from './methods/toObject';
+import { countByFactory, groupByFactory } from './operations/aggregations';
+import {
+  filterFactory,
+  flatMapFactory,
+  flattenFactory,
+  flipFactory,
+  interposeFactory,
+  mapFactory,
+  maxFactory,
+  partitionFactory,
+  reverseFactory,
+  skipWhileFactory,
+  sliceFactory,
+  sortFactory,
+  takeWhileFactory,
+  zipWithFactory,
+} from './operations/factories';
+import { reify } from './operations/helpers';
+import {
+  concatFactory,
+  FromEntriesSequence,
+  ToIndexedSequence,
+  ToKeyedSequence,
+  ToSetSequence,
+} from './operations/sequences';
 import { IS_COLLECTION_SYMBOL } from './predicates/isCollection';
 import { isIndexed, IS_INDEXED_SYMBOL } from './predicates/isIndexed';
 import { isKeyed, IS_KEYED_SYMBOL } from './predicates/isKeyed';

--- a/src/Map.js
+++ b/src/Map.js
@@ -1,7 +1,6 @@
 import { Collection, KeyedCollection, KeyedCollectionImpl } from './Collection';
 import { hash } from './Hash';
 import { Iterator, iteratorValue, iteratorDone } from './Iterator';
-import { sortFactory } from './Operations';
 import { OrderedMap } from './OrderedMap';
 import {
   DELETE,
@@ -26,6 +25,7 @@ import { update } from './methods/update';
 import { updateIn } from './methods/updateIn';
 import { wasAltered } from './methods/wasAltered';
 import { withMutations } from './methods/withMutations';
+import { sortFactory } from './operations/factories';
 import { IS_MAP_SYMBOL, isMap } from './predicates/isMap';
 import { isOrdered } from './predicates/isOrdered';
 import arrCopy from './utils/arrCopy';

--- a/src/Set.js
+++ b/src/Set.js
@@ -5,12 +5,12 @@ import {
   SetCollection,
 } from './Collection';
 import { emptyMap } from './Map';
-import { sortFactory } from './Operations';
 import { OrderedSet } from './OrderedSet';
 import { DELETE } from './TrieUtils';
 import { asImmutable } from './methods/asImmutable';
 import { asMutable } from './methods/asMutable';
 import { withMutations } from './methods/withMutations';
+import { sortFactory } from './operations/factories';
 import { isOrdered } from './predicates/isOrdered';
 import { IS_SET_SYMBOL, isSet } from './predicates/isSet';
 import assertNotInfinite from './utils/assertNotInfinite';

--- a/src/operations/aggregations.js
+++ b/src/operations/aggregations.js
@@ -1,0 +1,26 @@
+import { Map } from '../Map';
+import { OrderedMap } from '../OrderedMap';
+import { isKeyed } from '../predicates/isKeyed';
+import { isOrdered } from '../predicates/isOrdered';
+import { collectionClass, reify } from './helpers.js';
+
+export function countByFactory(collection, grouper, context) {
+  const groups = Map().asMutable();
+  collection.__iterate((v, k) => {
+    groups.update(grouper.call(context, v, k, collection), 0, (a) => a + 1);
+  });
+  return groups.asImmutable();
+}
+
+export function groupByFactory(collection, grouper, context) {
+  const isKeyedIter = isKeyed(collection);
+  const groups = (isOrdered(collection) ? OrderedMap() : Map()).asMutable();
+  collection.__iterate((v, k) => {
+    groups.update(
+      grouper.call(context, v, k, collection),
+      (a) => ((a = a || []), a.push(isKeyedIter ? [k, v] : v), a)
+    );
+  });
+  const coerce = collectionClass(collection);
+  return groups.map((arr) => reify(collection, coerce(arr))).asImmutable();
+}

--- a/src/operations/factories.js
+++ b/src/operations/factories.js
@@ -1,9 +1,4 @@
-import {
-  Collection,
-  KeyedCollection,
-  SetCollection,
-  IndexedCollection,
-} from './Collection';
+import { Collection } from '../Collection';
 import {
   getIterator,
   Iterator,
@@ -12,21 +7,8 @@ import {
   ITERATE_KEYS,
   ITERATE_VALUES,
   ITERATE_ENTRIES,
-} from './Iterator';
-import { Map } from './Map';
-import { OrderedMap } from './OrderedMap';
-import {
-  SeqImpl,
-  KeyedSeq,
-  SetSeq,
-  IndexedSeq,
-  keyedSeqFromValue,
-  indexedSeqFromValue,
-  ArraySeq,
-  KeyedSeqImpl,
-  IndexedSeqImpl,
-  SetSeqImpl,
-} from './Seq';
+} from '../Iterator';
+import { KeyedSeq, SetSeq, IndexedSeq, ArraySeq } from '../Seq';
 import {
   NOT_SET,
   ensureSize,
@@ -34,187 +16,18 @@ import {
   wholeSlice,
   resolveBegin,
   resolveEnd,
-} from './TrieUtils';
-import { isCollection } from './predicates/isCollection';
-import { IS_INDEXED_SYMBOL, isIndexed } from './predicates/isIndexed';
-import { IS_KEYED_SYMBOL, isKeyed } from './predicates/isKeyed';
-import { isOrdered, IS_ORDERED_SYMBOL } from './predicates/isOrdered';
-import { isSeq } from './predicates/isSeq';
-
-export class ToKeyedSequence extends KeyedSeqImpl {
-  constructor(indexed, useKeys) {
-    super();
-
-    this._iter = indexed;
-    this._useKeys = useKeys;
-    this.size = indexed.size;
-  }
-
-  get(key, notSetValue) {
-    return this._iter.get(key, notSetValue);
-  }
-
-  has(key) {
-    return this._iter.has(key);
-  }
-
-  valueSeq() {
-    return this._iter.valueSeq();
-  }
-
-  reverse() {
-    const reversedSequence = reverseFactory(this, true);
-    if (!this._useKeys) {
-      reversedSequence.valueSeq = () => this._iter.toSeq().reverse();
-    }
-    return reversedSequence;
-  }
-
-  map(mapper, context) {
-    const mappedSequence = mapFactory(this, mapper, context);
-    if (!this._useKeys) {
-      mappedSequence.valueSeq = () => this._iter.toSeq().map(mapper, context);
-    }
-    return mappedSequence;
-  }
-
-  __iterate(fn, reverse) {
-    return this._iter.__iterate((v, k) => fn(v, k, this), reverse);
-  }
-
-  __iterator(type, reverse) {
-    return this._iter.__iterator(type, reverse);
-  }
-}
-ToKeyedSequence.prototype[IS_ORDERED_SYMBOL] = true;
-
-export class ToIndexedSequence extends IndexedSeqImpl {
-  constructor(iter) {
-    super();
-
-    this._iter = iter;
-    this.size = iter.size;
-  }
-
-  includes(value) {
-    return this._iter.includes(value);
-  }
-
-  __iterate(fn, reverse) {
-    let i = 0;
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
-    reverse && ensureSize(this);
-    return this._iter.__iterate(
-      (v) => fn(v, reverse ? this.size - ++i : i++, this),
-      reverse
-    );
-  }
-
-  __iterator(type, reverse) {
-    const iterator = this._iter.__iterator(ITERATE_VALUES, reverse);
-    let i = 0;
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
-    reverse && ensureSize(this);
-    return new Iterator(() => {
-      const step = iterator.next();
-      return step.done
-        ? step
-        : iteratorValue(
-            type,
-            reverse ? this.size - ++i : i++,
-            step.value,
-            step
-          );
-    });
-  }
-}
-
-export class ToSetSequence extends SetSeqImpl {
-  constructor(iter) {
-    super();
-
-    this._iter = iter;
-    this.size = iter.size;
-  }
-
-  has(key) {
-    return this._iter.includes(key);
-  }
-
-  __iterate(fn, reverse) {
-    return this._iter.__iterate((v) => fn(v, v, this), reverse);
-  }
-
-  __iterator(type, reverse) {
-    const iterator = this._iter.__iterator(ITERATE_VALUES, reverse);
-    return new Iterator(() => {
-      const step = iterator.next();
-      return step.done
-        ? step
-        : iteratorValue(type, step.value, step.value, step);
-    });
-  }
-}
-
-export class FromEntriesSequence extends KeyedSeqImpl {
-  constructor(entries) {
-    super();
-
-    this._iter = entries;
-    this.size = entries.size;
-  }
-
-  entrySeq() {
-    return this._iter.toSeq();
-  }
-
-  __iterate(fn, reverse) {
-    return this._iter.__iterate((entry) => {
-      // Check if entry exists first so array access doesn't throw for holes
-      // in the parent iteration.
-      if (entry) {
-        validateEntry(entry);
-        const indexedCollection = isCollection(entry);
-        return fn(
-          indexedCollection ? entry.get(1) : entry[1],
-          indexedCollection ? entry.get(0) : entry[0],
-          this
-        );
-      }
-    }, reverse);
-  }
-
-  __iterator(type, reverse) {
-    const iterator = this._iter.__iterator(ITERATE_VALUES, reverse);
-    return new Iterator(() => {
-      while (true) {
-        const step = iterator.next();
-        if (step.done) {
-          return step;
-        }
-        const entry = step.value;
-        // Check if entry exists first so array access doesn't throw for holes
-        // in the parent iteration.
-        if (entry) {
-          validateEntry(entry);
-          const indexedCollection = isCollection(entry);
-          return iteratorValue(
-            type,
-            indexedCollection ? entry.get(0) : entry[0],
-            indexedCollection ? entry.get(1) : entry[1],
-            step
-          );
-        }
-      }
-    });
-  }
-}
-
-ToIndexedSequence.prototype.cacheResult =
-  ToKeyedSequence.prototype.cacheResult =
-  ToSetSequence.prototype.cacheResult =
-  FromEntriesSequence.prototype.cacheResult =
-    cacheResultThrough;
+} from '../TrieUtils';
+import { isCollection } from '../predicates/isCollection';
+import { isIndexed } from '../predicates/isIndexed';
+import { isKeyed } from '../predicates/isKeyed';
+import { isSeq } from '../predicates/isSeq';
+import {
+  cacheResultThrough,
+  collectionClass,
+  defaultComparator,
+  makeSequence,
+  reify,
+} from './helpers.js';
 
 export function flipFactory(collection) {
   const flipSequence = makeSequence(collection);
@@ -384,27 +197,6 @@ export function filterFactory(collection, predicate, context, useKeys) {
   return filterSequence;
 }
 
-export function countByFactory(collection, grouper, context) {
-  const groups = Map().asMutable();
-  collection.__iterate((v, k) => {
-    groups.update(grouper.call(context, v, k, collection), 0, (a) => a + 1);
-  });
-  return groups.asImmutable();
-}
-
-export function groupByFactory(collection, grouper, context) {
-  const isKeyedIter = isKeyed(collection);
-  const groups = (isOrdered(collection) ? OrderedMap() : Map()).asMutable();
-  collection.__iterate((v, k) => {
-    groups.update(
-      grouper.call(context, v, k, collection),
-      (a) => ((a = a || []), a.push(isKeyedIter ? [k, v] : v), a)
-    );
-  });
-  const coerce = collectionClass(collection);
-  return groups.map((arr) => reify(collection, coerce(arr))).asImmutable();
-}
-
 export function partitionFactory(collection, predicate, context) {
   const isKeyedIter = isKeyed(collection);
   const groups = [[], []];
@@ -424,9 +216,9 @@ export function sliceFactory(collection, begin, end, useKeys) {
     return collection;
   }
 
-  // begin or end can not be resolved if they were provided as negative numbers and
-  // this collection's size is unknown. In that case, cache first so there is
-  // a known size and these do not resolve to NaN.
+  // begin or end can not be resolved if they were provided as negative numbers
+  // and this collection's size is unknown. In that case, cache first so there
+  // is a known size and these do not resolve to NaN.
   if (typeof originalSize === 'undefined' && (begin < 0 || end < 0)) {
     return sliceFactory(collection.toSeq().cacheResult(), begin, end, useKeys);
   }
@@ -604,136 +396,6 @@ export function skipWhileFactory(collection, predicate, context, useKeys) {
   return skipSequence;
 }
 
-class ConcatSeq extends SeqImpl {
-  constructor(iterables) {
-    super();
-
-    this._wrappedIterables = iterables.flatMap((iterable) => {
-      if (iterable._wrappedIterables) {
-        return iterable._wrappedIterables;
-      }
-      return [iterable];
-    });
-    this.size = this._wrappedIterables.reduce((sum, iterable) => {
-      if (sum !== undefined) {
-        const size = iterable.size;
-        if (size !== undefined) {
-          return sum + size;
-        }
-      }
-    }, 0);
-    this[IS_KEYED_SYMBOL] = this._wrappedIterables[0][IS_KEYED_SYMBOL];
-    this[IS_INDEXED_SYMBOL] = this._wrappedIterables[0][IS_INDEXED_SYMBOL];
-    this[IS_ORDERED_SYMBOL] = this._wrappedIterables[0][IS_ORDERED_SYMBOL];
-  }
-
-  __iterateUncached(fn, reverse) {
-    if (this._wrappedIterables.length === 0) {
-      return;
-    }
-
-    if (reverse) {
-      return this.cacheResult().__iterate(fn, reverse);
-    }
-
-    let iterableIndex = 0;
-    const useKeys = isKeyed(this);
-    const iteratorType = useKeys ? ITERATE_ENTRIES : ITERATE_VALUES;
-    let currentIterator = this._wrappedIterables[iterableIndex].__iterator(
-      iteratorType,
-      reverse
-    );
-
-    let keepGoing = true;
-    let index = 0;
-    while (keepGoing) {
-      let next = currentIterator.next();
-      while (next.done) {
-        iterableIndex++;
-        if (iterableIndex === this._wrappedIterables.length) {
-          return index;
-        }
-        currentIterator = this._wrappedIterables[iterableIndex].__iterator(
-          iteratorType,
-          reverse
-        );
-        next = currentIterator.next();
-      }
-      const fnResult = useKeys
-        ? fn(next.value[1], next.value[0], this)
-        : fn(next.value, index, this);
-      keepGoing = fnResult !== false;
-      index++;
-    }
-    return index;
-  }
-
-  __iteratorUncached(type, reverse) {
-    if (this._wrappedIterables.length === 0) {
-      return new Iterator(iteratorDone);
-    }
-
-    if (reverse) {
-      return this.cacheResult().__iterator(type, reverse);
-    }
-
-    let iterableIndex = 0;
-    let currentIterator = this._wrappedIterables[iterableIndex].__iterator(
-      type,
-      reverse
-    );
-    return new Iterator(() => {
-      let next = currentIterator.next();
-      while (next.done) {
-        iterableIndex++;
-        if (iterableIndex === this._wrappedIterables.length) {
-          return next;
-        }
-        currentIterator = this._wrappedIterables[iterableIndex].__iterator(
-          type,
-          reverse
-        );
-        next = currentIterator.next();
-      }
-      return next;
-    });
-  }
-}
-
-export function concatFactory(collection, values) {
-  const isKeyedCollection = isKeyed(collection);
-  const iters = [collection]
-    .concat(values)
-    .map((v) => {
-      if (!isCollection(v)) {
-        v = isKeyedCollection
-          ? keyedSeqFromValue(v)
-          : indexedSeqFromValue(Array.isArray(v) ? v : [v]);
-      } else if (isKeyedCollection) {
-        v = KeyedCollection(v);
-      }
-      return v;
-    })
-    .filter((v) => v.size !== 0);
-
-  if (iters.length === 0) {
-    return collection;
-  }
-
-  if (iters.length === 1) {
-    const singleton = iters[0];
-    if (
-      singleton === collection ||
-      (isKeyedCollection && isKeyed(singleton)) ||
-      (isIndexed(collection) && isIndexed(singleton))
-    ) {
-      return singleton;
-    }
-  }
-
-  return new ConcatSeq(iters);
-}
-
 export function flattenFactory(collection, depth, useKeys) {
   const flatSequence = makeSequence(collection);
   flatSequence.__iterateUncached = function (fn, reverse) {
@@ -886,7 +548,7 @@ export function zipWithFactory(keyIter, zipper, iters, zipAll) {
   const zipSequence = makeSequence(keyIter);
   const sizes = new ArraySeq(iters).map((i) => i.size);
   zipSequence.size = zipAll ? sizes.max() : sizes.min();
-  // Note: this a generic base implementation of __iterate in terms of
+  // Note: this is a generic base implementation of __iterate in terms of
   // __iterator which may be more generically useful in the future.
   zipSequence.__iterate = function (fn, reverse) {
     /* generic:
@@ -914,6 +576,7 @@ export function zipWithFactory(keyIter, zipper, iters, zipAll) {
   };
   zipSequence.__iteratorUncached = function (type, reverse) {
     const iterators = iters.map(
+      // eslint-disable-next-line no-sequences
       (i) => ((i = Collection(i)), getIterator(reverse ? i.reverse() : i))
     );
     let iterations = 0;
@@ -940,66 +603,4 @@ export function zipWithFactory(keyIter, zipper, iters, zipAll) {
     });
   };
   return zipSequence;
-}
-
-// #pragma Helper Functions
-
-export function reify(iter, seq) {
-  return iter === seq
-    ? iter
-    : isSeq(iter)
-      ? seq
-      : iter.create
-        ? iter.create(seq)
-        : iter.constructor(seq);
-}
-
-function validateEntry(entry) {
-  if (entry !== Object(entry)) {
-    throw new TypeError('Expected [K, V] tuple: ' + entry);
-  }
-}
-
-function collectionClass(collection) {
-  return isKeyed(collection)
-    ? KeyedCollection
-    : isIndexed(collection)
-      ? IndexedCollection
-      : SetCollection;
-}
-
-function makeSequence(collection) {
-  return Object.create(
-    (isKeyed(collection)
-      ? KeyedSeqImpl
-      : isIndexed(collection)
-        ? IndexedSeqImpl
-        : SetSeqImpl
-    ).prototype
-  );
-}
-
-function cacheResultThrough() {
-  if (this._iter.cacheResult) {
-    this._iter.cacheResult();
-    this.size = this._iter.size;
-    return this;
-  }
-  return SeqImpl.prototype.cacheResult.call(this);
-}
-
-function defaultComparator(a, b) {
-  if (a === undefined && b === undefined) {
-    return 0;
-  }
-
-  if (a === undefined) {
-    return 1;
-  }
-
-  if (b === undefined) {
-    return -1;
-  }
-
-  return a > b ? 1 : a < b ? -1 : 0;
 }

--- a/src/operations/helpers.js
+++ b/src/operations/helpers.js
@@ -1,0 +1,63 @@
+import {
+  KeyedCollection,
+  IndexedCollection,
+  SetCollection,
+} from '../Collection';
+import { SeqImpl, KeyedSeqImpl, IndexedSeqImpl, SetSeqImpl } from '../Seq';
+import { isIndexed } from '../predicates/isIndexed';
+import { isKeyed } from '../predicates/isKeyed';
+import { isSeq } from '../predicates/isSeq';
+
+export function reify(iter, seq) {
+  return iter === seq
+    ? iter
+    : isSeq(iter)
+      ? seq
+      : iter.create
+        ? iter.create(seq)
+        : iter.constructor(seq);
+}
+
+export function makeSequence(collection) {
+  return Object.create(
+    (isKeyed(collection)
+      ? KeyedSeqImpl
+      : isIndexed(collection)
+        ? IndexedSeqImpl
+        : SetSeqImpl
+    ).prototype
+  );
+}
+
+export function collectionClass(collection) {
+  return isKeyed(collection)
+    ? KeyedCollection
+    : isIndexed(collection)
+      ? IndexedCollection
+      : SetCollection;
+}
+
+export function cacheResultThrough() {
+  if (this._iter.cacheResult) {
+    this._iter.cacheResult();
+    this.size = this._iter.size;
+    return this;
+  }
+  return SeqImpl.prototype.cacheResult.call(this);
+}
+
+export function defaultComparator(a, b) {
+  if (a === undefined && b === undefined) {
+    return 0;
+  }
+
+  if (a === undefined) {
+    return 1;
+  }
+
+  if (b === undefined) {
+    return -1;
+  }
+
+  return a > b ? 1 : a < b ? -1 : 0;
+}

--- a/src/operations/sequences.js
+++ b/src/operations/sequences.js
@@ -1,0 +1,334 @@
+import { KeyedCollection } from '../Collection';
+import {
+  Iterator,
+  iteratorValue,
+  iteratorDone,
+  ITERATE_ENTRIES,
+  ITERATE_VALUES,
+} from '../Iterator';
+import {
+  SeqImpl,
+  KeyedSeqImpl,
+  IndexedSeqImpl,
+  SetSeqImpl,
+  keyedSeqFromValue,
+  indexedSeqFromValue,
+} from '../Seq';
+import { ensureSize } from '../TrieUtils';
+import { isCollection } from '../predicates/isCollection';
+import { IS_INDEXED_SYMBOL, isIndexed } from '../predicates/isIndexed';
+import { IS_KEYED_SYMBOL, isKeyed } from '../predicates/isKeyed';
+import { IS_ORDERED_SYMBOL } from '../predicates/isOrdered';
+import { mapFactory, reverseFactory } from './factories';
+import { cacheResultThrough } from './helpers.js';
+
+export class ToKeyedSequence extends KeyedSeqImpl {
+  constructor(indexed, useKeys) {
+    super();
+
+    this._iter = indexed;
+    this._useKeys = useKeys;
+    this.size = indexed.size;
+  }
+
+  get(key, notSetValue) {
+    return this._iter.get(key, notSetValue);
+  }
+
+  has(key) {
+    return this._iter.has(key);
+  }
+
+  valueSeq() {
+    return this._iter.valueSeq();
+  }
+
+  reverse() {
+    const reversedSequence = reverseFactory(this, true);
+    if (!this._useKeys) {
+      reversedSequence.valueSeq = () => this._iter.toSeq().reverse();
+    }
+    return reversedSequence;
+  }
+
+  map(mapper, context) {
+    const mappedSequence = mapFactory(this, mapper, context);
+    if (!this._useKeys) {
+      mappedSequence.valueSeq = () => this._iter.toSeq().map(mapper, context);
+    }
+    return mappedSequence;
+  }
+
+  __iterate(fn, reverse) {
+    return this._iter.__iterate((v, k) => fn(v, k, this), reverse);
+  }
+
+  __iterator(type, reverse) {
+    return this._iter.__iterator(type, reverse);
+  }
+}
+ToKeyedSequence.prototype[IS_ORDERED_SYMBOL] = true;
+
+export class ToIndexedSequence extends IndexedSeqImpl {
+  constructor(iter) {
+    super();
+
+    this._iter = iter;
+    this.size = iter.size;
+  }
+
+  includes(value) {
+    return this._iter.includes(value);
+  }
+
+  __iterate(fn, reverse) {
+    let i = 0;
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
+    reverse && ensureSize(this);
+    return this._iter.__iterate(
+      (v) => fn(v, reverse ? this.size - ++i : i++, this),
+      reverse
+    );
+  }
+
+  __iterator(type, reverse) {
+    const iterator = this._iter.__iterator(ITERATE_VALUES, reverse);
+    let i = 0;
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions -- TODO enable eslint here
+    reverse && ensureSize(this);
+    return new Iterator(() => {
+      const step = iterator.next();
+      return step.done
+        ? step
+        : iteratorValue(
+            type,
+            reverse ? this.size - ++i : i++,
+            step.value,
+            step
+          );
+    });
+  }
+}
+
+export class ToSetSequence extends SetSeqImpl {
+  constructor(iter) {
+    super();
+
+    this._iter = iter;
+    this.size = iter.size;
+  }
+
+  has(key) {
+    return this._iter.includes(key);
+  }
+
+  __iterate(fn, reverse) {
+    return this._iter.__iterate((v) => fn(v, v, this), reverse);
+  }
+
+  __iterator(type, reverse) {
+    const iterator = this._iter.__iterator(ITERATE_VALUES, reverse);
+    return new Iterator(() => {
+      const step = iterator.next();
+      return step.done
+        ? step
+        : iteratorValue(type, step.value, step.value, step);
+    });
+  }
+}
+
+export class FromEntriesSequence extends KeyedSeqImpl {
+  constructor(entries) {
+    super();
+
+    this._iter = entries;
+    this.size = entries.size;
+  }
+
+  entrySeq() {
+    return this._iter.toSeq();
+  }
+
+  __iterate(fn, reverse) {
+    return this._iter.__iterate((entry) => {
+      // Check if entry exists first so array access doesn't throw for holes
+      // in the parent iteration.
+      if (entry) {
+        validateEntry(entry);
+        const indexedCollection = isCollection(entry);
+        return fn(
+          indexedCollection ? entry.get(1) : entry[1],
+          indexedCollection ? entry.get(0) : entry[0],
+          this
+        );
+      }
+    }, reverse);
+  }
+
+  __iterator(type, reverse) {
+    const iterator = this._iter.__iterator(ITERATE_VALUES, reverse);
+    return new Iterator(() => {
+      while (true) {
+        const step = iterator.next();
+        if (step.done) {
+          return step;
+        }
+        const entry = step.value;
+        // Check if entry exists first so array access doesn't throw for holes
+        // in the parent iteration.
+        if (entry) {
+          validateEntry(entry);
+          const indexedCollection = isCollection(entry);
+          return iteratorValue(
+            type,
+            indexedCollection ? entry.get(0) : entry[0],
+            indexedCollection ? entry.get(1) : entry[1],
+            step
+          );
+        }
+      }
+    });
+  }
+}
+
+ToIndexedSequence.prototype.cacheResult =
+  ToKeyedSequence.prototype.cacheResult =
+  ToSetSequence.prototype.cacheResult =
+  FromEntriesSequence.prototype.cacheResult =
+    cacheResultThrough;
+
+class ConcatSeq extends SeqImpl {
+  constructor(iterables) {
+    super();
+
+    this._wrappedIterables = iterables.flatMap((iterable) => {
+      if (iterable._wrappedIterables) {
+        return iterable._wrappedIterables;
+      }
+      return [iterable];
+    });
+    this.size = this._wrappedIterables.reduce((sum, iterable) => {
+      if (sum !== undefined) {
+        const size = iterable.size;
+        if (size !== undefined) {
+          return sum + size;
+        }
+      }
+    }, 0);
+    this[IS_KEYED_SYMBOL] = this._wrappedIterables[0][IS_KEYED_SYMBOL];
+    this[IS_INDEXED_SYMBOL] = this._wrappedIterables[0][IS_INDEXED_SYMBOL];
+    this[IS_ORDERED_SYMBOL] = this._wrappedIterables[0][IS_ORDERED_SYMBOL];
+  }
+
+  __iterateUncached(fn, reverse) {
+    if (this._wrappedIterables.length === 0) {
+      return;
+    }
+
+    if (reverse) {
+      return this.cacheResult().__iterate(fn, reverse);
+    }
+
+    let iterableIndex = 0;
+    const useKeys = isKeyed(this);
+    const iteratorType = useKeys ? ITERATE_ENTRIES : ITERATE_VALUES;
+    let currentIterator = this._wrappedIterables[iterableIndex].__iterator(
+      iteratorType,
+      reverse
+    );
+
+    let keepGoing = true;
+    let index = 0;
+    while (keepGoing) {
+      let next = currentIterator.next();
+      while (next.done) {
+        iterableIndex++;
+        if (iterableIndex === this._wrappedIterables.length) {
+          return index;
+        }
+        currentIterator = this._wrappedIterables[iterableIndex].__iterator(
+          iteratorType,
+          reverse
+        );
+        next = currentIterator.next();
+      }
+      const fnResult = useKeys
+        ? fn(next.value[1], next.value[0], this)
+        : fn(next.value, index, this);
+      keepGoing = fnResult !== false;
+      index++;
+    }
+    return index;
+  }
+
+  __iteratorUncached(type, reverse) {
+    if (this._wrappedIterables.length === 0) {
+      return new Iterator(iteratorDone);
+    }
+
+    if (reverse) {
+      return this.cacheResult().__iterator(type, reverse);
+    }
+
+    let iterableIndex = 0;
+    let currentIterator = this._wrappedIterables[iterableIndex].__iterator(
+      type,
+      reverse
+    );
+    return new Iterator(() => {
+      let next = currentIterator.next();
+      while (next.done) {
+        iterableIndex++;
+        if (iterableIndex === this._wrappedIterables.length) {
+          return next;
+        }
+        currentIterator = this._wrappedIterables[iterableIndex].__iterator(
+          type,
+          reverse
+        );
+        next = currentIterator.next();
+      }
+      return next;
+    });
+  }
+}
+
+export function concatFactory(collection, values) {
+  const isKeyedCollection = isKeyed(collection);
+  const iters = [collection]
+    .concat(values)
+    .map((v) => {
+      if (!isCollection(v)) {
+        v = isKeyedCollection
+          ? keyedSeqFromValue(v)
+          : indexedSeqFromValue(Array.isArray(v) ? v : [v]);
+      } else if (isKeyedCollection) {
+        v = KeyedCollection(v);
+      }
+      return v;
+    })
+    .filter((v) => v.size !== 0);
+
+  if (iters.length === 0) {
+    return collection;
+  }
+
+  if (iters.length === 1) {
+    const singleton = iters[0];
+    if (
+      singleton === collection ||
+      (isKeyedCollection && isKeyed(singleton)) ||
+      (isIndexed(collection) && isIndexed(singleton))
+    ) {
+      return singleton;
+    }
+  }
+
+  return new ConcatSeq(iters);
+}
+
+function validateEntry(entry) {
+  if (entry !== Object(entry)) {
+    throw new TypeError('Expected [K, V] tuple: ' + entry);
+  }
+}


### PR DESCRIPTION
## Why

`src/Operations.js` is monolithic and creates an init-time circular dependency that prevents `Collection.ts` from importing it directly:

```
Collection.ts (mid-load)
  └── Operations.js
       ├── Map → OrderedMap → List → class ListImpl extends IndexedCollectionImpl
       │   💥 IndexedCollectionImpl undefined (Collection.ts mid-load)
       └── class ToKeyedSequence extends KeyedSeqImpl
           💥 KeyedSeqImpl undefined (Seq.js mid-load too)
```

Even sorting out the `Map`/`OrderedMap` imports doesn't fix it: `Operations.js` itself declares `class ToKeyedSequence extends KeyedSeqImpl` at the top level, which fails when Seq.js is mid-load.

This PR splits the file into 4 cohesive sub-files that isolate the dangerous parts (top-level `extends`, Map/OrderedMap imports) so the safe sub-file (`factories.ts`) becomes importable from anywhere.

## How

`src/operations/`:

- **`helpers.js`** (JS) — `reify`, `makeSequence`, `collectionClass`, `defaultComparator`, `cacheResultThrough`. No class extends, no Map import, safe to load from anywhere.
- **`factories.js`** (TS) — the 14 pure factories (`flipFactory`, `mapFactory`, `reverseFactory`, `filterFactory`, `sliceFactory`, `takeWhileFactory`, `skipWhileFactory`, `flattenFactory`, `flatMapFactory`, `interposeFactory`, `sortFactory`, `maxFactory`, `zipWithFactory`, `partitionFactory`) + local `maxCompare`. 
- **`sequences.js`** (JS) — the 5 Sequence classes (`ToKeyedSequence`, `ToIndexedSequence`, `ToSetSequence`, `FromEntriesSequence`, `ConcatSeq`) + `concatFactory` + `validateEntry` + the top-level prototype assignments.
- **`aggregations.js`** (JS) — `countByFactory`, `groupByFactory` (the only two callers of `Map`/`OrderedMap`).

No `index.ts` — a re-exporting index would re-create the same load-time cascade. Direct imports in `Map.js`, `Set.js` (`sortFactory`) and `CollectionImpl.js` are updated to point at the precise sub-files.

Adds `dpdm` and the `check-circular-deps` npm script for verification.

## Result

- **14 → 12 circular dependencies** (`npm run check-circular-deps`). The two `Map.js → Operations.js` cycles are gone. The remaining cycles are unrelated (`Map ↔ methods/* ↔ functional/*`, `OrderedSet → CollectionImpl`, `Seq.js → Collection.ts`) and out of scope.
- All **746 tests still pass**.
- Type-check passes.

## Next step

This sets up the next PR: `Collection.ts` can now `import { … } from './operations/factories'` to migrate more methods from the `CollectionImpl.js` mixin into the class — `factories.ts` is now safe to load mid-`Collection.ts`-load.

## Test plan

- [x] `npm run type-check:ts`
- [x] `npm run check-circular-deps` (12 cycles, down from 14)
- [x] `npx jest` (746/746)