### PR TITLE
Add AI agent tooling and documentation

### DIFF
--- a/.agents/commands/migrate-to-ts.md
+++ b/.agents/commands/migrate-to-ts.md
@@ -1,0 +1,69 @@
+# Migrate a source file from JavaScript to TypeScript
+
+Migrate the file `$ARGUMENTS` from JavaScript to TypeScript following the
+conventions of the immutable-js 6.x branch.
+
+## Steps
+
+1. **Rename** the file: replace the `.js` extension with `.ts`.
+   Make sure to update any imports of this file in other source files.
+
+2. **Add explicit types** to all function parameters, return values, and
+   class properties. Do not use `any` — use `unknown` or proper types instead.
+
+3. **Remove JSDoc type annotations** (`@param {Foo}`, `@returns {Bar}`, etc.)
+   where TypeScript types now make them redundant. Keep non-type JSDoc (e.g.
+   `@deprecated`, meaningful descriptions).
+
+4. **Fix imports**: use `import type` for type-only imports. Import from the
+   concrete `.ts` source files, not from `type-definitions/immutable.d.ts`.
+
+5. **Cross-reference `type-definitions/immutable.d.ts`** — this file is the
+   authoritative source for the current public API types and documentation.
+   It must not be modified during a file migration: it will be deleted in one
+   shot once the full migration is complete.
+
+   When writing types for the migrated file:
+   - Open `immutable.d.ts` and find the declarations that correspond to the
+     symbols you are migrating.
+   - **Copy the JSDoc description** from `immutable.d.ts` to the migrated
+     symbol. This is the authoritative public API documentation. Keep the
+     full comment block, stripping only the `@param {Type}` and
+     `@returns {Type}` type annotations that TypeScript types now replace;
+     preserve `@param` descriptions, `@example` blocks, `@deprecated`,
+     `@see`, etc.
+   - If the hand-written declaration is **stricter** than what you would
+     naturally write (narrower union, branded type, stricter generic
+     constraint…), **keep that stricter typing** in the new `.ts` source —
+     do not relax it.
+   - If you are **unsure** whether your type matches the intent of the
+     hand-written declaration, or if reconciling them feels complex, **stop
+     and ask the user** before continuing.
+   - The type-level tests in `type-definitions/ts-tests/` are your safety
+     net: run `npm run test:types` to catch regressions.
+
+6. **Do not add backwards-compatibility shims** or re-exports — remove code
+   cleanly.
+
+7. **Add or update type tests** in `type-definitions/ts-tests/`: if the
+   migrated file introduces or refines public types that are not yet covered,
+   add the missing tests. Run `npm run test:types` to verify.
+
+8. **Verify**:
+   ```bash
+   npm run type-check
+   npm run test:unit
+   npm run test:types
+   npm run lint
+   ```
+   Fix any errors before considering the migration complete.
+
+## Conventions to follow
+
+- Strict TypeScript: no `any`, honour `noUncheckedIndexedAccess`.
+- Internal implementation classes are named `*Impl` and are not exported.
+- Factory functions are not class constructors — do not expose `new` in the
+  public API.
+- Imports must be ordered alphabetically (`import/order` ESLint rule).
+- `import type` for type-only imports (`verbatimModuleSyntax` is enabled).
+- Run `npm run format` after editing to apply Prettier.

--- a/.claude/commands
+++ b/.claude/commands
@@ -1,0 +1,1 @@
+../.agents/commands

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run test:unit*)",
+      "Bash(npm run test:types*)",
+      "Bash(npm run type-check*)",
+      "Bash(npm run lint*)",
+      "Bash(npm run format*)",
+      "Bash(npm run build*)",
+      "Bash(npm test*)",
+      "Bash(npm install*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git add*)",
+      "Bash(git fetch*)",
+      "Bash(git checkout*)",
+      "Bash(git branch*)",
+      "Bash(git show*)",
+      "Bash(git ls-tree*)",
+      "Bash(find src*)",
+      "Bash(grep*)"
+    ]
+  }
+}

--- a/.github/instructions/migrate-to-ts.instructions.md
+++ b/.github/instructions/migrate-to-ts.instructions.md
@@ -1,0 +1,1 @@
+../../.agents/commands/migrate-to-ts.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,204 @@
+# immutable-js – Agent Guide
+
+## Repository overview
+
+immutable-js provides persistent, immutable data collections for JavaScript
+(List, Map, Set, OrderedMap, OrderedSet, Stack, Record, Range, Repeat, Seq…).
+The public API surface lives in `src/` and the type definitions are generated
+from source (the goal is to eventually delete `type-definitions/immutable.d.ts`
+entirely and let TypeScript infer everything from the `.ts` sources).
+
+---
+
+## Branch strategy
+
+| Branch  | Purpose |
+|---------|---------|
+| `6.x`   | **Active development** – all new features and the TS migration live here |
+| `main`  | **Bug-fixes only** – backports from `6.x` when needed |
+
+**Always develop on `6.x` unless the task is explicitly a bug-fix that must
+land on `main`.**
+
+---
+
+## Goals for v6
+
+1. **Full TypeScript migration** – every `.js` file in `src/` must become
+   `.ts`. Types should be derived from the source, not from
+   `type-definitions/immutable.d.ts`.
+2. **Delete `type-definitions/immutable.d.ts`** – once the TS migration is
+   complete, types will be emitted by the TypeScript compiler directly.
+3. **Modern codebase** – the build target is `"last 2 versions, not dead"` via
+   Babel. IE ≤ 12, Safari ≤ 8 and other legacy browsers are no longer
+   supported.
+
+### Breaking changes already shipped in 6.x
+
+- **Modern JS output** (babel replaces buble; ES2022 class syntax in dist).
+- **`instanceof` no longer works** on factory functions (`Map()`, `List()`,
+  etc.). Use `Map.isMap()`, `List.isList()`, etc. instead.
+- **Empty collections are no longer singletons** (`Map() !== Map()`).
+- **TypeScript < 5.0 dropped** (uses `const` type parameters for `getIn`).
+- **transducers-js compatibility removed.**
+
+---
+
+## TypeScript migration status
+
+### Already migrated to `.ts`
+
+| File | Notes |
+|------|-------|
+| `src/Collection.ts` | Core collection class, partially done |
+| `src/CollectionHelperMethods.ts` | Mixin helper methods |
+| `src/Hash.ts` | |
+| `src/Iterator.ts` | |
+| `src/Math.ts` | |
+| `src/PairSorting.ts` | |
+| `src/Range.ts` | |
+| `src/TrieUtils.ts` | |
+| `src/ValueObject.ts` | |
+| `src/is.ts` | |
+| `src/toJS.ts` | |
+| `src/predicates/*.ts` | All predicate files are already TS |
+| `src/utils/*.ts` | All utility files are already TS |
+| `src/functional/*.ts` | Most functional helpers are TS (except `merge.js`) |
+
+### Still in JavaScript – to migrate
+
+| File | Complexity |
+|------|------------|
+| `src/Immutable.js` | Entry point – low complexity, just re-exports |
+| `src/CollectionImpl.js` | Core collection implementation |
+| `src/Seq.js` | Lazy sequences |
+| `src/List.js` | Large, complex (HAMT trie) |
+| `src/Map.js` | Large, complex (HAMT trie) |
+| `src/OrderedMap.js` | |
+| `src/OrderedSet.js` | |
+| `src/Record.js` | |
+| `src/Repeat.js` | |
+| `src/Set.js` | |
+| `src/Stack.js` | |
+| `src/fromJS.js` | |
+| `src/functional/merge.js` | |
+| `src/methods/*.js` | All method files in this directory |
+
+---
+
+## Development commands
+
+```bash
+# Run the full test suite (format + lint + type-check + build + unit + type tests)
+npm test
+
+# Run only unit tests (fast, no build required)
+npm run test:unit
+
+# Run only type tests (tstyche)
+npm run test:types
+
+# Type-check without running tests
+npm run type-check
+
+# Format code (auto-fix)
+npm run format
+
+# Lint (check only)
+npm run lint
+
+# Build the dist/ directory
+npm run build
+```
+
+> In local development `npm run test:unit` resolves `import 'immutable'`
+> directly to `src/Immutable.js` (see `resources/jestResolver.js`). On CI it
+> uses the built `dist/immutable.js` instead. Always run `npm run build`
+> before running the full `npm test`.
+
+---
+
+## Project structure
+
+```
+src/                  Source files (mix of .js and .ts during migration)
+  predicates/         isMap, isList, … – all already TS
+  utils/              Internal helpers – all already TS
+  functional/         Standalone functional helpers – mostly TS
+  methods/            Mixin methods shared across collections – still JS
+__tests__/            Jest test files (TypeScript)
+type-definitions/
+  immutable.d.ts      Hand-written type declarations (to be deleted once migration is complete)
+  ts-tests/           TSTyche type-level tests
+  flow-tests/         Flow type tests (legacy)
+resources/            Build scripts, rollup config, jest preprocessor
+website/              Next.js documentation site
+dist/                 Build output (not committed)
+```
+
+---
+
+## Code conventions
+
+### TypeScript
+
+- **Strict mode** is enabled (`"strict": true`, `noUncheckedIndexedAccess`,
+  `noImplicitOverride`).
+- Target: `es2022`, module: `ESNext`, `verbatimModuleSyntax: true`.
+- Use `import type` for type-only imports.
+- No `any` – prefer proper types or `unknown`.
+
+### Formatting
+
+- **Prettier**: `singleQuote: true`, `trailingComma: 'es5'`.
+- **EditorConfig**: 2-space indent, LF line endings, UTF-8.
+- Run `npm run format` to auto-fix before committing.
+
+### ESLint
+
+- `eqeqeq` enforced (no `==`).
+- `no-var` enforced – use `const`/`let`.
+- `prefer-arrow-callback` enforced.
+- `no-console` in `src/*`.
+- Imports must be ordered alphabetically (`import/order`).
+
+### General style
+
+- Factory functions, not class constructors for public API (do not add `new`
+  to public-facing factories).
+- Internal implementation classes are named `*Impl` (e.g. `CollectionImpl`,
+  `ListImpl`) and are not exported.
+- No backwards-compatibility shims – remove code cleanly when migrating.
+- No comments explaining *what* the code does; only add a comment when the
+  *why* is non-obvious.
+
+---
+
+## When migrating a file from JS to TS
+
+Follow the step-by-step guide in [`.agents/commands/migrate-to-ts.md`](.agents/commands/migrate-to-ts.md).
+
+---
+
+## Build system
+
+- **Rollup** (`resources/rollup-config.mjs`) bundles the library into:
+  - `dist/immutable.js` (UMD)
+  - `dist/immutable.min.js` (UMD minified)
+  - `dist/immutable.mjs` (ES module)
+- **Babel** (`babel.config.cjs`) transpiles TS and modern JS via
+  `@babel/preset-env` (targets: `last 2 versions, not dead`) and
+  `@babel/preset-typescript`.
+- **Jest** uses `resources/jestPreprocessor.js`: TS files are transpiled by
+  the TypeScript compiler directly; JS files go through Babel via rollup.
+
+---
+
+## Pull requests
+
+- Target branch: **`6.x`** (unless it is a bug-fix that must land on `main`).
+- Keep commits focused – one logical change per commit.
+- Update `CHANGELOG.md` under the `## Unreleased` section for user-visible changes.
+- Type tests in `type-definitions/ts-tests/` must be updated when public
+  types change. If a migrated file introduces or refines public types that
+  are not yet covered by a type test, add the missing tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Canonical files:
- AGENTS.md: instructions for all AI agents (read natively by Claude, Copilot, Gemini…)
- CLAUDE.md → AGENTS.md (symlink)
- .agents/commands/migrate-to-ts.md: step-by-step JS→TS migration prompt

Tool-specific wiring:
- .claude/commands → ../.agents/commands (symlink to whole directory)
- .claude/settings.json: pre-approved npm/git commands to reduce permission prompts
- .github/instructions/migrate-to-ts.instructions.md → .agents/commands/migrate-to-ts.md

Migration guide covers: rename, types, JSDoc cleanup, docstring copy from immutable.d.ts, import fixes, strict typing from .d.ts, type tests, verification.

https://claude.ai/code/session_01RqFUncNFqm3MhCderznz5h