### PR TITLE
fix(reverseFactory): read reversedSequence.size in __iterator instead of this

### DIFF
--- a/__tests__/IndexedSeq.ts
+++ b/__tests__/IndexedSeq.ts
@@ -30,6 +30,28 @@ describe('IndexedSequence', () => {
     expect(operated.last()).toEqual('A');
   });
 
+  it('can be iterated in reverse through a lazy chain', () => {
+    // Regression: reverseFactory's __iterator is an arrow function, so `this`
+    // is NOT the reversed sequence there — it must read `reversedSequence.size`
+    // rather than `this.size`. The bug only surfaces when the reversed indexed
+    // Seq is iterated *backwards* (reverse=true) via the iterator protocol,
+    // which a wrapping `.reverse()` triggers on the inner sequence.
+    // The `.map()` in between prevents the two reverses from collapsing.
+    const seq = Seq([1, 2, 3])
+      .reverse()
+      .map((x) => x * 10)
+      .reverse();
+
+    // Consuming via the iterator protocol (not toArray, which uses __iterate)
+    // is what exercised the broken `this.size` path.
+    expect([...seq]).toEqual([10, 20, 30]);
+    expect([...seq.entries()]).toEqual([
+      [0, 10],
+      [1, 20],
+      [2, 30],
+    ]);
+  });
+
   it('negative indexes correctly', () => {
     const seq = Seq(['A', 'B', 'C', 'D', 'E']);
 

--- a/src/Operations.js
+++ b/src/Operations.js
@@ -317,7 +317,9 @@ export function reverseFactory(collection, useKeys) {
       const entry = step.value;
       return iteratorValue(
         type,
-        useKeys ? entry[0] : reverse ? this.size - ++i : i++,
+        // `__iterator` is an arrow function, so `this` is not the reversed
+        // sequence here — read `reversedSequence.size` explicitly.
+        useKeys ? entry[0] : reverse ? reversedSequence.size - ++i : i++,
         entry[1],
         step
       );


### PR DESCRIPTION
## Why

`reverseFactory`'s `__iterator` is an **arrow function**, so `this` inside it is *not* the reversed sequence — it is the lexical `this` of `reverseFactory`, which is `undefined` (ESM strict mode). The expression `this.size` therefore throws as soon as a **lazy, indexed** reversed `Seq` is iterated **backwards** (`reverse=true`) through the **iterator protocol**:

```
TypeError: Cannot read properties of undefined (reading 'size')
```

Note the sibling `__iterate` method right above is a regular `function () {}`, so its `this.size` is correct and is intentionally left untouched.

### How to reproduce

```js
const seq = Seq([1, 2, 3]).reverse().map((x) => x * 10).reverse();
[...seq];          // 💥 throws on main
[...seq.entries()]; // 💥 throws on main
```

Three conditions are required to hit the broken branch (verified empirically):
1. a lazy `Seq` (a `List` would be materialized by `reify` and never run the arrow);
2. an indexed sequence (`useKeys = false`);
3. backwards iteration via the iterator protocol — the wrapping `.reverse()` forces `reverse=true` on the inner sequence, and the `.map()` keeps the two reverses from collapsing. (`toArray()` would not trigger it, as it goes through `__iterate`.)

## How

Read `reversedSequence.size` explicitly instead of `this.size` in `__iterator`.

## Test plan

- [x] Added a regression test in `__tests__/IndexedSeq.ts` that fails on `main` (`TypeError`) and passes with the fix.
- [x] `npx jest IndexedSeq` → 4/4 pass.