### PR TITLE
better types 6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Dates are formatted as YYYY-MM-DD.
 ## Unreleased
 
 - fix(IndexedCollection): `has(index)` on a lazy `Seq` of unknown size now checks index existence instead of searching for a value equal to the index
+- `isSubset`/`isSuperset` now normalize non-Immutable inputs through `Collection()` (based on `isCollection`) instead of duck-typing an arbitrary `includes`/`isSubset` method. A plain object that is not an Immutable collection but happens to expose its own `includes` (for `isSubset`) or `isSubset` (for `isSuperset`) method will no longer have that method invoked — it is treated as a regular iterable. Immutable collections and arrays are unaffected.
 
 ## 5.1.6
 
@@ -20,26 +21,26 @@ Dates are formatted as YYYY-MM-DD.
 
 ## 5.1.4
 
-* Migrate some files to TS by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2125
-  * Iterator.ts
-  * PairSorting.ts
-  * toJS.ts
-  * Math.ts
-  * Hash.ts
-* Extract CollectionHelperMethods and convert to TS by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2131
-* Use npm [trusted publishing only](https://docs.npmjs.com/trusted-publishers) to avoid token stealing.
+- Migrate some files to TS by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2125
+  - Iterator.ts
+  - PairSorting.ts
+  - toJS.ts
+  - Math.ts
+  - Hash.ts
+- Extract CollectionHelperMethods and convert to TS by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2131
+- Use npm [trusted publishing only](https://docs.npmjs.com/trusted-publishers) to avoid token stealing.
 
 ### Documentation
 
-* Fix/a11y issues by @lyannel in https://github.com/immutable-js/immutable-js/pull/2136
-* Doc add Map.get signature update by @borracciaBlu in https://github.com/immutable-js/immutable-js/pull/2138
-* fix(doc):minor-issues#2132 by @JayMeDotDot in https://github.com/immutable-js/immutable-js/pull/2133
-* Fix algolia search by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2135
-* Typo in OrderedMap by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2144
+- Fix/a11y issues by @lyannel in https://github.com/immutable-js/immutable-js/pull/2136
+- Doc add Map.get signature update by @borracciaBlu in https://github.com/immutable-js/immutable-js/pull/2138
+- fix(doc):minor-issues#2132 by @JayMeDotDot in https://github.com/immutable-js/immutable-js/pull/2133
+- Fix algolia search by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2135
+- Typo in OrderedMap by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2144
 
 ### Internal
 
-* chore: Sort all imports and activate eslint import rule by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2119
+- chore: Sort all imports and activate eslint import rule by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2119
 
 ## 6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Dates are formatted as YYYY-MM-DD.
 
 - fix(IndexedCollection): `has(index)` on a lazy `Seq` of unknown size now checks index existence instead of searching for a value equal to the index
 - `isSubset`/`isSuperset` now normalize non-Immutable inputs through `Collection()` (based on `isCollection`) instead of duck-typing an arbitrary `includes`/`isSubset` method. A plain object that is not an Immutable collection but happens to expose its own `includes` (for `isSubset`) or `isSubset` (for `isSuperset`) method will no longer have that method invoked — it is treated as a regular iterable. Immutable collections and arrays are unaffected.
+- [TypeScript]: `reduce`/`reduceRight` without an initial value now infer the result type from the collection's values when the reducer returns a value (e.g. `list.reduce((a, b) => a + b)` infers `number`), matching `Array#reduce`. Previously an explicit type argument was required.
 
 ## 5.1.6
 

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import fc from 'fast-check';
 import { List, Map, Range, Seq, Set, fromJS } from 'immutable';
 import { create as createSeed } from 'random-seed';
@@ -628,6 +628,21 @@ describe('List', () => {
     expect(r).toEqual(111);
     const r2 = v.reduce((reduction, value) => reduction + value, 1000);
     expect(r2).toEqual(1111);
+  });
+
+  it('reduces without an initial value', () => {
+    // With a single value and no initial reduction, the reducer is never
+    // called and the lone value is returned as-is.
+    const reducer = jest.fn((reduction: number, value: number) =>
+      Math.max(reduction, value)
+    );
+    expect(List.of(42).reduce(reducer)).toEqual(42);
+    expect(reducer).not.toHaveBeenCalled();
+
+    // An empty list with no initial reduction returns undefined.
+    expect(
+      List<number>().reduce((reduction, value) => reduction + value)
+    ).toBeUndefined();
   });
 
   it('reduces from the right', () => {

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -284,6 +284,23 @@ describe('Set', () => {
     expect(s.isSuperset(['B', 'C', 'D'])).toBe(false);
   });
 
+  it('can determine if it is a subset of an iterable', () => {
+    const s = Set.of('A', 'B');
+    // plain array (uses the iterable's own `includes`)
+    expect(s.isSubset(['A', 'B', 'C'])).toBe(true);
+    expect(s.isSubset(['A', 'Z'])).toBe(false);
+    // another immutable collection
+    expect(s.isSubset(Set.of('A', 'B', 'C'))).toBe(true);
+    expect(s.isSubset(List.of('A', 'B', 'C'))).toBe(true);
+  });
+
+  it('accepts a primitive iterable (string) without throwing', () => {
+    // A string is a valid Iterable<string>; the membership test must not throw.
+    expect(Set.of('a', 'b').isSubset('abc')).toBe(true);
+    expect(Set.of('a', 'z').isSubset('abc')).toBe(false);
+    expect(Set.of('a', 'b').isSuperset('ab')).toBe(true);
+  });
+
   describe('accepts Symbol as entry #579', () => {
     it('operates on small number of symbols, preserving set uniqueness', () => {
       const a = Symbol();

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -322,6 +322,7 @@ export class CollectionImpl<K, V> implements ValueObject {
    *
    * @see `Array#reduce`.
    */
+  reduce(reducer: (reduction: V, value: V, key: K, iter: this) => V): V;
   reduce<R>(
     reducer: (reduction: R, value: V, key: K, iter: this) => R,
     initialReduction: R,
@@ -332,16 +333,15 @@ export class CollectionImpl<K, V> implements ValueObject {
     reducer: (reduction: V | R, value: V, key: K, iter: this) => R,
     initialReduction?: R,
     context?: unknown
-  ): R {
+  ): V | R | undefined {
     return reduce(
       this,
-      // @ts-expect-error reducer is (reduction: V | R, value: V, key: K, iter: this) => R, but CollectionImpl<unknown, unknown> is expected
       reducer,
       initialReduction,
       context,
       arguments.length < 2,
       false
-    ) as R; // TODO need better types for `reduce`
+    );
   }
 
   /**
@@ -350,6 +350,7 @@ export class CollectionImpl<K, V> implements ValueObject {
    * Note: Similar to this.reverse().reduce(), and provided for parity
    * with `Array#reduceRight`.
    */
+  reduceRight(reducer: (reduction: V, value: V, key: K, iter: this) => V): V;
   reduceRight<R>(
     reducer: (reduction: R, value: V, key: K, iter: this) => R,
     initialReduction: R,
@@ -362,16 +363,15 @@ export class CollectionImpl<K, V> implements ValueObject {
     reducer: (reduction: V | R, value: V, key: K, iter: this) => R,
     initialReduction?: R,
     context?: unknown
-  ): R {
+  ): V | R | undefined {
     return reduce(
       this,
-      // @ts-expect-error reducer is (reduction: V | R, value: V, key: K, iter: this) => R, but CollectionImpl<unknown, unknown> is expected
       reducer,
       initialReduction,
       context,
       arguments.length < 2,
       true
-    ) as R; // TODO need better types for `reduceRight`
+    );
   }
 
   /**

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -159,9 +159,9 @@ export class CollectionImpl<K, V> implements ValueObject {
   findEntry(
     predicate: (value: V, key: K, iter: this) => boolean,
     context?: unknown,
-    notSetValue?: V
+    notSetValue?: [K, V]
   ): [K, V] | undefined {
-    let found = notSetValue as [K, V] | undefined;
+    let found = notSetValue;
 
     this.__iterate((v, k, c) => {
       if (predicate.call(context, v, k, c)) {
@@ -177,6 +177,11 @@ export class CollectionImpl<K, V> implements ValueObject {
   /**
    * Returns the first value for which the `predicate` returns true.
    */
+  find<NSV>(
+    predicate: (value: V, key: K, iter: this) => boolean,
+    context?: unknown,
+    notSetValue?: NSV
+  ): V | NSV;
   find(
     predicate: (value: V, key: K, iter: this) => boolean,
     context?: unknown,
@@ -215,7 +220,7 @@ export class CollectionImpl<K, V> implements ValueObject {
   first<NSV>(notSetValue: NSV): V | NSV;
   first(): V | undefined;
   first(notSetValue?: unknown): unknown {
-    return this.find(returnTrue, null, notSetValue as V | undefined);
+    return this.find(returnTrue, null, notSetValue);
   }
 
   /**
@@ -229,11 +234,7 @@ export class CollectionImpl<K, V> implements ValueObject {
   get<NSV>(searchKey: K, notSetValue: NSV): V | NSV;
   get(searchKey: K): V | undefined;
   get(searchKey: K, notSetValue?: unknown): unknown {
-    return this.find(
-      (_, key) => is(key, searchKey),
-      undefined,
-      notSetValue as V | undefined
-    );
+    return this.find((_, key) => is(key, searchKey), undefined, notSetValue);
   }
 
   /**
@@ -241,9 +242,7 @@ export class CollectionImpl<K, V> implements ValueObject {
    * to determine equality
    */
   has(searchKey: K): boolean {
-    return (
-      this.get(searchKey, NOT_SET as unknown as V) !== (NOT_SET as unknown as V)
-    );
+    return this.get(searchKey, NOT_SET) !== NOT_SET;
   }
 
   /**
@@ -495,7 +494,7 @@ export class IndexedCollectionImpl<T>
   override first<NSV>(notSetValue: NSV): T | NSV;
   override first(): T | undefined;
   override first(notSetValue?: unknown): unknown {
-    return this.get(0, notSetValue as T | undefined);
+    return this.get(0, notSetValue);
   }
 
   /**
@@ -507,7 +506,7 @@ export class IndexedCollectionImpl<T>
   last<NSV>(notSetValue: NSV): T | NSV;
   last(): T | undefined;
   last(notSetValue?: unknown): unknown {
-    return this.get(-1, notSetValue as T | undefined);
+    return this.get(-1, notSetValue);
   }
 
   /**
@@ -525,11 +524,7 @@ export class IndexedCollectionImpl<T>
       this.size === Infinity ||
       (this.size !== undefined && index > this.size)
       ? notSetValue
-      : this.find(
-          (_, key) => key === index,
-          undefined,
-          notSetValue as T | undefined
-        );
+      : this.find((_, key) => key === index, undefined, notSetValue);
   }
 
   /**
@@ -542,12 +537,7 @@ export class IndexedCollectionImpl<T>
       index >= 0 &&
       (this.size !== undefined
         ? this.size === Infinity || index < this.size
-        : this.find(
-            (_, key) => key === index,
-            undefined,
-            // @ts-expect-error NSV will be add to find later
-            NOT_SET
-          ) !== NOT_SET)
+        : this.find((_, key) => key === index, undefined, NOT_SET) !== NOT_SET)
     );
   }
 }

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -33,6 +33,17 @@ export function Collection(value: unknown): CollectionImpl<unknown, unknown> {
   return isCollection(value) ? value : Seq(value);
 }
 
+function hasIncludesMethod<V>(
+  iter: Iterable<V>
+): iter is Iterable<V> & { includes(value: V): boolean } {
+  return (
+    typeof iter === 'object' &&
+    iter !== null &&
+    'includes' in iter &&
+    typeof iter.includes === 'function'
+  );
+}
+
 export class CollectionImpl<K, V> implements ValueObject {
   private __hash: number | undefined;
 
@@ -268,12 +279,7 @@ export class CollectionImpl<K, V> implements ValueObject {
    * True if `iter` includes every value in this Collection.
    */
   isSubset(iter: Iterable<V>): boolean {
-    // TODO better types !
-    const c =
-      typeof (iter as unknown as { includes?: unknown })?.includes ===
-      'function'
-        ? (iter as unknown as CollectionImpl<unknown, V>)
-        : (Collection(iter as never) as unknown as CollectionImpl<unknown, V>);
+    const c = hasIncludesMethod(iter) ? iter : Collection(iter);
 
     return this.every((value) => c.includes(value));
   }
@@ -282,14 +288,7 @@ export class CollectionImpl<K, V> implements ValueObject {
    * True if this Collection includes every value in `iter`.
    */
   isSuperset(iter: Iterable<V>): boolean {
-    // TODO better types !
-    const c =
-      typeof (iter as unknown as { isSubset?: unknown })?.isSubset ===
-      'function'
-        ? (iter as unknown as CollectionImpl<unknown, V>)
-        : (Collection(iter as never) as unknown as CollectionImpl<unknown, V>);
-
-    return c.isSubset(this as unknown as Iterable<V>);
+    return Collection(iter).every((value) => this.includes(value));
   }
 
   /**

--- a/src/CollectionHelperMethods.ts
+++ b/src/CollectionHelperMethods.ts
@@ -1,21 +1,24 @@
 import type { CollectionImpl } from './Collection';
 import assertNotInfinite from './utils/assertNotInfinite';
 
-export function reduce(
-  collection: CollectionImpl<unknown, unknown>,
-  reducer: (...args: unknown[]) => unknown,
-  reduction: unknown,
+export function reduce<K, V, R, C extends CollectionImpl<K, V>>(
+  collection: C,
+  reducer: (reduction: V | R, value: V, key: K, iter: C) => R,
+  reduction: V | R | undefined,
   context: unknown,
   useFirst: boolean,
   reverse: boolean
-) {
+): V | R | undefined {
   assertNotInfinite(collection.size);
   collection.__iterate((v, k, c) => {
     if (useFirst) {
       useFirst = false;
       reduction = v;
     } else {
-      reduction = reducer.call(context, reduction, v, k, c);
+      // `reduction` has already been seeded here (either with the provided
+      // initial value or with the first iterated value), so it is never the
+      // `undefined` placeholder — only a `V` or a `R`.
+      reduction = reducer.call(context, reduction!, v, k, c);
     }
   }, reverse);
   return reduction;

--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -4216,6 +4216,7 @@ declare namespace Immutable {
      *
      * @see `Array#reduce`.
      */
+    reduce(reducer: (reduction: V, value: V, key: K, iter: this) => V): V;
     reduce<R>(
       reducer: (reduction: R, value: V, key: K, iter: this) => R,
       initialReduction: R,
@@ -4231,6 +4232,7 @@ declare namespace Immutable {
      * Note: Similar to this.reverse().reduce(), and provided for parity
      * with `Array#reduceRight`.
      */
+    reduceRight(reducer: (reduction: V, value: V, key: K, iter: this) => V): V;
     reduceRight<R>(
       reducer: (reduction: R, value: V, key: K, iter: this) => R,
       initialReduction: R,

--- a/type-definitions/ts-tests/reduce.ts
+++ b/type-definitions/ts-tests/reduce.ts
@@ -1,0 +1,83 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import { Collection, List, Map, Set } from 'immutable';
+import { expect, test } from 'tstyche';
+
+test('reduce', () => {
+  // With an initial value, the result type is the accumulator type `R`.
+  (l: List<number>) => {
+    expect(
+      l.reduce((acc: string, value) => acc + value, 'seed')
+    ).type.toBe<string>();
+  };
+
+  // With an initial value (overload 1), the reduction is typed `R`.
+  (l: List<number>) => {
+    l.reduce((acc, value, key, iter) => {
+      expect(acc).type.toBe<string>();
+      expect(value).type.toBe<number>();
+      expect(key).type.toBe<number>();
+      expect(iter).type.toBe<List<number>>();
+      return `${acc}${value}`;
+    }, 'seed');
+  };
+
+  // Without an initial value and a reducer that returns a value (`R = V`),
+  // the result type `V` is inferred from the values — no annotation needed.
+  (l: List<number>) => {
+    expect(l.reduce((acc, value) => acc + value)).type.toBe<number>();
+  };
+
+  // Without an initial value but a reducer that returns a different type `R`,
+  // the reduction is typed `V | R`, since the first value (a `V`) seeds it.
+  (l: List<number>) => {
+    expect(
+      l.reduce((acc: string | number, value) => {
+        expect(value).type.toBe<number>();
+        return `${acc}${value}`;
+      })
+    ).type.toBe<string>();
+  };
+
+  // Keyed collection: key is `K`.
+  (m: Map<string, number>) => {
+    m.reduce((acc, value, key, iter) => {
+      expect(value).type.toBe<number>();
+      expect(key).type.toBe<string>();
+      expect(iter).type.toBe<Map<string, number>>();
+      return acc + value;
+    }, 0);
+  };
+
+  // Set collection: value and key are both `T`.
+  (s: Set<number>) => {
+    s.reduce((acc, value, key) => {
+      expect(value).type.toBe<number>();
+      expect(key).type.toBe<number>();
+      return acc + value;
+    }, 0);
+  };
+
+  // Base Collection.
+  (c: Collection<string, number>) => {
+    expect(
+      c.reduce((acc: boolean, value) => acc && value > 0, true)
+    ).type.toBe<boolean>();
+  };
+});
+
+test('reduceRight', () => {
+  (l: List<number>) => {
+    expect(
+      l.reduceRight((acc: string, value) => acc + value, 'seed')
+    ).type.toBe<string>();
+  };
+
+  (l: List<number>) => {
+    l.reduceRight((acc, value, key, iter) => {
+      expect(value).type.toBe<number>();
+      expect(key).type.toBe<number>();
+      expect(iter).type.toBe<List<number>>();
+      return acc + value;
+    }, 0);
+  };
+});


### PR DESCRIPTION
Improves the TypeScript types of `Collection.ts` as part of the ongoing TS migration, removing hand-written `as` casts and `@ts-expect-error` suppressions in favour of properly inferred types.

### `find` and related accessors

- Add a `NSV` (not-set value) type parameter to `find`, and type `findEntry`'s `notSetValue` as `[K, V]`.
- Drop the now-unnecessary casts in `find`, `get`, `has`, `first` and `last` (`as V | undefined`, `as unknown as V`, …) and remove a `@ts-expect-error` on `notSetValue`.

### `isSubset` / `isSuperset`

- Replace the scattered `as unknown as { … }` / `as unknown as CollectionImpl` casts with a small `hasIncludesMethod` type guard.
- Rewrite `isSuperset` as `Collection(iter).every((value) => this.includes(value))`, which is behaviourally equivalent to the previous `iter.isSubset(this)` delegation but removes the `this as unknown as Iterable<V>` cast (`isSubset` is not overridden anywhere, so there was no polymorphism to preserve).
- The type guard checks `typeof iter === 'object'` before using `in`, so passing a primitive iterable (e.g. a `string`) no longer throws.

**Behaviour change:** `isSubset`/`isSuperset` now normalize non-Immutable inputs through `Collection()` (based on `isCollection`) instead of duck-typing an arbitrary `includes`/`isSubset` method. A plain object that is not an Immutable collection but exposes its own `includes`/`isSubset` method will no longer have that method invoked — it is treated as a regular iterable. Immutable collections and arrays are unaffected.

### `reduce` / `reduceRight`

- Type the shared `reduce` helper generically, removing the `@ts-expect-error` and the `as R` cast at both call sites. The implementation signature now returns the honest `V | R | undefined` (the public overloads still return `R`).
- Add an `Array#reduce`-style overload for the no-initial case where the accumulator is a value (`R = V`), so the result type is inferred from the collection's values instead of requiring an explicit type argument: `list.reduce((a, b) => a + b)` now infers `number`.

### Tests

- Add tstyche coverage for `reduce`/`reduceRight` (none existed before): result type with/without an initial value, the new value inference, and the reducer argument types across `List`, `Map`, `Set` and `Collection`.
- Add unit tests: `isSubset` against arrays/collections and a primitive `string` (regression for the `in` throw), and `reduce` without an initial value (single value returns the seed, empty collection returns `undefined`).

`CHANGELOG.md` updated for the user-visible behaviour and type changes.
