### PR TITLE
Better type for reduce if not ininitial value is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Dates are formatted as YYYY-MM-DD.
 ## Unreleased
 
 - fix(IndexedCollection): `has(index)` on a lazy `Seq` of unknown size now checks index existence instead of searching for a value equal to the index
+- [TypeScript]: `reduce`/`reduceRight` without an initial value now infer the result type from the collection's values when the reducer returns a value (e.g. `list.reduce((a, b) => a + b)` infers `number`), matching `Array#reduce`. Previously an explicit type argument was required.
 
 ## 5.1.6
 
@@ -20,26 +21,26 @@ Dates are formatted as YYYY-MM-DD.
 
 ## 5.1.4
 
-* Migrate some files to TS by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2125
-  * Iterator.ts
-  * PairSorting.ts
-  * toJS.ts
-  * Math.ts
-  * Hash.ts
-* Extract CollectionHelperMethods and convert to TS by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2131
-* Use npm [trusted publishing only](https://docs.npmjs.com/trusted-publishers) to avoid token stealing.
+- Migrate some files to TS by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2125
+  - Iterator.ts
+  - PairSorting.ts
+  - toJS.ts
+  - Math.ts
+  - Hash.ts
+- Extract CollectionHelperMethods and convert to TS by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2131
+- Use npm [trusted publishing only](https://docs.npmjs.com/trusted-publishers) to avoid token stealing.
 
 ### Documentation
 
-* Fix/a11y issues by @lyannel in https://github.com/immutable-js/immutable-js/pull/2136
-* Doc add Map.get signature update by @borracciaBlu in https://github.com/immutable-js/immutable-js/pull/2138
-* fix(doc):minor-issues#2132 by @JayMeDotDot in https://github.com/immutable-js/immutable-js/pull/2133
-* Fix algolia search by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2135
-* Typo in OrderedMap by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2144
+- Fix/a11y issues by @lyannel in https://github.com/immutable-js/immutable-js/pull/2136
+- Doc add Map.get signature update by @borracciaBlu in https://github.com/immutable-js/immutable-js/pull/2138
+- fix(doc):minor-issues#2132 by @JayMeDotDot in https://github.com/immutable-js/immutable-js/pull/2133
+- Fix algolia search by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2135
+- Typo in OrderedMap by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2144
 
 ### Internal
 
-* chore: Sort all imports and activate eslint import rule by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2119
+- chore: Sort all imports and activate eslint import rule by @jdeniau in https://github.com/immutable-js/immutable-js/pull/2119
 
 ## 5.1.3
 

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 import fc from 'fast-check';
 import { List, Map, Range, Seq, Set, fromJS } from 'immutable';
 import { create as createSeed } from 'random-seed';
@@ -624,10 +624,25 @@ describe('List', () => {
 
   it('reduces values', () => {
     const v = List.of(1, 10, 100);
-    const r = v.reduce<number>((reduction, value) => reduction + value);
+    const r = v.reduce((reduction, value) => reduction + value);
     expect(r).toEqual(111);
     const r2 = v.reduce((reduction, value) => reduction + value, 1000);
     expect(r2).toEqual(1111);
+  });
+
+  it('reduces without an initial value', () => {
+    // With a single value and no initial reduction, the reducer is never
+    // called and the lone value is returned as-is.
+    const reducer = jest.fn((reduction: number, value: number) =>
+      Math.max(reduction, value)
+    );
+    expect(List.of(42).reduce(reducer)).toEqual(42);
+    expect(reducer).not.toHaveBeenCalled();
+
+    // An empty list with no initial reduction returns undefined.
+    expect(
+      List<number>().reduce((reduction, value) => reduction + value)
+    ).toBeUndefined();
   });
 
   it('reduces from the right', () => {

--- a/__tests__/Set.ts
+++ b/__tests__/Set.ts
@@ -277,6 +277,23 @@ describe('Set', () => {
     expect(s.isSuperset(['B', 'C', 'D'])).toBe(false);
   });
 
+  it('can determine if it is a subset of an iterable', () => {
+    const s = Set.of('A', 'B');
+    // plain array (uses the iterable's own `includes`)
+    expect(s.isSubset(['A', 'B', 'C'])).toBe(true);
+    expect(s.isSubset(['A', 'Z'])).toBe(false);
+    // another immutable collection
+    expect(s.isSubset(Set.of('A', 'B', 'C'))).toBe(true);
+    expect(s.isSubset(List.of('A', 'B', 'C'))).toBe(true);
+  });
+
+  it('accepts a primitive iterable (string) without throwing', () => {
+    // A string is a valid Iterable<string>; the membership test must not throw.
+    expect(Set.of('a', 'b').isSubset('abc')).toBe(true);
+    expect(Set.of('a', 'z').isSubset('abc')).toBe(false);
+    expect(Set.of('a', 'b').isSuperset('ab')).toBe(true);
+  });
+
   describe('accepts Symbol as entry #579', () => {
     it('operates on small number of symbols, preserving set uniqueness', () => {
       const a = Symbol();

--- a/src/CollectionHelperMethods.ts
+++ b/src/CollectionHelperMethods.ts
@@ -1,23 +1,26 @@
 import type { Collection } from '../type-definitions/immutable';
 import assertNotInfinite from './utils/assertNotInfinite';
 
-export function reduce(
-  collection: Collection<unknown, unknown>,
-  reducer: (...args: unknown[]) => unknown,
-  reduction: unknown,
+export function reduce<K, V, R, C extends Collection<K, V>>(
+  collection: C,
+  reducer: (reduction: V | R, value: V, key: K, iter: C) => R,
+  reduction: V | R | undefined,
   context: unknown,
   useFirst: boolean,
   reverse: boolean
-) {
+): V | R | undefined {
   // @ts-expect-error Migrate to CollectionImpl in v6
   assertNotInfinite(collection.size);
   // @ts-expect-error Migrate to CollectionImpl in v6
-  collection.__iterate((v, k, c) => {
+  collection.__iterate((v: V, k: K, c: C) => {
     if (useFirst) {
       useFirst = false;
       reduction = v;
     } else {
-      reduction = reducer.call(context, reduction, v, k, c);
+      // `reduction` has already been seeded here (either with the provided
+      // initial value or with the first iterated value), so it is never the
+      // `undefined` placeholder — only a `V` or a `R`.
+      reduction = reducer.call(context, reduction!, v, k, c);
     }
   }, reverse);
   return reduction;

--- a/type-definitions/immutable.d.ts
+++ b/type-definitions/immutable.d.ts
@@ -4219,6 +4219,7 @@ declare namespace Immutable {
      *
      * @see `Array#reduce`.
      */
+    reduce(reducer: (reduction: V, value: V, key: K, iter: this) => V): V;
     reduce<R>(
       reducer: (reduction: R, value: V, key: K, iter: this) => R,
       initialReduction: R,
@@ -4234,6 +4235,7 @@ declare namespace Immutable {
      * Note: Similar to this.reverse().reduce(), and provided for parity
      * with `Array#reduceRight`.
      */
+    reduceRight(reducer: (reduction: V, value: V, key: K, iter: this) => V): V;
     reduceRight<R>(
       reducer: (reduction: R, value: V, key: K, iter: this) => R,
       initialReduction: R,

--- a/type-definitions/ts-tests/reduce.ts
+++ b/type-definitions/ts-tests/reduce.ts
@@ -1,0 +1,83 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+import { Collection, List, Map, Set } from 'immutable';
+import { expect, test } from 'tstyche';
+
+test('reduce', () => {
+  // With an initial value, the result type is the accumulator type `R`.
+  (l: List<number>) => {
+    expect(
+      l.reduce((acc: string, value) => acc + value, 'seed')
+    ).type.toBe<string>();
+  };
+
+  // With an initial value (overload 1), the reduction is typed `R`.
+  (l: List<number>) => {
+    l.reduce((acc, value, key, iter) => {
+      expect(acc).type.toBe<string>();
+      expect(value).type.toBe<number>();
+      expect(key).type.toBe<number>();
+      expect(iter).type.toBe<List<number>>();
+      return `${acc}${value}`;
+    }, 'seed');
+  };
+
+  // Without an initial value and a reducer that returns a value (`R = V`),
+  // the result type `V` is inferred from the values — no annotation needed.
+  (l: List<number>) => {
+    expect(l.reduce((acc, value) => acc + value)).type.toBe<number>();
+  };
+
+  // Without an initial value but a reducer that returns a different type `R`,
+  // the reduction is typed `V | R`, since the first value (a `V`) seeds it.
+  (l: List<number>) => {
+    expect(
+      l.reduce((acc: string | number, value) => {
+        expect(value).type.toBe<number>();
+        return `${acc}${value}`;
+      })
+    ).type.toBe<string>();
+  };
+
+  // Keyed collection: key is `K`.
+  (m: Map<string, number>) => {
+    m.reduce((acc, value, key, iter) => {
+      expect(value).type.toBe<number>();
+      expect(key).type.toBe<string>();
+      expect(iter).type.toBe<Map<string, number>>();
+      return acc + value;
+    }, 0);
+  };
+
+  // Set collection: value and key are both `T`.
+  (s: Set<number>) => {
+    s.reduce((acc, value, key) => {
+      expect(value).type.toBe<number>();
+      expect(key).type.toBe<number>();
+      return acc + value;
+    }, 0);
+  };
+
+  // Base Collection.
+  (c: Collection<string, number>) => {
+    expect(
+      c.reduce((acc: boolean, value) => acc && value > 0, true)
+    ).type.toBe<boolean>();
+  };
+});
+
+test('reduceRight', () => {
+  (l: List<number>) => {
+    expect(
+      l.reduceRight((acc: string, value) => acc + value, 'seed')
+    ).type.toBe<string>();
+  };
+
+  (l: List<number>) => {
+    l.reduceRight((acc, value, key, iter) => {
+      expect(value).type.toBe<number>();
+      expect(key).type.toBe<number>();
+      expect(iter).type.toBe<List<number>>();
+      return acc + value;
+    }, 0);
+  };
+});


### PR DESCRIPTION
[TypeScript]: `reduce`/`reduceRight` without an initial value now infer the result type from the collection's values when the reducer returns a value (e.g. `list.reduce((a, b) => a + b)` infers `number`), matching `Array#reduce`. Previously an explicit type argument was required.