### PR TITLE
Type collection size as number | undefined

### DIFF
--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -77,7 +77,10 @@ function hasIncludesMethod<V>(
 export class CollectionImpl<K, V> implements ValueObject {
   private __hash: number | undefined;
 
-  size: number = 0;
+  // Lazy `Seq`s may not know their size until materialized, so the base type is
+  // `number | undefined`. Concrete collections (List, Map, Range, …) always know
+  // their size and narrow this back to `number`.
+  size: number | undefined = 0;
 
   // Brand tested by the `isCollection` predicate. Declared for the type here;
   // the value is set on the prototype just below the class. It cannot be a

--- a/src/Range.ts
+++ b/src/Range.ts
@@ -46,6 +46,10 @@ export class RangeImpl extends IndexedSeqImpl implements Seq.Indexed<number> {
   private _end: number;
   private _step: number;
 
+  // A Range always knows its (finite or Infinity) size, narrowing the base's
+  // `number | undefined` back to `number`.
+  declare size: number;
+
   constructor(start: number, end: number, step: number, size: number) {
     super();
 

--- a/src/TrieUtils.ts
+++ b/src/TrieUtils.ts
@@ -32,7 +32,8 @@ export function OwnerID() {}
 
 export function ensureSize(iter: CollectionImpl<unknown, unknown>): number {
   if (iter.size === undefined) {
-    iter.size = iter.__iterate(returnTrue);
+    // Materialize the size; the assignment yields the freshly counted `number`.
+    return (iter.size = iter.__iterate(returnTrue));
   }
 
   return iter.size;
@@ -66,7 +67,7 @@ export function returnTrue(): true {
 export function wholeSlice(
   begin: number | undefined,
   end: number | undefined,
-  size: number
+  size: number | undefined
 ): boolean {
   return (
     ((begin === 0 && !isNeg(begin)) ||
@@ -75,19 +76,43 @@ export function wholeSlice(
   );
 }
 
-export function resolveBegin(begin: number | undefined, size: number): number {
+export function resolveBegin(
+  begin: number | undefined,
+  size: number | undefined
+): number {
   return resolveIndex(begin, size, 0);
 }
 
-export function resolveEnd(end: number | undefined, size: number): number {
+// With a known `size` the end always resolves to a number. With an unknown size
+// and no explicit `end`, the end stays `undefined` (the slice runs to the —
+// not-yet-known — end of the sequence).
+export function resolveEnd(end: number | undefined, size: number): number;
+export function resolveEnd(
+  end: number | undefined,
+  size: number | undefined
+): number | undefined;
+export function resolveEnd(
+  end: number | undefined,
+  size: number | undefined
+): number | undefined {
   return resolveIndex(end, size, size);
 }
 
 function resolveIndex(
   index: number | undefined,
-  size: number,
+  size: number | undefined,
   defaultIndex: number
-): number {
+): number;
+function resolveIndex(
+  index: number | undefined,
+  size: number | undefined,
+  defaultIndex: number | undefined
+): number | undefined;
+function resolveIndex(
+  index: number | undefined,
+  size: number | undefined,
+  defaultIndex: number | undefined
+): number | undefined {
   // Sanitize indices using this shorthand for ToInt32(argument)
   // http://www.ecma-international.org/ecma-262/6.0/#sec-toint32
   return index === undefined
@@ -95,7 +120,7 @@ function resolveIndex(
     : isNeg(index)
       ? size === Infinity
         ? size
-        : Math.max(0, size + index) | 0
+        : Math.max(0, (size ?? 0) + index) | 0
       : size === undefined || size === index
         ? index
         : Math.min(size, index) | 0;

--- a/src/operations/factories.ts
+++ b/src/operations/factories.ts
@@ -374,9 +374,11 @@ export function sliceFactory<C extends CollectionImpl<unknown, unknown>>(
   // unknown and this slice did not supply an end and should contain all
   // elements after resolvedBegin.
   // In that case, resolvedSize will be NaN and sliceSize will remain undefined.
-  const resolvedSize = resolvedEnd - resolvedBegin;
+  const resolvedSize =
+    resolvedEnd === undefined ? NaN : resolvedEnd - resolvedBegin;
   let sliceSize: number | undefined;
   if (resolvedSize === resolvedSize) {
+    // TODO useless branch ?
     sliceSize = resolvedSize < 0 ? 0 : resolvedSize;
   }
 

--- a/src/utils/assertNotInfinite.ts
+++ b/src/utils/assertNotInfinite.ts
@@ -1,6 +1,6 @@
 import invariant from './invariant';
 
-export default function assertNotInfinite(size: number): void {
+export default function assertNotInfinite(size: number | undefined): void {
   invariant(
     size !== Infinity,
     'Cannot perform this action with an infinite size.'

--- a/src/utils/hashCollection.ts
+++ b/src/utils/hashCollection.ts
@@ -30,7 +30,9 @@ export function hashCollection<K, V>(collection: CollectionImpl<K, V>): number {
           }
   );
 
-  return murmurHashOfSize(collection.size, h);
+  // An unmaterialized lazy seq has `size === undefined`; the original bitwise
+  // `^ size` coerced that to 0, so fall back to 0 explicitly.
+  return murmurHashOfSize(collection.size ?? 0, h);
 }
 
 function murmurHashOfSize(size: number, h: number): number {


### PR DESCRIPTION
## Summary

Types the base collection `size` as `number | undefined` to match the runtime: a lazy `Seq` may not know its size until it is materialized. Concrete collections always know their size and narrow it back to `number` (`RangeImpl` here; the remaining JS leaves — `List`, `Map`, … — as they migrate).

This is a prerequisite for migrating `Seq.js` to TypeScript: the typed `*SeqImpl` base classes inherit `size`, which is only sound if the base type allows `undefined`.

## Why this is mostly revival, not new guards

The old `size: number` was a lie — several helpers already guarded `size === undefined` / `size === Infinity`, which were dead code under that type. Widening makes them meaningful again:

- `assertNotInfinite` accepts `number | undefined` (`undefined` is not infinite)
- `wholeSlice` / `resolveBegin` widened; `resolveEnd` is **overloaded** so a known `size` still resolves to `number` (callers like `RangeImpl.slice` are unaffected)
- `ensureSize` returns the freshly materialized size
- `hashCollection` falls back to `0` for an unknown size (matches the original bitwise coercion)
- `sliceFactory` keeps its NaN handling when the end can't be resolved
- `RangeImpl` narrows `size: number`

No runtime behavior change.

## Test plan

- `npm run type-check` ✅
- `npm run test:unit` — 784 passed ✅
- `npm run test:types` (tstyche) — 828 passed ✅
- eslint on changed files ✅
