### PR TITLE
Remove weird if that was testing NaN equality

### DIFF
--- a/__tests__/slice.ts
+++ b/__tests__/slice.ts
@@ -226,6 +226,19 @@ describe('slice', () => {
     expect(iterTail.next()).toEqual({ value: undefined, done: true });
   });
 
+  it('slices a sequence with unknown size and no end', () => {
+    let seq = Seq([0, 1, 2, 3, 4, 5]);
+    expect(seq.size).toEqual(6);
+
+    // flatMap is lazy and thus the resulting sequence has no size.
+    seq = seq.flatMap((a) => [a]);
+    expect(seq.size).toEqual(undefined);
+
+    const sliced = seq.slice(4);
+    expect(sliced.size).toEqual(undefined);
+    expect(sliced.toArray()).toEqual([4, 5]);
+  });
+
   it('works like Array.prototype.slice', () => {
     fc.assert(
       fc.property(

--- a/src/operations/factories.ts
+++ b/src/operations/factories.ts
@@ -371,16 +371,12 @@ export function sliceFactory<C extends CollectionImpl<unknown, unknown>>(
   const resolvedEnd = resolveEnd(end, originalSize);
 
   // Note: resolvedEnd is undefined when the original sequence's length is
-  // unknown and this slice did not supply an end and should contain all
-  // elements after resolvedBegin.
-  // In that case, resolvedSize will be NaN and sliceSize will remain undefined.
-  const resolvedSize =
-    resolvedEnd === undefined ? NaN : resolvedEnd - resolvedBegin;
-  let sliceSize: number | undefined;
-  if (resolvedSize === resolvedSize) {
-    // TODO useless branch ?
-    sliceSize = resolvedSize < 0 ? 0 : resolvedSize;
-  }
+  // unknown and this slice did not supply an end. In that case the slice runs
+  // to the end of the collection, so its size remains unknown.
+  const sliceSize =
+    resolvedEnd === undefined
+      ? undefined
+      : Math.max(0, resolvedEnd - resolvedBegin);
 
   // TODO [TS-MIGRATION] build-by-mutation scaffold (see MutableSequence)
   const sliceSeq = makeSequence(collection) as unknown as MutableSequence;


### PR DESCRIPTION
if `resolvedSize` is a number `resolvedSize === resolvedSize` is true.  (even ` Infinity === Infinity` is true)
The only case where it is false is when `resolvedSize` is `NaN` because `NaN === NaN` returns false. 

For `resolvedSize` to be NaN, the only possible way is if `resolvedEnd` is undefined. So let's simplify and handle directly undefined value.