### PR TITLE
fix(Repeat): lastIndexOf returned size instead of size - 1

### DIFF
--- a/__tests__/Repeat.ts
+++ b/__tests__/Repeat.ts
@@ -16,4 +16,18 @@ describe('Repeat', () => {
   it('does not claim to be equal to undefined', () => {
     expect(Repeat(1).equals(undefined)).toEqual(false);
   });
+
+  it('indexOf and lastIndexOf return the first and last index', () => {
+    const v = Repeat('wtf', 3);
+    expect(v.indexOf('wtf')).toBe(0);
+    expect(v.lastIndexOf('wtf')).toBe(2);
+    expect(v.indexOf('nope')).toBe(-1);
+    expect(v.lastIndexOf('nope')).toBe(-1);
+  });
+
+  it('lastIndexOf on an empty Repeat returns -1', () => {
+    const v = Repeat('wtf', 0);
+    expect(v.indexOf('wtf')).toBe(-1);
+    expect(v.lastIndexOf('wtf')).toBe(-1);
+  });
 });

--- a/src/Repeat.js
+++ b/src/Repeat.js
@@ -57,15 +57,15 @@ export class Repeat extends IndexedSeq {
   }
 
   indexOf(searchValue) {
-    if (is(this._value, searchValue)) {
+    if (this.size !== 0 && is(this._value, searchValue)) {
       return 0;
     }
     return -1;
   }
 
   lastIndexOf(searchValue) {
-    if (is(this._value, searchValue)) {
-      return this.size;
+    if (this.size !== 0 && is(this._value, searchValue)) {
+      return this.size - 1;
     }
     return -1;
   }


### PR DESCRIPTION
## Bug

`Repeat#lastIndexOf` returns `this.size` when the searched value matches, but the last valid index of a `Repeat` of `n` elements is `n - 1`.

```js
const { Repeat, List, Seq } = require('immutable');

Repeat('x', 3).lastIndexOf('x');        // => 3  (should be 2)
List(['x','x','x']).lastIndexOf('x');   // => 2  ✅
Seq.Indexed(['x','x','x']).lastIndexOf('x'); // => 2  ✅
['x','x','x'].lastIndexOf('x');         // => 2  ✅ (native)
```

Every other indexed collection (`List`, `Range`, generic `Seq`) and the native `Array` return `size - 1`; only `Repeat` was off by one.

While fixing this I noticed a related issue on **empty** repeats — both `indexOf` and `lastIndexOf` reported the value as present even though the collection has no elements:

```js
Repeat('x', 0).indexOf('x');      // => 0  (should be -1)
Repeat('x', 0).lastIndexOf('x');  // => 0  (should be -1)
```

`lastIndexOf('missing')` is documented to return `-1` when the value isn't found, and an empty collection contains nothing, so both should return `-1`.

## Fix

In `src/Repeat.js`:

- `lastIndexOf` returns `this.size - 1` (instead of `this.size`) on a match.
- both `indexOf` and `lastIndexOf` guard on `this.size !== 0` so an empty `Repeat` returns `-1`.

The infinite case is unchanged: `Repeat(value)` has `size === Infinity`, so `size - 1` is still `Infinity`.

## Tests

Added regression tests to `__tests__/Repeat.ts` covering the first/last index of a non-empty repeat and the empty-repeat case. They fail on `main` (`lastIndexOf` returns `3` instead of `2`; empty repeat returns `0` instead of `-1`) and pass with the fix. Full suite (798 tests) green, eslint + prettier clean.