### PR TITLE
fix(List): preserve undefined values when grown past 32 elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ Dates are formatted as YYYY-MM-DD.
 
 ## Unreleased
 
-- fix(IndexedCollection): `has(index)` on a lazy `Seq` of unknown size now checks index existence instead of searching for a value equal to the index
-- [TypeScript]: `reduce`/`reduceRight` without an initial value now infer the result type from the collection's values when the reducer returns a value (e.g. `list.reduce((a, b) => a + b)` infers `number`), matching `Array#reduce`. Previously an explicit type argument was required.
+- fix(List): a `List` grown past 32 elements while all its values are `undefined` no longer reads those values back as `null` (affected `get`, iteration, `toArray`, `equals` and `hashCode`)
+
+- [TypeScript]: `reduce`/`reduceRight` without an initial value now infer the result type from the collection's values when the reducer returns a value (e.g. `list.reduce((a, b) => a + b)` infers `number`), matching `Array#reduce`. Previously an explicit type argument was required. [#2205](https://github.com/immutable-js/immutable-js/pull/2205)
 
 ## 5.1.8
 
@@ -21,10 +22,10 @@ Dates are formatted as YYYY-MM-DD.
 - fix(List): guard oversized bounds in setListBounds. Fixes CVE https://github.com/immutable-js/immutable-js/security/advisories/GHSA-v56q-mh7h-f735
 - perf(Map): index large hash-collision buckets for faster lookups. Fixes CVE https://github.com/immutable-js/immutable-js/security/advisories/GHSA-xvcm-6775-5m9r
 
-
 ## 5.1.7
 
 - fix(Repeat): lastIndexOf returned size instead of size - 1 by @chatman-media in https://github.com/immutable-js/immutable-js/pull/2227. Fixes CVE [CVE-2026-29063 ](https://github.com/immutable-js/immutable-js/security/advisories/GHSA-wf6x-7x77-mvgw)
+- fix(IndexedCollection): `has(index)` on a lazy `Seq` of unknown size now checks index existence instead of searching for a value equal to the index [#2203](https://github.com/immutable-js/immutable-js/pull/2203)
 
 ## 5.1.6
 

--- a/__tests__/List.ts
+++ b/__tests__/List.ts
@@ -935,6 +935,100 @@ describe('List', () => {
     );
   });
 
+  // A List grown past 32 elements while every value is `undefined` must read
+  // back `undefined` at every index, never `null`.
+  describe('preserves stored undefined (never reads back as null)', () => {
+    // Asserts every in-bounds slot reads as `undefined` (not `null`) through
+    // every read path: get, toArray, the values iterator (both directions),
+    // forEach, and the structural equals / hashCode.
+    function expectAllUndefined(list: List<number | undefined>, size: number) {
+      const expected = List<number | undefined>(
+        new Array(size).fill(undefined)
+      );
+
+      expect(list.size).toBe(size);
+      for (let i = 0; i < size; i++) {
+        expect(list.get(i)).toBeUndefined();
+      }
+      expect(list.toArray()).toEqual(new Array(size).fill(undefined));
+      expect([...list.values()]).toEqual(new Array(size).fill(undefined));
+      expect([...list.toSeq().reverse().values()]).toEqual(
+        new Array(size).fill(undefined)
+      );
+      list.forEach((value) => expect(value).toBeUndefined());
+      // @ts-expect-error null should not be here
+      expect(list.includes(null)).toBe(false);
+      expect(list.equals(expected)).toBe(true);
+      expect(list.hashCode()).toBe(expected.hashCode());
+    }
+
+    it('setSize(32).setSize(33) — minimal repro', () => {
+      expectAllUndefined(
+        List<number | undefined>().setSize(32).setSize(33),
+        33
+      );
+    });
+
+    it('setSize(1).setSize(33) — grows a tiny List across the boundary', () => {
+      expectAllUndefined(List<number | undefined>().setSize(1).setSize(33), 33);
+    });
+
+    it('setSize(31).setSize(33)', () => {
+      expectAllUndefined(
+        List<number | undefined>().setSize(31).setSize(33),
+        33
+      );
+    });
+
+    it('setSize(32).setSize(65) — undefined region spanning two leaf nodes', () => {
+      expectAllUndefined(
+        List<number | undefined>().setSize(32).setSize(65),
+        65
+      );
+    });
+
+    it('setSize(32).push(undefined) — grow via push, not setSize', () => {
+      expectAllUndefined(
+        List<number | undefined>().setSize(32).push(undefined),
+        33
+      );
+    });
+
+    it('writing undefined past index 32 in a mutation', () => {
+      const list = List<number | undefined>().withMutations((m) => {
+        for (let i = 0; i < 33; i++) {
+          m.set(i, undefined);
+        }
+      });
+      expectAllUndefined(list, 33);
+    });
+
+    // The sequence reported in #2230, reaching the same all-undefined state
+    // through unshift/delete/shift rather than setSize.
+    it('unshift/delete/setSize/shift sequence (issue #2230)', () => {
+      const list = List<number | undefined>()
+        .unshift(86)
+        .unshift(87)
+        .unshift(54) // [54, 87, 86]
+        .delete(1) // [54, 86]
+        .setSize(6) // [54, 86, undefined, undefined, undefined, undefined]
+        .shift()
+        .shift() // [undefined, undefined, undefined, undefined]
+        .delete(1); // -> [undefined, undefined, undefined]
+
+      expectAllUndefined(list, 3);
+    });
+
+    // A genuine `null` value is a valid element and must round-trip as `null`,
+    // distinct from an absent / undefined slot.
+    it('keeps an explicitly stored null as null', () => {
+      const list = List<number | null>().setSize(32).setSize(33).set(0, null);
+      expect(list.get(0)).toBeNull();
+      expect(list.get(1)).toBeUndefined();
+      expect(list.toArray()[0]).toBeNull();
+    });
+  });
+
   it('can be efficiently sliced', () => {
     const v1 = Range(0, 2000).toList();
     const v2 = v1.slice(100, -100).toList();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -144,7 +144,12 @@ export default tseslintConfig(
       'jest/expect-expect': [
         'error',
         {
-          assertFunctionNames: ['expect', 'expectIs', 'expectIsNot'],
+          assertFunctionNames: [
+            'expect',
+            'expectIs',
+            'expectIsNot',
+            'expectAllUndefined',
+          ],
           additionalTestBlockFunctions: [],
         },
       ],

--- a/src/List.js
+++ b/src/List.js
@@ -48,7 +48,7 @@ export class List extends IndexedCollection {
     assertNotInfinite(size);
     if (size > 0 && size < SIZE) {
       // eslint-disable-next-line no-constructor-return
-      return makeList(0, size, SHIFT, null, new VNode(iter.toArray()));
+      return makeList(0, size, SHIFT, undefined, new VNode(iter.toArray()));
     }
     // eslint-disable-next-line no-constructor-return
     return empty.withMutations((list) => {
@@ -279,7 +279,18 @@ ListPrototype['@@transducer/result'] = function (obj) {
   return obj.asImmutable();
 };
 
+/**
+ * A node in the List's 32-wide trie. At inner levels `array` holds child
+ * `VNode`s; at the leaf level it holds the List's values. Missing slots are
+ * `undefined` array holes.
+ *
+ * @template T
+ */
 class VNode {
+  /**
+   * @param {Array<VNode<T> | T | undefined>} array
+   * @param {OwnerID} [ownerID]
+   */
   constructor(array, ownerID) {
     this.array = array;
     this.ownerID = ownerID;
@@ -417,6 +428,16 @@ function iterateList(list, reverse) {
   }
 }
 
+/**
+ * @param {number} origin
+ * @param {number} capacity
+ * @param {number} level
+ * @param {VNode | undefined} [root] The trie root, or `undefined` when every
+ *   in-range value lives in the tail (or is a virtual `undefined`).
+ * @param {VNode | undefined} [tail]
+ * @param {OwnerID} [ownerID]
+ * @param {number} [hash]
+ */
 function makeList(origin, capacity, level, root, tail, ownerID, hash) {
   const list = Object.create(ListPrototype);
   list.size = capacity - origin;
@@ -534,6 +555,14 @@ function editableVNode(node, ownerID) {
   return new VNode(node ? node.array.slice() : [], ownerID);
 }
 
+/**
+ * Returns the leaf `VNode` holding `rawIndex`, or `undefined` when no node is
+ * allocated for it (an all-`undefined` region).
+ *
+ * @param {List} list
+ * @param {number} rawIndex
+ * @returns {VNode | undefined}
+ */
 function listNodeFor(list, rawIndex) {
   if (rawIndex >= getTailOffset(list._capacity)) {
     return list._tail;
@@ -677,7 +706,7 @@ function setListBounds(list, begin, end) {
     newOrigin -= newTailOffset;
     newCapacity -= newTailOffset;
     newLevel = SHIFT;
-    newRoot = null;
+    newRoot = undefined;
     newTail = newTail && newTail.removeBefore(owner, 0, newOrigin);
 
     // Otherwise, if the root has been trimmed, garbage collect.


### PR DESCRIPTION
## Bug

A `List` grown past 32 elements while every value is `undefined` reads those values back as `null`, corrupting `get`, iteration, `toArray`, `equals` and `hashCode`.

```js
List().setSize(32).setSize(33).get(0); // => null   (expected: undefined)
```

This affects any path that produces an all-`undefined` region spanning the 32-element (tail → root) boundary — `setSize`, `push(undefined)`, mutations, and the `unshift`/`delete`/`shift` sequence from #2230.

## Root cause

A `List` represents an absent trie node as `undefined` almost everywhere (`clear()`, `emptyList()`, and the trie's own array holes via `removeBefore`). But `_root` was stored as `null` in two spots:

- the small-List constructor: `makeList(0, size, SHIFT, null, …)`
- the "origin within tail" branch of `setListBounds`: `newRoot = null`

For small lists this is invisible (indices route to the tail, never the root). But once such a List grows past the next 32-element boundary, in-range indices route through `_root`, and the read idiom `node && node.array[i]` returns the falsy node itself — `null && x === null` leaks `null`, whereas `undefined && x === undefined` reads correctly.

## Fix

Normalize both sites to `undefined` so an absent root has a single sentinel, consistent with the rest of the file. No reader change is needed: `node && node.array[i]` is correct once `_root` is `VNode | undefined`. JSDoc is added on `VNode` / `makeList` / `listNodeFor` to capture that shape ahead of the TypeScript migration.

## Notes

This supersedes #2230: that change guards the "Merge Tail into tree" step, but its condition starts with `oldTail && …`, so it does not cover the `setSize(≤32).setSize(≥33)` family (where `oldTail` is itself `null`) — `setSize(32).setSize(33)` still returns `null` with it applied.

## Tests

8 regression cases in `__tests__/List.ts` (minimal repro + variants, the #2230 sequence, and a `null`-round-trips guard against over-correction). Full suite green (826 tests, incl. fast-check property tests).