### PR TITLE
docs: place [Symbol.iterator] under Iterators headings

### DIFF
--- a/website/docs/Collection.Indexed.mdx
+++ b/website/docs/Collection.Indexed.mdx
@@ -464,11 +464,6 @@ Returns a new indexed Collection with the values for which the `predicate` funct
 <Signature
   code={`partition<C>(predicate: (this: C, value: T, index: number, iter: this) => unknown, context?: C): [this, this];`}
 />
-
-<MemberLabel label="[Symbol.iterator]()" />
-
-<Signature code={`[Symbol.iterator](): IterableIterator<T>;`} />
-
 <MemberLabel label="filterNot()" />
 
 Returns a new Collection with only the values for which the `predicate` function returns false.
@@ -615,6 +610,11 @@ Returns an Iterable of the values in the Collection.
 Returns an Iterable of the [key, value] entries in the Collection.
 
 <Signature code={`entries(): Iterable<[number, T]>;`} />
+
+<MemberLabel label="[Symbol.iterator]()" />
+
+<Signature code={`[Symbol.iterator](): IterableIterator<T>;`} />
+
 
 ## Collections (Seq)
 

--- a/website/docs/Collection.Keyed.mdx
+++ b/website/docs/Collection.Keyed.mdx
@@ -196,13 +196,6 @@ Note: `filter()` always returns a new instance, even if it results in not filter
 />
 
 Returns a new keyed Collection with the values for which the `predicate` function returns false and another for which it returns true.
-
-<MemberLabel label="[Symbol.iterator]()" />
-
-<Signature code={`[Symbol.iterator](): IterableIterator<[K, V]>;`} />
-
-Yields [key, value] pairs.
-
 ## Value equality
 
 <MemberLabel label="equals()" />
@@ -404,6 +397,13 @@ An iterator of this `Collection`'s entries as `[ key, value ]` tuples.
 <Signature code={`entries(): IterableIterator<[K, V]>;`} />
 
 Note: this will return an ES6 iterator which does not support Immutable.js sequence algorithms. Use `entrySeq` instead if you want an Immutable.js Seq.
+
+<MemberLabel label="[Symbol.iterator]()" />
+
+<Signature code={`[Symbol.iterator](): IterableIterator<[K, V]>;`} />
+
+Yields [key, value] pairs.
+
 
 ## Collections (Seq)
 

--- a/website/docs/OrderedCollection.mdx
+++ b/website/docs/OrderedCollection.mdx
@@ -15,8 +15,11 @@ Shallowly converts this collection to an Array.
 
 <Signature code="toArray(): Array<T>" />
 
+## Iterators
+
 <MemberLabel label="[Symbol.iterator]()" />
 
 Returns an iterator that iterates over the values in this collection.
 
 <Signature code="[Symbol.iterator](): IterableIterator<T>" />
+

--- a/website/docs/Seq.Indexed.mdx
+++ b/website/docs/Seq.Indexed.mdx
@@ -460,11 +460,6 @@ Returns a new indexed Seq with the values for which the `predicate` function ret
 <Signature
   code={`partition<C>(predicate: (this: C, value: T, index: number, iter: this) => unknown, context?: C): [this, this];`}
 />
-
-<MemberLabel label="[Symbol.iterator]()" />
-
-<Signature code={`[Symbol.iterator](): IterableIterator<T>;`} />
-
 <MemberLabel label="filterNot()" />
 
 Returns a new Collection with only the values for which the `predicate` function returns false.
@@ -611,6 +606,11 @@ Returns an Iterable of the values in the Collection.
 Returns an Iterable of the [key, value] entries in the Collection.
 
 <Signature code={`entries(): Iterable<[number, T]>;`} />
+
+<MemberLabel label="[Symbol.iterator]()" />
+
+<Signature code={`[Symbol.iterator](): IterableIterator<T>;`} />
+
 
 ## Collections (Seq)
 

--- a/website/docs/Seq.Keyed.mdx
+++ b/website/docs/Seq.Keyed.mdx
@@ -202,13 +202,6 @@ Note: `filter()` always returns a new instance, even if it results in not filter
 />
 
 Returns a new keyed Seq with the values for which the `predicate` function returns false and another for which is returns true.
-
-<MemberLabel label="[Symbol.iterator]()" />
-
-<Signature code={`[Symbol.iterator](): IterableIterator<[K, V]>;`} />
-
-Yields [key, value] pairs.
-
 ## Value equality
 
 <MemberLabel label="equals()" />
@@ -410,6 +403,13 @@ An iterator of this `Collection`'s entries as `[ key, value ]` tuples.
 <Signature code={`entries(): IterableIterator<[K, V]>;`} />
 
 Note: this will return an ES6 iterator which does not support Immutable.js sequence algorithms. Use `entrySeq` instead if you want an Immutable.js Seq.
+
+<MemberLabel label="[Symbol.iterator]()" />
+
+<Signature code={`[Symbol.iterator](): IterableIterator<[K, V]>;`} />
+
+Yields [key, value] pairs.
+
 
 ## Collections (Seq)
 

--- a/website/docs/Stack.mdx
+++ b/website/docs/Stack.mdx
@@ -291,13 +291,6 @@ const c = a.zipWith((a, b) => a + b, b);
 ## Sequence algorithms
 
 <MemberLabel label="partition()" />
-
-<MemberLabel label="[Symbol.iterator]()" />
-
-Returns an iterator of this Stack.
-
-<Signature code={`[Symbol.iterator](): IterableIterator<T>`} />
-
 <MemberLabel label="filterNot()" />
 
 Returns a new Stack with only the values for which the `predicate` function returns false.
@@ -660,6 +653,13 @@ An iterator of this Stack's values.
 An iterator of this Stack's entries as [key, value] tuples.
 
 <Signature code={`entries(): IterableIterator<[number, T]>`} />
+
+<MemberLabel label="[Symbol.iterator]()" />
+
+Returns an iterator of this Stack.
+
+<Signature code={`[Symbol.iterator](): IterableIterator<T>`} />
+
 
 ## Collections (Seq)
 


### PR DESCRIPTION
## Summary
- Moves `[Symbol.iterator]` documentation under the **Iterators** heading in Stack, Collection.Indexed, Collection.Keyed, Seq.Indexed, Seq.Keyed, and OrderedCollection docs.
- Matches the existing layout on the Collection docs page so the sidebar/TOC lists this method with other iterators instead of Sequence algorithms/functions.

Fixes #1608

## Test plan
- [x] Open the docs pages for the updated types and confirm `[Symbol.iterator]` appears under Iterators
- [x] Confirm it no longer appears under Sequence algorithms / Sequence functions